### PR TITLE
switch old dipy.reconst.peak to dipy.direction.peak

### DIFF
--- a/scilpy/reconst/utils.py
+++ b/scilpy/reconst/utils.py
@@ -4,7 +4,7 @@ from __future__ import division
 
 import warnings
 
-from dipy.reconst.peaks import peak_directions
+from dipy.direction.peaks import peak_directions
 from dipy.reconst.shm import sph_harm_lookup
 import numpy as np
 

--- a/scripts/scil_compute_fodf.py
+++ b/scripts/scil_compute_fodf.py
@@ -24,7 +24,7 @@ from dipy.core.gradients import gradient_table
 from dipy.data import get_sphere
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.reconst.csdeconv import ConstrainedSphericalDeconvModel
-from dipy.reconst.peaks import (peaks_from_model,
+from dipy.direction.peaks import (peaks_from_model,
                                 reshape_peaks_for_visualization)
 import nibabel as nib
 import numpy as np

--- a/scripts/scil_compute_fodf_metrics.py
+++ b/scripts/scil_compute_fodf_metrics.py
@@ -34,7 +34,7 @@ import nibabel as nib
 
 from dipy.core.ndindex import ndindex
 from dipy.data import get_sphere
-from dipy.reconst.peaks import reshape_peaks_for_visualization
+from dipy.direction.peaks import reshape_peaks_for_visualization
 
 from scilpy.io.utils import (add_overwrite_arg, add_sh_basis_args,
                              assert_inputs_exist, assert_outputs_exists)


### PR DESCRIPTION
Switching old dipy.reconst.peak module to the new one dipy.direction.peak

https://github.com/nipy/dipy/pull/1824