### PR TITLE
Futurize streamlines compression

### DIFF
--- a/scilpy/io/streamlines.py
+++ b/scilpy/io/streamlines.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+
+import nibabel as nib
+
+
+def check_tracts_same_format(parser, tractogram_1, tractogram_2):
+    """
+    Assert that two filepaths have the same valid extension.
+    :param parser: argparse.ArgumentParser object
+    :param tractogram_1: Tractogram filename #1
+    :param tractogram_2: Tractogram filename #2
+    """
+    if not nib.streamlines.is_supported(tractogram_1):
+        parser.error('Format of "{}" not supported.'.format(tractogram_1))
+    if not nib.streamlines.is_supported(tractogram_2):
+        parser.error('Format of "{}" not supported.'.format(tractogram_2))
+
+    ext_1 = os.path.splitext(tractogram_1)[1]
+    ext_2 = os.path.splitext(tractogram_2)[1]
+    if not ext_1 == ext_2:
+        parser.error(
+            'Input and output tractogram file must use the same format.')

--- a/scilpy/io/streamlines.py
+++ b/scilpy/io/streamlines.py
@@ -22,4 +22,4 @@ def check_tracts_same_format(parser, tractogram_1, tractogram_2):
     ext_2 = os.path.splitext(tractogram_2)[1]
     if not ext_1 == ext_2:
         parser.error(
-            'Input and output tractogram file must use the same format.')
+            'Input and output tractogram files must use the same format.')

--- a/scripts/scil_compress_streamlines.py
+++ b/scripts/scil_compress_streamlines.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Compress tractogram by removing collinear (or almost) points.
+
+The compression threshold represents the maximum distance (in mm) to the
+original position of the point.
+"""
+
+import argparse
+import logging
+
+from dipy.tracking.streamlinespeed import compress_streamlines
+import nibabel as nib
+from nibabel.streamlines import LazyTractogram
+import numpy as np
+
+from scilpy.io.streamlines import check_tracts_same_format
+from scilpy.io.utils import (add_overwrite_arg,
+                             assert_inputs_exist,
+                             assert_outputs_exists)
+
+
+def _build_args_parser():
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+    p.add_argument('in_tractogram',
+                   help='Path of the input tractogram file (trk or tck).')
+    p.add_argument('out_tractogram',
+                   help='Path of the output tractogram file (trk or tck).')
+
+    p.add_argument('-e', dest='error_rate', type=float, default=0.1,
+                   help='Maximum compression distance in mm. '
+                   '[default: %(default)s]')
+    add_overwrite_arg(p)
+
+    return p
+
+
+def compress_streamlines_wrapper(tractogram, error_rate):
+    return lambda: [(yield compress_streamlines(
+        s, error_rate)) for s in tractogram.streamlines]
+
+
+def main():
+    parser = _build_args_parser()
+    args = parser.parse_args()
+
+    assert_inputs_exist(parser, [args.in_tractogram])
+    assert_outputs_exists(parser, args, [args.out_tractogram])
+    check_tracts_same_format(parser, args.in_tractogram, args.out_tractogram)
+
+    if args.error_rate < 0.001 or args.error_rate > 1:
+        logging.warn(
+            'You are using an error rate of {}.\n'
+            'We recommend setting it between 0.001 and 1.\n'
+            '0.001 will do almost nothing to the streamlines\n'
+            'while 1 will higly compress/linearize the streamlines'
+            .format(args.error_rate))
+
+    in_tractogram = nib.streamlines.load(args.in_tractogram, lazy_load=True)
+    compressed_streamlines = compress_streamlines_wrapper(in_tractogram,
+                                                          args.error_rate)
+    out_tractogram = LazyTractogram(compressed_streamlines,
+                                    affine_to_rasmm=np.eye(4))
+    nib.streamlines.save(out_tractogram, args.out_tractogram,
+                         header=in_tractogram.header)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Simple transfert of scripts, remove dependency from TractConverter while keeping the lazy_loading/saving feature and tested for python 3