### PR TITLE
BF: Fix shell indices

### DIFF
--- a/scripts/scil_extract_dwi_shell.py
+++ b/scripts/scil_extract_dwi_shell.py
@@ -116,7 +116,7 @@ def main():
     tol = args.tolerance
     indices = [get_shell_indices(bvals, shell, tol=tol)
                for shell in args.bvals_to_extract]
-    indices = np.sort(np.hstack(indices))
+    indices = np.unique(np.sort(np.hstack(indices)))
 
     if len(indices) == 0:
         parser.error('There are no volumes that have the supplied b-values.')


### PR DESCRIPTION
Add a unique function on the shell indices otherwise the script crash on a case like bvals_to_extract="0 1500 1499".