### PR TITLE
Connectivity script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# VS Code
+.vscode/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 bz2file==0.98
 cycler==0.10.0
+Cython==0.29.6
 dipy==0.16.0
 future==0.17.1
 h5py==2.9.0
@@ -12,5 +13,6 @@ pyparsing==2.2.0
 python-dateutil==2.7.2
 pytz==2018.4
 scipy==1.0.1
+setuptools==39.0.1
 six==1.11.0
 vtk==8.1.0

--- a/scilpy/io/streamlines.py
+++ b/scilpy/io/streamlines.py
@@ -1,9 +1,14 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from __future__ import division
 import os
+import six
 
 import nibabel as nib
+from nibabel.streamlines import Field, Tractogram
+from nibabel.streamlines.trk import (get_affine_rasmm_to_trackvis,
+                                     get_affine_trackvis_to_rasmm)
 
 
 def check_tracts_same_format(parser, tractogram_1, tractogram_2):
@@ -23,3 +28,63 @@ def check_tracts_same_format(parser, tractogram_1, tractogram_2):
     if not ext_1 == ext_2:
         parser.error(
             'Input and output tractogram files must use the same format.')
+
+
+def load_trk_in_voxel_space(trk_file, anat=None, grid_res=None,
+                            raise_on_empty=True):
+    """
+    Load streamlines in voxel space, corner aligned
+
+    :param trk_file: path or nibabel object
+    :param anat: path or nibabel image (optional)
+    :param grid_res: specify the grid resolution (3,) (optional)
+    :param raise_on_empty: specify if an error should be raised when
+           the file is empty
+    :return: NiBabel tractogram with streamlines loaded in voxel space
+    """
+    if isinstance(trk_file, six.string_types):
+        trk_file = nib.streamlines.load(trk_file)
+
+    if trk_file.header[Field.NB_STREAMLINES] == 0 and raise_on_empty:
+        raise Exception("The file contains no streamline")
+
+    if anat and grid_res:
+        raise Exception("Parameters anat and grid_res cannot be used together")
+
+    if anat:
+        if isinstance(anat, six.string_types):
+            anat = nib.load(anat)
+        spacing = anat.header['pixdim'][1:4]
+    elif grid_res:
+        spacing = grid_res
+    else:
+        spacing = trk_file.header[Field.VOXEL_SIZES]
+
+    affine_to_voxmm = get_affine_rasmm_to_trackvis(trk_file.header)
+    tracto = trk_file.tractogram
+    tracto.apply_affine(affine_to_voxmm)
+    streamlines = tracto.streamlines
+
+    if trk_file.header[Field.NB_STREAMLINES] > 0:
+        streamlines._data /= spacing
+    return streamlines
+
+
+def save_from_voxel_space(streamlines, anat, ref_tracts, out_name):
+    if isinstance(ref_tracts, six.string_types):
+        nib_object = nib.streamlines.load(ref_tracts, lazy_load=True)
+    else:
+        nib_object = ref_tracts
+
+    if isinstance(anat, six.string_types):
+        anat = nib.load(anat)
+
+    affine_to_rasmm = get_affine_trackvis_to_rasmm(nib_object.header)
+
+    tracto = Tractogram(streamlines=streamlines,
+                        affine_to_rasmm=affine_to_rasmm)
+
+    spacing = anat.header['pixdim'][1:4]
+    tracto.streamlines._data *= spacing
+
+    nib.streamlines.save(tracto, out_name, header=nib_object.header)

--- a/scilpy/io/utils.py
+++ b/scilpy/io/utils.py
@@ -6,6 +6,7 @@ import six
 
 import nibabel as nib
 from nibabel.streamlines import TrkFile
+import shutil
 
 from scilpy.utils.bvec_bval_tools import DEFAULT_B0_THRESHOLD
 
@@ -108,3 +109,33 @@ def create_header_from_anat(reference, base_filetype=TrkFile):
         nib.aff2axcodes(affine))
 
     return new_header
+
+
+def assert_output_dirs_exist_and_empty(parser, args, *dirs):
+    """
+    Assert that all output directories exist.
+    If not, print parser's usage and exit.
+    If exists and not empty, and -f used, delete dirs.
+    :param parser: argparse.ArgumentParser object
+    :param args: argparse namespace
+    :param dirs: list of paths
+    """
+    for path in dirs:
+        if not os.path.isdir(path):
+            parser.error('Output directory {} doesn\'t exist.'.format(path))
+        if os.listdir(path):
+            if not args.overwrite:
+                parser.error(
+                    'Output directory {} isn\'t empty and some files could be '
+                    'overwritten. Use -f option if you want to continue.'
+                    .format(path))
+            else:
+                for the_file in os.listdir(args.output):
+                    file_path = os.path.join(args.output, the_file)
+                    try:
+                        if os.path.isfile(file_path):
+                            os.unlink(file_path)
+                        elif os.path.isdir(file_path):
+                            shutil.rmtree(file_path)
+                    except Exception as e:
+                        print(e)

--- a/scilpy/tractanalysis/__init__.py
+++ b/scilpy/tractanalysis/__init__.py
@@ -1,6 +1,0 @@
-# TODO
-# try:
-#     from robust_streamlines_metrics import compute_robust_tract_counts_map
-# except ImportError as e:
-#     e.args += ("Try running setup.py",)
-#     raise

--- a/scilpy/tractanalysis/__init__.py
+++ b/scilpy/tractanalysis/__init__.py
@@ -1,0 +1,6 @@
+# TODO
+# try:
+#     from robust_streamlines_metrics import compute_robust_tract_counts_map
+# except ImportError as e:
+#     e.args += ("Try running setup.py",)
+#     raise

--- a/scilpy/tractanalysis/features.py
+++ b/scilpy/tractanalysis/features.py
@@ -1,0 +1,164 @@
+# -*- coding: utf-8 -*-
+
+from itertools import count, takewhile
+import logging
+
+from dipy.segment.clustering import Cluster, QuickBundles
+from dipy.tracking import metrics as tm
+import numpy as np
+
+
+def remove_loops_and_sharp_turns(streamlines,
+                                 use_qb,
+                                 max_angle,
+                                 qb_threshold):
+    """
+    Remove loops and sharp turns from a list of streamlines.
+
+    Parameters
+    ----------
+    streamlines: list of ndarray
+        The list of streamlines from which to remove loops and sharp turns.
+    use_qb: bool
+        Set to True if the additional QuickBundles pass is done.
+        This will help remove sharp turns. Should only be used on
+        bundled streamlines, not on whole-brain tractograms.
+    max_angle: float
+        Maximal winding angle a streamline can have before
+        being classified as a loop.
+    qb_threshold: float
+        Quickbundles distance threshold, only used if use_qb is True.
+
+    Returns
+    -------
+    A tuple containing
+        list of ndarray: the clean streamlines
+        list of ndarray: the list of removed streamlines, if any
+    """
+
+    loops = []
+    streamlines_clean = []
+    for s in streamlines:
+        if tm.winding(s) >= max_angle:
+            loops.append(s)
+        else:
+            streamlines_clean.append(s)
+
+    # TODO can we use QBx instead?
+    if use_qb:
+        if len(streamlines_clean) > 1:
+            streamlines = streamlines_clean
+            curvature = []
+            streamlines_clean = []
+
+            qb = QuickBundles(threshold=qb_threshold)
+            clusters = qb.cluster(streamlines)
+
+            for cc in clusters.centroids:
+                curvature.append(tm.mean_curvature(cc))
+            mean_curvature = sum(curvature)/len(curvature)
+
+            for i in range(len(clusters.centroids)):
+                if tm.mean_curvature(clusters.centroids[i]) > mean_curvature:
+                    for indice in clusters[i].indices:
+                        loops.append(streamlines[indice])
+                else:
+                    for indice in clusters[i].indices:
+                        streamlines_clean.append(streamlines[indice])
+        else:
+            logging.debug("Impossible to use the use_qb option because " +
+                          "not more than one streamline left from the\n" +
+                          "input file.")
+
+    return streamlines_clean, loops
+
+
+def _get_streamlines_bounding_box(streamlines):
+    box_min = np.array([np.inf, np.inf, np.inf])
+    box_max = -np.array([np.inf, np.inf, np.inf])
+
+    for s in streamlines:
+        box_min = np.minimum(box_min, np.min(s, axis=0))
+        box_max = np.maximum(box_max, np.max(s, axis=0))
+
+    return box_min, box_max
+
+
+def _prune(streamlines, threshold, features):
+    indices = np.arange(len(streamlines))
+
+    outlier_indices = indices[features < threshold]
+    rest_indices = indices[features >= threshold]
+
+    return outlier_indices, rest_indices
+
+
+# TODO could replace QB by QBx. Would need to adjust thresholds.
+def _outliers_removal_using_hierarchical_quickbundles(streamlines,
+                                                     min_threshold=0.5,
+                                                     nb_samplings_max=30,
+                                                     sampling_seed=1234):
+    if nb_samplings_max < 2:
+        raise ValueError("'nb_samplings_max' must be >= 2")
+
+    rng = np.random.RandomState(sampling_seed)
+    metric = "MDF_12points"
+
+    box_min, box_max = _get_streamlines_bounding_box(streamlines)
+
+    # Half of the bounding box's halved diagonal length.
+    initial_threshold = np.min(np.abs(box_max - box_min)) / 2.
+
+    # Quickbundle's threshold is halved between hierarchical level.
+    thresholds = list(takewhile(lambda t: t >= min_threshold,
+                                (initial_threshold / 1.2**i for i in count())))
+
+    ordering = np.arange(len(streamlines))
+    nb_clusterings = 0
+    path_lengths_per_streamline = 0
+
+    streamlines_path = np.ones((len(streamlines), len(thresholds),
+                                nb_samplings_max), dtype=int) * -1
+
+    for i in range(nb_samplings_max):
+        rng.shuffle(ordering)
+
+        cluster_orderings = [ordering]
+        for j, threshold in enumerate(thresholds):
+            id_cluster = 0
+
+            next_cluster_orderings = []
+            qb = QuickBundles(metric=metric, threshold=threshold)
+            for cluster_ordering in cluster_orderings:
+                clusters = qb.cluster(streamlines, ordering=cluster_ordering)
+                nb_clusterings += 1
+
+                for k, cluster in enumerate(clusters):
+                    streamlines_path[cluster.indices, j, i] = id_cluster
+                    id_cluster += 1
+                    if len(cluster) > 10:
+                        next_cluster_orderings.append(cluster.indices)
+
+            cluster_orderings = next_cluster_orderings
+
+        if i <= 1:  # Needs at least two orderings to compute stderror.
+            continue
+
+        path_lengths_per_streamline = np.sum((streamlines_path != -1),
+                                             axis=1)[:, :i]
+
+    summary = np.mean(path_lengths_per_streamline,
+                      axis=1) / np.max(path_lengths_per_streamline)
+    return summary
+
+
+# TODO threshold as param
+def remove_outliers(streamlines):
+    summary = _outliers_removal_using_hierarchical_quickbundles(streamlines)
+    outliers, outliers_removed = _prune(streamlines,
+                                        0.3, summary)
+    outliers_strl = Cluster(indices=outliers, refdata=streamlines)
+    no_outliers_strl = Cluster(indices=outliers_removed,
+                               refdata=streamlines)
+
+    return no_outliers_strl, outliers_strl

--- a/scilpy/tractanalysis/features.py
+++ b/scilpy/tractanalysis/features.py
@@ -155,7 +155,6 @@ def _outliers_removal_using_hierarchical_quickbundles(streamlines,
     return summary
 
 
-# TODO threshold as param
 def remove_outliers(streamlines, threshold):
     summary = _outliers_removal_using_hierarchical_quickbundles(streamlines)
     outliers, outliers_removed = _prune(streamlines,

--- a/scilpy/tractanalysis/features.py
+++ b/scilpy/tractanalysis/features.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import division
+
+from builtins import range
 from itertools import count, takewhile
 import logging
 

--- a/scilpy/tractanalysis/features.py
+++ b/scilpy/tractanalysis/features.py
@@ -9,9 +9,9 @@ import numpy as np
 
 
 def remove_loops_and_sharp_turns(streamlines,
-                                 use_qb,
                                  max_angle,
-                                 qb_threshold):
+                                 use_qb=False,
+                                 qb_threshold=15.):
     """
     Remove loops and sharp turns from a list of streamlines.
 
@@ -153,10 +153,10 @@ def _outliers_removal_using_hierarchical_quickbundles(streamlines,
 
 
 # TODO threshold as param
-def remove_outliers(streamlines):
+def remove_outliers(streamlines, threshold):
     summary = _outliers_removal_using_hierarchical_quickbundles(streamlines)
     outliers, outliers_removed = _prune(streamlines,
-                                        0.3, summary)
+                                        threshold, summary)
     outliers_strl = Cluster(indices=outliers, refdata=streamlines)
     no_outliers_strl = Cluster(indices=outliers_removed,
                                refdata=streamlines)

--- a/scilpy/tractanalysis/features.py
+++ b/scilpy/tractanalysis/features.py
@@ -95,9 +95,9 @@ def _prune(streamlines, threshold, features):
 
 # TODO could replace QB by QBx. Would need to adjust thresholds.
 def _outliers_removal_using_hierarchical_quickbundles(streamlines,
-                                                     min_threshold=0.5,
-                                                     nb_samplings_max=30,
-                                                     sampling_seed=1234):
+                                                      min_threshold=0.5,
+                                                      nb_samplings_max=30,
+                                                      sampling_seed=1234):
     if nb_samplings_max < 2:
         raise ValueError("'nb_samplings_max' must be >= 2")
 

--- a/scilpy/tractanalysis/quick_tools.pyx
+++ b/scilpy/tractanalysis/quick_tools.pyx
@@ -5,58 +5,6 @@ import cython
 import numpy as np
 cimport numpy as cnp
 
-
-# @cython.boundscheck(False)
-# @cython.wraparound(False)
-# @cython.cdivision(True)
-# def get_intersection_profile_single(atlas_data, strl_indices):
-#     """
-#     TODO change
-#     Get the indices of the voxels traversed by each streamline; then returns
-#     an ArraySequence of indices. Yes, of *indices*. ArraySequence.data is
-#     always of type float32 and contains points except here: it's of type
-#     uint16 and contain indices. You can use this object exactly as you would
-#     use a normal ArraySequence.
-#
-#     :param streamlines: nibabel.streamlines.array_sequence.ArraySequence
-#         should be in voxel space, aligned to corner.
-#     """
-#     cdef:
-#         cnp.npy_intp nb_indices = strl_indices.shape[0]
-#         cnp.npy_intp at_point = 0
-#
-#     label_values = np.full((nb_indices, ), -1, dtype=np.int32)
-#     indices_values = np.full((nb_indices, ), -1, dtype=np.int32)
-#
-#     cdef:
-#         cnp.npy_intp index_idx = 0
-#         cnp.npy_int32[:, :, :] atlas_view = atlas_data
-#         cnp.npy_int32[:] data_view = label_values
-#         cnp.npy_int32[:] indices_view = indices_values
-#
-#
-#     data_view[at_point] = atlas_view[strl_indices[0][0],
-#                                     strl_indices[0][1],
-#                                     strl_indices[0][2]]
-#     indices_view[at_point] = 0
-#
-#     at_point += 1
-#
-#     for index_idx in range(1, nb_indices):
-#         next_val = atlas_view[strl_indices[index_idx][0],
-#                               strl_indices[index_idx][1],
-#                               strl_indices[index_idx][2]]
-#
-#         if next_val != data_view[at_point - 1]:
-#             data_view[at_point] = next_val
-#             indices_view[at_point] = index_idx
-#             at_point += 1
-#
-#     label_values.resize((at_point,), refcheck=False)
-#     indices_values.resize((at_point,), refcheck=False)
-#
-#     return (label_values, indices_values)
-
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def get_next_real_point(points_to_index, vox_index):

--- a/scilpy/tractanalysis/quick_tools.pyx
+++ b/scilpy/tractanalysis/quick_tools.pyx
@@ -1,0 +1,102 @@
+# encoding: utf-8
+#cython: profile=False
+
+import cython
+import numpy as np
+cimport numpy as cnp
+
+
+# @cython.boundscheck(False)
+# @cython.wraparound(False)
+# @cython.cdivision(True)
+# def get_intersection_profile_single(atlas_data, strl_indices):
+#     """
+#     TODO change
+#     Get the indices of the voxels traversed by each streamline; then returns
+#     an ArraySequence of indices. Yes, of *indices*. ArraySequence.data is
+#     always of type float32 and contains points except here: it's of type
+#     uint16 and contain indices. You can use this object exactly as you would
+#     use a normal ArraySequence.
+#
+#     :param streamlines: nibabel.streamlines.array_sequence.ArraySequence
+#         should be in voxel space, aligned to corner.
+#     """
+#     cdef:
+#         cnp.npy_intp nb_indices = strl_indices.shape[0]
+#         cnp.npy_intp at_point = 0
+#
+#     label_values = np.full((nb_indices, ), -1, dtype=np.int32)
+#     indices_values = np.full((nb_indices, ), -1, dtype=np.int32)
+#
+#     cdef:
+#         cnp.npy_intp index_idx = 0
+#         cnp.npy_int32[:, :, :] atlas_view = atlas_data
+#         cnp.npy_int32[:] data_view = label_values
+#         cnp.npy_int32[:] indices_view = indices_values
+#
+#
+#     data_view[at_point] = atlas_view[strl_indices[0][0],
+#                                     strl_indices[0][1],
+#                                     strl_indices[0][2]]
+#     indices_view[at_point] = 0
+#
+#     at_point += 1
+#
+#     for index_idx in range(1, nb_indices):
+#         next_val = atlas_view[strl_indices[index_idx][0],
+#                               strl_indices[index_idx][1],
+#                               strl_indices[index_idx][2]]
+#
+#         if next_val != data_view[at_point - 1]:
+#             data_view[at_point] = next_val
+#             indices_view[at_point] = index_idx
+#             at_point += 1
+#
+#     label_values.resize((at_point,), refcheck=False)
+#     indices_values.resize((at_point,), refcheck=False)
+#
+#     return (label_values, indices_values)
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def get_next_real_point(points_to_index, vox_index):
+    cdef:
+        int next_point = -1
+        int map_idx = -1
+        int nb_points_to_index
+        int internal_vox_index
+        cnp.npy_ulong[:] pts_to_index_view
+
+    nb_points_to_index = len(points_to_index)
+    internal_vox_index = vox_index
+    pts_to_index_view = points_to_index
+
+    while map_idx < internal_vox_index and next_point < nb_points_to_index:
+        next_point += 1
+        #map_idx = points_to_index[next_point]
+        map_idx = pts_to_index_view[next_point]
+
+    return next_point
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def get_previous_real_point(points_to_index, vox_index):
+    cdef:
+        int previous_point
+        int map_index
+        int nb_points_to_index
+        int internal_vox_index
+        cnp.npy_ulong[:] pts_to_index_view
+
+    nb_points_to_index = len(points_to_index)
+    previous_point = nb_points_to_index
+    internal_vox_index = vox_index
+    map_idx = internal_vox_index + 1
+    pts_to_index_view = points_to_index
+
+    while map_idx > internal_vox_index and previous_point >= 0:
+        previous_point -= 1
+        map_idx = pts_to_index_view[previous_point]
+
+    return previous_point

--- a/scilpy/tractanalysis/tools.py
+++ b/scilpy/tractanalysis/tools.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-#
-# from __future__ import division
-#
+
+from __future__ import division
+from builtins import range
 
 import numpy as np
 

--- a/scilpy/tractanalysis/tools.py
+++ b/scilpy/tractanalysis/tools.py
@@ -138,7 +138,6 @@ def extract_longest_segments_from_profile(strl_indices, atlas_data):
             end_idx = el_idx
         el_idx -= 1
 
-    # TODO check self connections
     if end_label is None or end_idx <= start_idx + 1:
         return []
 
@@ -148,11 +147,8 @@ def extract_longest_segments_from_profile(strl_indices, atlas_data):
              'end_index': end_idx}]
 
 
-# TODO self connect
 def compute_connectivity(indices, atlas_data,
-                         segmenting_func,
-                         allow_self_connection,
-                         minimize_self_connection):
+                         segmenting_func):
     atlas_data = atlas_data.astype(np.int32)
     real_labels = np.unique(atlas_data)
 

--- a/scilpy/tractanalysis/tools.py
+++ b/scilpy/tractanalysis/tools.py
@@ -46,98 +46,6 @@ def get_point_on_line(first_point, second_point, vox_lower_corner):
             t1 = min(t1, max(v0, v1))
 
     return first_point + ray * (t0 + t1) / 2.
-#
-#
-# def intersects_two_rois(roi_data_1, roi_data_2, voxel_map):
-#     entry_found = False
-#     exit_found = False
-#     went_out_of_exit = False
-#     exit_roi_data = None
-#     in_strl_idx = None
-#     out_strl_idx = None
-#
-#     # TODO simplify
-#     strl_indices = voxel_map
-#
-#     logging.debug(strl_indices)
-#     for idx, point in enumerate(strl_indices):
-#         # logging.debug("Point: {}".format(point))
-#         if entry_found and exit_found:
-#             # Still add points that are in exit roi, to mimic entry ROI
-#             # This will need to be modified to correctly handle continuation
-#             if exit_roi_data[tuple(point)] > 0:
-#                 if not went_out_of_exit:
-#                     out_strl_idx = idx
-#             else:
-#                 went_out_of_exit = True
-#         elif entry_found and not exit_found:
-#             # If we reached the exit ROI
-#             if exit_roi_data[tuple(point)] > 0:
-#                 exit_found = True
-#                 out_strl_idx = idx
-#         elif not entry_found:
-#             # Check if we are in one of ROIs
-#             if roi_data_1[tuple(point)] > 0 or roi_data_2[tuple(point)] > 0:
-#                 entry_found = True
-#                 in_strl_idx = idx
-#                 if roi_data_1[tuple(point)] > 0:
-#                     exit_roi_data = roi_data_2
-#                 else:
-#                     exit_roi_data = roi_data_1
-#
-#     return in_strl_idx, out_strl_idx
-#
-#
-# def intersects_two_rois_atlas(atlas_data, voxel_map,
-#                               allow_self_connection=True,
-#                               minimize_self_connections=True):
-#     entry_found = False
-#     exit_found = False
-#
-#     entry_label = None
-#     exit_label = None
-#     went_out_of_entry = False
-#     reentered_entry = False
-#
-#     in_strl_idx = None
-#     out_strl_idx = None
-#
-#     # TODO simplify
-#     strl_indices = voxel_map
-#
-#     for idx, point in enumerate(strl_indices):
-#         # logging.debug("Point: {}".format(point))
-#         if entry_found and not exit_found:
-#             if atlas_data[tuple(point)] == 0:
-#                 went_out_of_entry = True
-#             elif atlas_data[tuple(point)] == entry_label:
-#                 if went_out_of_entry:
-#                     if not allow_self_connection:
-#                         continue
-#                     else:
-#                         reentered_entry = True
-#                         if not minimize_self_connections:
-#                             exit_label = entry_label
-#                             exit_found = True
-#                             out_strl_idx = idx
-#             else:
-#                 exit_found = True
-#                 exit_label = atlas_data[tuple(point)]
-#                 out_strl_idx = idx
-#         elif not entry_found:
-#             # Check if we are in one of ROIs
-#             if atlas_data[tuple(point)] > 0:
-#                 entry_found = True
-#                 entry_label = atlas_data[tuple(point)]
-#                 in_strl_idx = idx
-#
-#     # Can happen when allowing self connections but minimizing
-#     if entry_label is not None and exit_label is None:
-#         if allow_self_connection and reentered_entry:
-#             exit_label == entry_label
-#             # TODO missing the index
-#
-#     return entry_label, exit_label, in_strl_idx, out_strl_idx
 
 
 def compute_streamline_segment(orig_strl, inter_vox, in_vox_idx, out_vox_idx,
@@ -151,9 +59,6 @@ def compute_streamline_segment(orig_strl, inter_vox, in_vox_idx, out_vox_idx,
                                             in_vox_idx)
 
     if in_strl_point is None:
-        #logging.debug("No direct mapping to in streamline point found.")
-        #logging.debug("  Looking for next valid point")
-
         # Find the next real streamline point
         in_strl_point = get_next_real_point(points_to_indices, in_vox_idx)
 
@@ -168,9 +73,6 @@ def compute_streamline_segment(orig_strl, inter_vox, in_vox_idx, out_vox_idx,
                                               from_start=False)
 
     if exit_strl_point is None:
-        #logging.debug("No direct mapping to streamline exit point found.")
-        #logging.debug("  Looking for previous valid point")
-
         # Find the previous real streamline point
         exit_strl_point = get_previous_real_point(points_to_indices,
                                                   out_vox_idx)
@@ -188,34 +90,21 @@ def compute_streamline_segment(orig_strl, inter_vox, in_vox_idx, out_vox_idx,
     at_point = 0
 
     if additional_start_pt is not None:
-        #logging.debug("  adding artifical entry point: {}".format(
-        #              additional_start_pt))
         segment[0] = additional_start_pt
         at_point += 1
 
     if exit_strl_point >= in_strl_point:
-        #logging.debug("  adding points [{}:{}] from orig strl".format(
-        #              in_strl_point, exit_strl_point + 1))
-
         # Note: this works correctly even in the case where the "previous"
         # point is the same or lower than the entry point, because of
         # numpy indexing
-        ##print(in_strl_point, exit_strl_point)
         segment[at_point:at_point + nb_points_orig_strl] = \
             orig_strl[in_strl_point:exit_strl_point + 1]
         at_point += nb_points_orig_strl
-    #else:
-        #logging.debug("  exit point was found before entry point. "
-        #              "Not inserting from orig strl.")
-
 
     if additional_exit_pt is not None:
-        #logging.debug("  adding artifical exit point: {}".format(
-        #              additional_exit_pt))
         segment[at_point] = additional_exit_pt
         at_point += 1
 
-    #logging.debug("    new segment: {}".format(segment))
     return segment
 
 

--- a/scilpy/tractanalysis/tools.py
+++ b/scilpy/tractanalysis/tools.py
@@ -129,7 +129,7 @@ def extract_longest_segments_from_profile(strl_indices, atlas_data):
         el_idx += 1
 
     if el_idx >= nb_el_indices or not found_WM:
-       return []
+        return []
 
     el_idx = nb_el_indices - 1
     while end_label is None and el_idx > start_idx:

--- a/scilpy/tractanalysis/tools.py
+++ b/scilpy/tractanalysis/tools.py
@@ -1,0 +1,281 @@
+# -*- coding: utf-8 -*-
+#
+# from __future__ import division
+#
+
+import numpy as np
+
+from scilpy.tractanalysis.quick_tools import (get_next_real_point,
+                                              get_previous_real_point)
+
+
+def get_streamline_pt_index(points_to_index, vox_index, from_start=True):
+    cur_idx = np.where(points_to_index == vox_index)
+
+    if not len(cur_idx[0]):
+        return None
+
+    if from_start:
+        idx_to_take = 0
+    else:
+        idx_to_take = -1
+
+    return cur_idx[0][idx_to_take]
+
+
+def get_point_on_line(first_point, second_point, vox_lower_corner):
+    # To manage the case where there is no real streamline point in an
+    # intersected voxel, we need to generate an artificial point.
+    # We use line / cube intersections as presented in
+    # Physically Based Rendering, Second edition, pp. 192-195
+    # Some simplifications are made since we are sure that an intersection
+    # exists (else this function would not have been called).
+    ray = second_point - first_point
+    ray = ray / np.linalg.norm(ray)
+
+    corners = np.array([vox_lower_corner, vox_lower_corner + 1])
+
+    t0 = 0
+    t1 = np.inf
+    for i in range(3):
+        if ray[i] != 0.:
+            inv_ray = 1. / ray[i]
+            v0 = (corners[0, i] - first_point[i]) * inv_ray
+            v1 = (corners[1, i] - first_point[i]) * inv_ray
+            t0 = max(t0, min(v0, v1))
+            t1 = min(t1, max(v0, v1))
+
+    return first_point + ray * (t0 + t1) / 2.
+#
+#
+# def intersects_two_rois(roi_data_1, roi_data_2, voxel_map):
+#     entry_found = False
+#     exit_found = False
+#     went_out_of_exit = False
+#     exit_roi_data = None
+#     in_strl_idx = None
+#     out_strl_idx = None
+#
+#     # TODO simplify
+#     strl_indices = voxel_map
+#
+#     logging.debug(strl_indices)
+#     for idx, point in enumerate(strl_indices):
+#         # logging.debug("Point: {}".format(point))
+#         if entry_found and exit_found:
+#             # Still add points that are in exit roi, to mimic entry ROI
+#             # This will need to be modified to correctly handle continuation
+#             if exit_roi_data[tuple(point)] > 0:
+#                 if not went_out_of_exit:
+#                     out_strl_idx = idx
+#             else:
+#                 went_out_of_exit = True
+#         elif entry_found and not exit_found:
+#             # If we reached the exit ROI
+#             if exit_roi_data[tuple(point)] > 0:
+#                 exit_found = True
+#                 out_strl_idx = idx
+#         elif not entry_found:
+#             # Check if we are in one of ROIs
+#             if roi_data_1[tuple(point)] > 0 or roi_data_2[tuple(point)] > 0:
+#                 entry_found = True
+#                 in_strl_idx = idx
+#                 if roi_data_1[tuple(point)] > 0:
+#                     exit_roi_data = roi_data_2
+#                 else:
+#                     exit_roi_data = roi_data_1
+#
+#     return in_strl_idx, out_strl_idx
+#
+#
+# def intersects_two_rois_atlas(atlas_data, voxel_map,
+#                               allow_self_connection=True,
+#                               minimize_self_connections=True):
+#     entry_found = False
+#     exit_found = False
+#
+#     entry_label = None
+#     exit_label = None
+#     went_out_of_entry = False
+#     reentered_entry = False
+#
+#     in_strl_idx = None
+#     out_strl_idx = None
+#
+#     # TODO simplify
+#     strl_indices = voxel_map
+#
+#     for idx, point in enumerate(strl_indices):
+#         # logging.debug("Point: {}".format(point))
+#         if entry_found and not exit_found:
+#             if atlas_data[tuple(point)] == 0:
+#                 went_out_of_entry = True
+#             elif atlas_data[tuple(point)] == entry_label:
+#                 if went_out_of_entry:
+#                     if not allow_self_connection:
+#                         continue
+#                     else:
+#                         reentered_entry = True
+#                         if not minimize_self_connections:
+#                             exit_label = entry_label
+#                             exit_found = True
+#                             out_strl_idx = idx
+#             else:
+#                 exit_found = True
+#                 exit_label = atlas_data[tuple(point)]
+#                 out_strl_idx = idx
+#         elif not entry_found:
+#             # Check if we are in one of ROIs
+#             if atlas_data[tuple(point)] > 0:
+#                 entry_found = True
+#                 entry_label = atlas_data[tuple(point)]
+#                 in_strl_idx = idx
+#
+#     # Can happen when allowing self connections but minimizing
+#     if entry_label is not None and exit_label is None:
+#         if allow_self_connection and reentered_entry:
+#             exit_label == entry_label
+#             # TODO missing the index
+#
+#     return entry_label, exit_label, in_strl_idx, out_strl_idx
+
+
+def compute_streamline_segment(orig_strl, inter_vox, in_vox_idx, out_vox_idx,
+                               points_to_indices):
+    additional_start_pt = None
+    additional_exit_pt = None
+    nb_points = 0
+
+    # Check if the indexed voxel contains a real streamline point
+    in_strl_point = get_streamline_pt_index(points_to_indices,
+                                            in_vox_idx)
+
+    if in_strl_point is None:
+        #logging.debug("No direct mapping to in streamline point found.")
+        #logging.debug("  Looking for next valid point")
+
+        # Find the next real streamline point
+        in_strl_point = get_next_real_point(points_to_indices, in_vox_idx)
+
+        additional_start_pt = get_point_on_line(orig_strl[in_strl_point - 1],
+                                                orig_strl[in_strl_point],
+                                                inter_vox[in_vox_idx])
+        nb_points += 1
+
+    # Generate point for the current voxel
+    exit_strl_point = get_streamline_pt_index(points_to_indices,
+                                              out_vox_idx,
+                                              from_start=False)
+
+    if exit_strl_point is None:
+        #logging.debug("No direct mapping to streamline exit point found.")
+        #logging.debug("  Looking for previous valid point")
+
+        # Find the previous real streamline point
+        exit_strl_point = get_previous_real_point(points_to_indices,
+                                                  out_vox_idx)
+
+        additional_exit_pt = get_point_on_line(orig_strl[exit_strl_point],
+                                               orig_strl[exit_strl_point + 1],
+                                               inter_vox[out_vox_idx])
+        nb_points += 1
+
+    if exit_strl_point >= in_strl_point:
+        nb_points_orig_strl = exit_strl_point - in_strl_point + 1
+        nb_points += nb_points_orig_strl
+
+    segment = np.zeros((nb_points, 3))
+    at_point = 0
+
+    if additional_start_pt is not None:
+        #logging.debug("  adding artifical entry point: {}".format(
+        #              additional_start_pt))
+        segment[0] = additional_start_pt
+        at_point += 1
+
+    if exit_strl_point >= in_strl_point:
+        #logging.debug("  adding points [{}:{}] from orig strl".format(
+        #              in_strl_point, exit_strl_point + 1))
+
+        # Note: this works correctly even in the case where the "previous"
+        # point is the same or lower than the entry point, because of
+        # numpy indexing
+        ##print(in_strl_point, exit_strl_point)
+        segment[at_point:at_point + nb_points_orig_strl] = \
+            orig_strl[in_strl_point:exit_strl_point + 1]
+        at_point += nb_points_orig_strl
+    #else:
+        #logging.debug("  exit point was found before entry point. "
+        #              "Not inserting from orig strl.")
+
+
+    if additional_exit_pt is not None:
+        #logging.debug("  adding artifical exit point: {}".format(
+        #              additional_exit_pt))
+        segment[at_point] = additional_exit_pt
+        at_point += 1
+
+    #logging.debug("    new segment: {}".format(segment))
+    return segment
+
+
+def extract_longest_segments_from_profile(strl_indices, atlas_data):
+    start_label = None
+    end_label = None
+    start_idx = None
+    end_idx = None
+
+    nb_el_indices = len(strl_indices)
+    el_idx = 0
+    while start_label is None and el_idx < nb_el_indices:
+        if atlas_data[tuple(strl_indices[el_idx])] > 0:
+            start_label = atlas_data[tuple(strl_indices[el_idx])]
+            start_idx = el_idx
+        el_idx += 1
+
+    found_WM = False
+    while not found_WM and el_idx < nb_el_indices:
+        if atlas_data[tuple(strl_indices[el_idx])] == 0:
+            found_WM = True
+        el_idx += 1
+
+    if el_idx >= nb_el_indices or not found_WM:
+       return []
+
+    el_idx = nb_el_indices - 1
+    while end_label is None and el_idx > start_idx:
+        if atlas_data[tuple(strl_indices[el_idx])] > 0:
+            end_label = atlas_data[tuple(strl_indices[el_idx])]
+            end_idx = el_idx
+        el_idx -= 1
+
+    # TODO check self connections
+    if end_label is None or end_idx <= start_idx + 1:
+        return []
+
+    return [{'start_label': start_label,
+             'start_index': start_idx,
+             'end_label': end_label,
+             'end_index': end_idx}]
+
+
+# TODO self connect
+def compute_connectivity(indices, atlas_data,
+                         segmenting_func,
+                         allow_self_connection,
+                         minimize_self_connection):
+    atlas_data = atlas_data.astype(np.int32)
+    real_labels = np.unique(atlas_data)
+
+    connectivity = {k: {lab: [] for lab in real_labels} for k in real_labels}
+
+    for strl_idx, strl_indices in enumerate(indices):
+        segments_info = segmenting_func(strl_indices, atlas_data)
+
+        for si in segments_info:
+            connectivity[si['start_label']][si['end_label']].append(
+                {'strl_idx': strl_idx,
+                 'in_idx': si['start_index'],
+                 'out_idx': si['end_index']})
+
+    return connectivity

--- a/scilpy/tractanalysis/uncompress.pyx
+++ b/scilpy/tractanalysis/uncompress.pyx
@@ -1,0 +1,352 @@
+# encoding: utf-8
+#cython: profile=False
+#cython: language_level=3
+
+from libc.math cimport ceil, fabs, floor, sqrt
+from libc.math cimport fmin as cfmin
+
+import cython
+import nibabel as nib
+import numpy as np
+cimport numpy as cnp
+# TODO update Requirements.txt
+
+cdef struct Pointers:
+    # Incremented when we complete a streamline. Saved at the start of each
+    # streamline because we need to start anew if we resize data_out
+    cnp.npy_intp *lengths_in
+    cnp.npy_intp *lengths_out
+    cnp.npy_intp *offsets_in
+    cnp.npy_intp *offsets_out
+
+    # const, stop condition
+    cnp.npy_intp *lengths_in_end
+
+    # Incremented on each read/written point (each float, in fact)
+    float *data_in
+    cnp.uint16_t *data_out
+
+    # To bookkeep the final index related to a streamline point
+    cnp.npy_intp *pti_lengths_out
+    cnp.npy_intp *pti_offsets_out
+    cnp.uint64_t *points_to_index_out
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+@cython.cdivision(True)
+def uncompress(streamlines, return_mapping=False):
+    """
+    Get the indices of the voxels traversed by each streamline; then returns
+    an ArraySequence of indices. Yes, of *indices*. ArraySequence.data is
+    always of type float32 and contains points except here: it's of type
+    uint16 and contain indices. You can use this object exactly as you would
+    use a normal ArraySequence.
+
+    :param streamlines: nibabel.streamlines.array_sequence.ArraySequence
+        should be in voxel space, aligned to corner.
+    """
+    cdef:
+        cnp.npy_intp nb_streamlines = len(streamlines._lengths)
+        cnp.npy_intp at_point = 0
+
+        # Multiplying by 6 is simply a heuristic to avoiding resizing too many
+        # times. In my bundles tests, I had either 0 or 1 resize.
+        cnp.npy_intp max_points = (streamlines.data.size / 3) * 6
+
+    new_array_sequence = nib.streamlines.array_sequence.ArraySequence()
+    new_array_sequence._lengths.resize(nb_streamlines)
+    new_array_sequence._offsets.resize(nb_streamlines)
+    new_array_sequence._data = np.empty(max_points * 3, np.uint16)
+
+    points_to_index = nib.streamlines.array_sequence.ArraySequence()
+    points_to_index._lengths.resize(nb_streamlines)
+    points_to_index._offsets.resize(nb_streamlines)
+    points_to_index._data = np.zeros(int(streamlines.data.size / 3), np.uint64)
+
+    cdef:
+        cnp.npy_intp[:] lengths_view_in = streamlines._lengths
+        cnp.npy_intp[:] offsets_view_in = streamlines._offsets
+        float[:, :] data_view_in = streamlines._data
+        cnp.npy_intp[:] lengths_view_out = new_array_sequence._lengths
+        cnp.npy_intp[:] offsets_view_out = new_array_sequence._offsets
+        cnp.uint16_t[:] data_view_out = new_array_sequence._data
+        cnp.npy_intp[:] pti_lengths_view_out = points_to_index._lengths
+        cnp.npy_intp[:] pti_offsets_view_out = points_to_index._offsets
+        cnp.uint64_t[:] points_to_index_view_out = points_to_index._data
+
+    cdef Pointers pointers
+    pointers.lengths_in = &lengths_view_in[0]
+    pointers.lengths_in_end = pointers.lengths_in + nb_streamlines
+    pointers.offsets_in = &offsets_view_in[0]
+    pointers.data_in = &data_view_in[0, 0]
+    pointers.lengths_out = &lengths_view_out[0]
+    pointers.offsets_out = &offsets_view_out[0]
+    pointers.data_out = &data_view_out[0]
+    pointers.pti_lengths_out = &pti_lengths_view_out[0]
+    pointers.pti_offsets_out = &pti_offsets_view_out[0]
+    pointers.points_to_index_out = &points_to_index_view_out[0]
+
+    while 1:
+        at_point = _uncompress(&pointers, at_point, max_points - 1)
+        if pointers.lengths_in == pointers.lengths_in_end:
+            # Job finished, we can return the streamlines
+            break
+
+        # Resize and point the memoryview and pointer on the right data
+        max_points += max_points / 3  # Make it one third bigger
+        new_array_sequence._data.resize(max_points * 3, refcheck=False)
+        data_view_out = new_array_sequence._data
+        pointers.data_out = &data_view_out[0] + at_point * 3
+
+        if at_point == 0:
+            pointers.points_to_index_out = &points_to_index_view_out[0]
+        else:
+            pointers.points_to_index_out = &points_to_index_view_out[0] + pointers.offsets_in[0]
+
+    new_array_sequence._data.resize((at_point, 3), refcheck=False)
+
+    if not return_mapping:
+        return new_array_sequence
+    else:
+        return (new_array_sequence, points_to_index)
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cdef inline double norm(double x, double y, double z) nogil:
+    cdef double val = sqrt(x*x + y*y + z*z)
+    return val
+
+
+# Changing this to a memview was slower.
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cdef inline void c_get_closest_edge(double *p,
+                                    double *direction,
+                                    double *edge,
+                                    double eps=1.0) nogil:
+    edge[0] = floor(p[0] + eps) if direction[0] >= 0.0 else ceil(p[0] - eps)
+    edge[1] = floor(p[1] + eps) if direction[1] >= 0.0 else ceil(p[1] - eps)
+    edge[2] = floor(p[2] + eps) if direction[2] >= 0.0 else ceil(p[2] - eps)
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+@cython.cdivision(True)
+cdef cnp.npy_intp _uncompress(
+        Pointers* pointers,
+        cnp.npy_intp at_point,
+        cnp.npy_intp max_points) nogil:
+    cdef:
+        float *backup_data_in
+        cnp.npy_intp backup_at_point
+
+        cnp.npy_intp nb_points_in, point_idx, nb_points_out, prev_index, \
+                     nb_points_out_pti
+        double *current_pt = [0.0, 0.0, 0.0]
+        double *next_pt = [0.0, 0.0, 0.0]
+        double *direction = [0.0, 0.0, 0.0]
+        double *current_edge = [0.0, 0.0, 0.0]
+        double *jittered_point = [-1.0, -1.0, -1.0]
+
+        double direction_norm, remaining_distance
+        double length_ratio, move_ratio
+        cnp.uint16_t x = 0, y = 0, z = 0
+        cnp.uint16_t last_x, last_y, last_z
+
+    # For each streamline
+    while pointers.lengths_in != pointers.lengths_in_end:
+        # We must finish the streamline or start again from the beginning
+        backup_data_in = pointers.data_in
+        backup_at_point = at_point
+
+        nb_points_out = 0
+        nb_points_out_pti = 0
+        nb_points_in = pointers.lengths_in[0]
+
+        jittered_point[0] = -1.0
+        jittered_point[1] = -1.0
+        jittered_point[2] = -1.0
+
+        if backup_at_point == 0:  # If first
+            prev_index = 0
+        else:
+            # C negative indexing is supposed to be legal! From C99 §6.5.2.1/2
+            prev_index = pointers.offsets_out[-1] + pointers.lengths_out[-1]
+
+        # Check the very first point
+        x = <cnp.uint16_t>(pointers.data_in[0])
+        y = <cnp.uint16_t>(pointers.data_in[1])
+        z = <cnp.uint16_t>(pointers.data_in[2])
+        pointers.data_out[0] = x
+        pointers.data_out[1] = y
+        pointers.data_out[2] = z
+        pointers.points_to_index_out[0] = 0
+        pointers.points_to_index_out += 1
+        pointers.data_out += 3
+        nb_points_out += 1
+        nb_points_out_pti += 1
+        at_point += 1
+
+        # Make sure we don't already hit the max.
+        if at_point == max_points:
+            pointers.data_in = backup_data_in
+            return backup_at_point
+
+        for point_idx in range(nb_points_in - 1):
+            # Only checking the first element since all three should either be
+            # set to -1 when no jittering has taken place, or be > 0 if
+            # jittering has taken place, since we are in voxel coordinates.
+            if jittered_point[0] > -1.0:
+                # Make sure to use the correct point if we needed to jitter
+                # it because of an edge case
+                current_edge[0] = current_pt[0] = jittered_point[0]
+                current_edge[1] = current_pt[1] = jittered_point[1]
+                current_edge[2] = current_pt[2] = jittered_point[2]
+                jittered_point[0] = -1.0
+                jittered_point[1] = -1.0
+                jittered_point[2] = -1.0
+            else:
+                current_edge[0] = current_pt[0] = pointers.data_in[0]
+                current_edge[1] = current_pt[1] = pointers.data_in[1]
+                current_edge[2] = current_pt[2] = pointers.data_in[2]
+
+            # Always advance to next point
+            pointers.data_in += 3
+            next_pt[0] = pointers.data_in[0]
+            next_pt[1] = pointers.data_in[1]
+            next_pt[2] = pointers.data_in[2]
+            direction[0] = next_pt[0] - current_pt[0]
+            direction[1] = next_pt[1] - current_pt[1]
+            direction[2] = next_pt[2] - current_pt[2]
+
+            direction_norm = norm(direction[0], direction[1], direction[2])
+
+            # Make sure that the next point is not exactly on a voxel
+            # intersection or on the face of the voxel, since the behavior
+            # is not easy to define in this case.
+            if fabs(next_pt[0] - floor(next_pt[0])) < 1e-8 or\
+                fabs(next_pt[1] - floor(next_pt[1])) < 1e-8 or\
+                fabs(next_pt[2] - floor(next_pt[2])) < 1e-8:
+                # TODO in future, jitter edge or add thickness to deal with
+                # case where on an edge / face and the corresponding
+                # component of the direction is 0
+                next_pt[0] = next_pt[0] - 0.000001 * direction[0]
+                next_pt[1] = next_pt[1] - 0.000001 * direction[1]
+                next_pt[2] = next_pt[2] - 0.000001 * direction[2]
+
+                # Make sure we don't "underflow" the grid
+                if next_pt[0] < 0.0 or next_pt[1] < 0.0 or next_pt[2] < 0.0:
+                    next_pt[0] = next_pt[0] + 0.000002 * direction[0]
+                    next_pt[1] = next_pt[1] + 0.000002 * direction[1]
+                    next_pt[2] = next_pt[2] + 0.000002 * direction[2]
+
+                # Keep it in mind to correctly set when going back in the loop
+                jittered_point[0] = next_pt[0]
+                jittered_point[1] = next_pt[1]
+                jittered_point[2] = next_pt[2]
+
+                # Update those
+                direction[0] = next_pt[0] - current_pt[0]
+                direction[1] = next_pt[1] - current_pt[1]
+                direction[2] = next_pt[2] - current_pt[2]
+
+                direction_norm = norm(direction[0], direction[1], direction[2])
+
+            # Set the "remaining_distance" var to compute remaining length of
+            # vector to process
+            remaining_distance = direction_norm
+
+            # If consecutive coordinates are the same, skip one.
+            if direction_norm == 0:
+                continue
+
+            while True:
+                c_get_closest_edge(current_pt, direction, current_edge)
+
+                # Compute the smallest ratio of direction's length to get to an
+                # edge. This effectively means we find the first edge
+                # encountered. Set large value for length_ratio.
+                length_ratio = 10000
+                for dim_idx in range(3):
+                    if direction[dim_idx] != 0:
+                        length_ratio = cfmin(
+                            fabs((current_edge[dim_idx] - current_pt[dim_idx])
+                                / direction[dim_idx]),
+                            length_ratio)
+
+                # Check if last point is already on an edge
+                remaining_distance -= length_ratio * direction_norm
+
+                if remaining_distance < 0.:
+                    pointers.points_to_index_out[0] = nb_points_out - 1
+                    pointers.points_to_index_out += 1
+                    nb_points_out_pti += 1
+                    break
+
+                # Find the coordinates of voxel containing current point, to
+                # tag it in the map
+                move_ratio = length_ratio + 0.00000001
+                current_pt[0] = current_pt[0] + move_ratio * direction[0]
+                current_pt[1] = current_pt[1] + move_ratio * direction[1]
+                current_pt[2] = current_pt[2] + move_ratio * direction[2]
+
+                x = <cnp.uint16_t>(current_pt[0])
+                y = <cnp.uint16_t>(current_pt[1])
+                z = <cnp.uint16_t>(current_pt[2])
+                pointers.data_out[0] = x
+                pointers.data_out[1] = y
+                pointers.data_out[2] = z
+                pointers.data_out += 3
+                nb_points_out += 1
+
+                # Are we full yet? We return 1 before the max because we would
+                # still need to add the last point.
+                at_point += 1
+                if at_point == max_points:
+                    pointers.data_in = backup_data_in
+                    return backup_at_point
+
+        # We ignore the last point in the loop above, so we must increment it
+        pointers.data_in += 3
+
+        # Check last point
+        last_x = <cnp.uint16_t>next_pt[0]
+        last_y = <cnp.uint16_t>next_pt[1]
+        last_z = <cnp.uint16_t>next_pt[2]
+        if x != last_x or y != last_y or z != last_z:
+            with gil:
+                print('Got inside last')
+
+            pointers.data_out[0] = last_x
+            pointers.data_out[1] = last_y
+            pointers.data_out[2] = last_z
+            pointers.data_out += 3
+            pointers.points_to_index_out[0] = nb_points_out
+            pointers.points_to_index_out += 1
+            nb_points_out += 1
+            nb_points_out_pti += 1
+            at_point += 1
+
+        # Streamline finished, advance
+        pointers.lengths_out[0] = nb_points_out
+        pointers.pti_lengths_out[0] = nb_points_out_pti
+        if backup_at_point == 0:  # If first
+            pointers.offsets_out[0] = 0
+            pointers.pti_offsets_out[0] = 0
+        else:
+            # C negative indexing is supposed to be legal! From C99 §6.5.2.1/2
+            pointers.offsets_out[0] =\
+                pointers.offsets_out[-1] + pointers.lengths_out[-1]
+            pointers.pti_offsets_out[0] =\
+                pointers.pti_offsets_out[-1] + pointers.pti_lengths_out[-1]
+        pointers.offsets_out += 1
+        pointers.offsets_in += 1
+        pointers.lengths_in += 1
+        pointers.lengths_out += 1
+        pointers.pti_offsets_out += 1
+        pointers.pti_lengths_out += 1
+
+    # At this return, everything is finished
+    return at_point

--- a/scilpy/tractanalysis/uncompress.pyx
+++ b/scilpy/tractanalysis/uncompress.pyx
@@ -9,7 +9,6 @@ import cython
 import nibabel as nib
 import numpy as np
 cimport numpy as cnp
-# TODO update Requirements.txt
 
 cdef struct Pointers:
     # Incremented when we complete a streamline. Saved at the start of each

--- a/scripts/scil_compute_connectivity.py
+++ b/scripts/scil_compute_connectivity.py
@@ -83,7 +83,7 @@ def _create_required_output_dirs(out_paths, args):
 def _save_if_needed(streamlines, args, saving_options, out_paths,
                     save_type, step_type, in_label, out_label):
     if saving_options[save_type] and len(streamlines):
-        save_from_voxel_space(streamlines, args.labels, args.tracts,
+        save_from_voxel_space(streamlines, args.labels, args.tracks,
                               os.path.join(out_paths[step_type],
                                            '{}_{}.trk'.format(in_label,
                                                               out_label)))

--- a/scripts/scil_compute_connectivity.py
+++ b/scripts/scil_compute_connectivity.py
@@ -12,6 +12,9 @@ longest.
 This is robust to compressed streamlines.
 
 NOTE: this script can take a while to run. Please be patient.
+      Example: on a tractogram with 1.8M streamlines, running on a SSD:
+               - N minutes with full post-processing, only saving final bundles.
+               - 30 minutes with full post-processing, saving all possible files.
 """
 
 from __future__ import division
@@ -247,12 +250,10 @@ def main():
                  (time2 - time1) * 1000.0)
 
     # Compute the connectivity mapping
-    # TODO self connection?
     logging.info('*** Computing connectivity information ***')
     time1 = time.time()
     con_info = compute_connectivity(indices, img_labels.get_data(),
-                                    extract_longest_segments_from_profile,
-                                    False, True)
+                                    extract_longest_segments_from_profile)
     time2 = time.time()
     logging.info('    Connectivity computation took %0.3f ms',
                  (time2 - time1) * 1000.0)
@@ -347,10 +348,10 @@ def main():
 
             if not args.no_remove_loops_again:
                 no_qb_loops_strl, loops2 = remove_loops_and_sharp_turns(
-                                                    no_outliers,
-                                                    args.loop_max_angle,
-                                                    True,
-                                                    args.loop_qb_distance)
+                    no_outliers,
+                    args.loop_max_angle,
+                    True,
+                    args.loop_qb_distance)
                 _save_if_needed(loops2, args, saving_opts, out_paths,
                                 'discarded', 'qb_loops', in_label, out_label)
             else:
@@ -373,9 +374,6 @@ def main():
     # post-processing to avoid unnecessary -1 on labels for each access.
     con_mat = con_mat[1:, 1:]
     np.save(os.path.join(args.output, 'final_matrix.npy'), con_mat)
-
-    # In the future, could also be saved as a .json file, using pandas.
-    # Contact JC Houde for example.
 
 
 if __name__ == "__main__":

--- a/scripts/scil_compute_connectivity.py
+++ b/scripts/scil_compute_connectivity.py
@@ -10,7 +10,10 @@ reaching its final connected region, the kept connection is still the
 longest.
 
 This is robust to compressed streamlines.
+
+NOTE: this script can take a while to run. Please be patient.
 """
+
 from __future__ import division
 
 import argparse
@@ -20,7 +23,6 @@ import os
 from dipy.tracking.streamlinespeed import length
 import nibabel as nb
 import numpy as np
-# import pandas as pd
 
 from scilpy.io.streamlines import (load_trk_in_voxel_space,
                                    save_from_voxel_space)

--- a/scripts/scil_compute_connectivity.py
+++ b/scripts/scil_compute_connectivity.py
@@ -127,8 +127,8 @@ def build_args_parser():
     p = argparse.ArgumentParser(
         formatter_class=argparse.RawTextHelpFormatter,
         description=__doc__)
-    p.add_argument('tracts',
-                   help='Path of the tracts file, in a format supported by ' +
+    p.add_argument('tracks',
+                   help='Path of the tracks file, in a format supported by ' +
                         'the Nibabel streamlines API.')
     p.add_argument('labels',
                    help='Labels file name (nifti). Labels must be consecutive '
@@ -151,7 +151,7 @@ def build_args_parser():
                                 'loops.\nAngle criteria based on '
                                 '--loop_max_angle')
     post_proc.add_argument('--no_remove_outliers', action='store_true',
-                           help='If set, will NOT Remove outliers using QB.\n'
+                           help='If set, will NOT remove outliers using QB.\n'
                                 'Criteria based on --outlier_threshold.')
     post_proc.add_argument('--no_remove_loops_again', action='store_true',
                            help='If set, will NOT remove streamlines that '
@@ -199,7 +199,7 @@ def main():
     parser = build_args_parser()
     args = parser.parse_args()
 
-    assert_inputs_exist(parser, [args.tracts, args.labels])
+    assert_inputs_exist(parser, [args.tracks, args.labels])
 
     if os.path.abspath(args.output) == os.getcwd():
         parser.error('Do not use the current path as output directory.')
@@ -228,7 +228,7 @@ def main():
 
     logging.info('*** Loading streamlines ***')
     time1 = time.time()
-    streamlines = load_trk_in_voxel_space(args.tracts, args.labels)
+    streamlines = load_trk_in_voxel_space(args.tracks, args.labels)
     time2 = time.time()
 
     logging.info('    Number of streamlines to process: {}'.format(

--- a/scripts/scil_compute_connectivity.py
+++ b/scripts/scil_compute_connectivity.py
@@ -13,7 +13,7 @@ This is robust to compressed streamlines.
 
 NOTE: this script can take a while to run. Please be patient.
       Example: on a tractogram with 1.8M streamlines, running on a SSD:
-               - N minutes with full post-processing, only saving final bundles.
+               - 29 minutes with full post-processing, only saving final bundles.
                - 30 minutes with full post-processing, saving all possible files.
 """
 

--- a/scripts/scil_compute_connectivity.py
+++ b/scripts/scil_compute_connectivity.py
@@ -13,6 +13,7 @@ This is robust to compressed streamlines.
 
 NOTE: this script can take a while to run. Please be patient.
       Example: on a tractogram with 1.8M streamlines, running on a SSD:
+               - 4 minutes without post-processing, only saving final bundles.
                - 29 minutes with full post-processing, only saving final bundles.
                - 30 minutes with full post-processing, saving all possible files.
 """

--- a/scripts/scil_compute_connectivity.py
+++ b/scripts/scil_compute_connectivity.py
@@ -16,6 +16,7 @@ NOTE: this script can take a while to run. Please be patient.
 
 from __future__ import division
 
+from builtins import zip
 import argparse
 import logging
 import os
@@ -89,8 +90,8 @@ def _save_if_needed(streamlines, args, saving_options, out_paths,
 
 def _symmetrize_con_info(con_info):
     final_con_info = {}
-    for in_label in con_info.keys():
-        for out_label in con_info[in_label].keys():
+    for in_label in list(con_info.keys()):
+        for out_label in list(con_info[in_label].keys()):
 
             pair_info = con_info[in_label][out_label]
 
@@ -250,8 +251,8 @@ def main():
     con_mat = np.zeros((nb_labels + 1, nb_labels + 1),
                        dtype=np.uint32)
 
-    for in_label in final_con_info.keys():
-        for out_label in final_con_info[in_label].keys():
+    for in_label in list(final_con_info.keys()):
+        for out_label in list(final_con_info[in_label].keys()):
             pair_info = final_con_info[in_label][out_label]
 
             if not len(pair_info):

--- a/scripts/scil_compute_connectivity.py
+++ b/scripts/scil_compute_connectivity.py
@@ -5,7 +5,7 @@
 Compute a connectivity matrix from a tractogram and a parcellation.
 
 Current strategy is to keep the longest streamline segment connecting
-2 regions. If the streamlines crosses other gray matter regions before
+2 regions. If the streamline crosses other gray matter regions before
 reaching its final connected region, the kept connection is still the
 longest.
 
@@ -127,33 +127,33 @@ def build_args_parser():
         formatter_class=argparse.RawTextHelpFormatter,
         description=__doc__)
     p.add_argument('tracts',
-                   help='path of the tracts file, in a format supported by ' +
+                   help='Path of the tracts file, in a format supported by ' +
                         'the Nibabel streamlines API.')
     p.add_argument('labels',
-                   help='labels file name (nifti). Labels must be consecutive '
-                        'from 0 to N, with 0 the background.'
+                   help='Labels file name (nifti). Labels must be consecutive '
+                        'from 0 to N, with 0 the background. '
                         'This generates a NxN connectivity matrix.')
     p.add_argument('max_labels', type=int,
-                   help='maximal label value that could be present in the '
+                   help='Maximal label value that could be present in the '
                         'parcellation. Used to generate matrices with the '
                         'same size for all subjects.')
     p.add_argument(dest='output', metavar='output_dir',
-                   help='output directory path.')
+                   help='Output directory path.')
 
     post_proc = p.add_argument_group('Post-processing options')
     post_proc.add_argument('--no_pruning', action='store_true',
-                           help='if set, will NOT prune on length.\n'
+                           help='If set, will NOT prune on length.\n'
                                 'Length criteria in --min_length, '
                                 '--max_length')
     post_proc.add_argument('--no_remove_loops', action='store_true',
-                           help='if set, will NOT remove streamlines making '
+                           help='If set, will NOT remove streamlines making '
                                 'loops.\nAngle criteria based on '
                                 '--loop_max_angle')
     post_proc.add_argument('--no_remove_outliers', action='store_true',
-                           help='if set, will NOT Remove outliers using QB.\n'
+                           help='If set, will NOT Remove outliers using QB.\n'
                                 'Criteria based on --outlier_threshold.')
     post_proc.add_argument('--no_remove_loops_again', action='store_true',
-                           help='if set, will NOT remove streamlines that '
+                           help='If set, will NOT remove streamlines that '
                                 'loop according to QuickBundles.\n'
                                 'Threshold based on --loop_qb_distance.')
 
@@ -176,13 +176,13 @@ def build_args_parser():
 
     s = p.add_argument_group('Saving options')
     s.add_argument('--save_raw_connections', action='store_true',
-                   help='if set, will save all raw cut connections in a '
+                   help='If set, will save all raw cut connections in a '
                         'subdirectory')
     s.add_argument('--save_intermediate', action='store_true',
-                   help='if set, will save the intermediate results of '
+                   help='If set, will save the intermediate results of '
                         'filtering')
     s.add_argument('--save_discarded', action='store_true',
-                   help='if set, will save discarded streamlines in '
+                   help='If set, will save discarded streamlines in '
                         'subdirectories.\nIncludes loops, outliers and '
                         'qb_loops')
 
@@ -199,6 +199,10 @@ def main():
     args = parser.parse_args()
 
     assert_inputs_exist(parser, [args.tracts, args.labels])
+
+    if os.path.abspath(args.output) == os.getcwd():
+        parser.error('Do not use the current path as output directory.')
+
     assert_output_dirs_exist_and_empty(parser, args, args.output)
 
     log_level = logging.WARNING

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,9 @@
 import os
+
+from Cython.Build import cythonize
+import numpy
 from setuptools import setup, find_packages
+from setuptools.extension import Extension
 PACKAGES = find_packages()
 
 # Get version and release info, which is all stored in scilpy/version.py
@@ -24,6 +28,15 @@ opts = dict(name=NAME,
             install_requires=REQUIRES,
             requires=REQUIRES,
             scripts=SCRIPTS)
+
+extensions = [Extension('scilpy.tractanalysis.uncompress',
+                        ['scilpy/tractanalysis/uncompress.pyx'],
+                        include_dirs=[numpy.get_include()]),
+              Extension('scilpy.tractanalysis.quick_tools',
+                        ['scilpy/tractanalysis/quick_tools.pyx'],
+                        include_dirs=[numpy.get_include()])]
+
+opts['ext_modules'] = cythonize(extensions)
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ extensions = [Extension('scilpy.tractanalysis.uncompress',
                         ['scilpy/tractanalysis/uncompress.pyx'],
                         include_dirs=[numpy.get_include()]),
               Extension('scilpy.tractanalysis.quick_tools',
-                        ['scilpy/tractanalysis/quick_tools.pyx'],
+                        ['scilpy/tractanalysis/quick_tools.pyx']),
               Extension('scilpy.tractanalysis.streamlines_metrics',
                         ['scilpy/tractanalysis/streamlines_metrics.pyx'],
                         include_dirs=[numpy.get_include()])]


### PR DESCRIPTION
This is the first working version of a connectivity script.

It finds the longest GM-GM regions connected by each streamline. Cuts to make sure the streamlines really stay in the regions.

Applies optional post-processing steps: length pruning, loop removal, outlier rejection.

It creates a connectivity matrix, and saves the final bundles. It can optionally save raw connections and intermediate files.

NOTE: there are still a few TODOs that could be improved in future versions.

NOTE: There are TODOs that are related to adding other methods to compute values to assign to the connectivity matrix, such as mean FA, etc. It was decided that this could be added later on in the process.

@mdesco anything else you wanted in this first version?

To be able to use this, you will need to run

```
python setup.py build_ext --inplace
```