### PR TITLE
Move tractogram function to io streamlines and typo

### DIFF
--- a/scilpy/io/streamlines.py
+++ b/scilpy/io/streamlines.py
@@ -3,6 +3,7 @@
 
 import os
 
+from dipy.io.streamline import load_tractogram
 import nibabel as nib
 
 

--- a/scilpy/io/streamlines.py
+++ b/scilpy/io/streamlines.py
@@ -23,3 +23,21 @@ def check_tracts_same_format(parser, tractogram_1, tractogram_2):
     if not ext_1 == ext_2:
         parser.error(
             'Input and output tractogram files must use the same format.')
+
+
+def load_tractogram_with_reference(parser, args, filepath,
+                                   bbox_check=True):
+    _, ext = os.path.splitext(filepath)
+    if ext == '.trk':
+        sft = load_tractogram(filepath, 'same',
+                              bbox_valid_check=bbox_check)
+    elif ext in ['.tck', '.fib', '.vtk', '.dpy']:
+        if args.reference is None:
+            parser.error('--reference is required for this file format '
+                         '{}.'.format(filepath))
+        sft = load_tractogram(filepath, args.reference,
+                              bbox_valid_check=bbox_check)
+    else:
+        parser.error('{} is an unsupported file format'.format(filepath))
+
+    return sft

--- a/scilpy/io/utils.py
+++ b/scilpy/io/utils.py
@@ -19,24 +19,6 @@ def add_reference(parser):
                         'support (.nii or .nii.gz).')
 
 
-def load_tractogram_with_reference(parser, args, filepath,
-                                   bbox_check=True):
-    _, ext = os.path.splitext(filepath)
-    if ext == '.trk':
-        sft = load_tractogram(filepath, 'same',
-                              bbox_valid_check=bbox_check)
-    elif ext in ['.tck', '.fib', '.vtk', '.dpy']:
-        if args.reference is None:
-            parser.error('--reference is required for this file format '
-                         '{}.'.format(filepath))
-        sft = load_tractogram(filepath, args.reference,
-                              bbox_valid_check=bbox_check)
-    else:
-        parser.error('{} is an unsupported file format'.format(filepath))
-
-    return sft
-
-
 def add_overwrite_arg(parser):
     parser.add_argument(
         '-f', dest='overwrite', action='store_true',

--- a/scilpy/io/utils.py
+++ b/scilpy/io/utils.py
@@ -5,7 +5,6 @@ import os
 import six
 import xml.etree.ElementTree as ET
 
-from dipy.io.streamline import load_tractogram
 import nibabel as nib
 from nibabel.streamlines import TrkFile
 import numpy as np

--- a/scripts/scil_compute_todi.py
+++ b/scripts/scil_compute_todi.py
@@ -7,10 +7,10 @@ import logging
 import nibabel as nib
 import numpy as np
 
+from scilpy.io.streamlines import load_tractogram_with_reference
 from scilpy.io.utils import (add_overwrite_arg, add_reference,
                              add_sh_basis_args,
-                             assert_inputs_exist, assert_outputs_exist,
-                             load_tractogram_with_reference)
+                             assert_inputs_exist, assert_outputs_exist)
 from scilpy.tractanalysis.todi import TrackOrientationDensityImaging
 
 

--- a/scripts/scil_convert_tractogram.py
+++ b/scripts/scil_convert_tractogram.py
@@ -6,9 +6,9 @@ import os
 
 from dipy.io.streamline import save_tractogram
 
+from scilpy.io.streamlines import load_tractogram_with_reference
 from scilpy.io.utils import (add_overwrite_arg, add_reference,
-                             assert_inputs_exist, assert_outputs_exist,
-                             load_tractogram_with_reference)
+                             assert_inputs_exist, assert_outputs_exist)
 
 DESCRIPTION = """
 Conversion of '.tck', '.trk', '.fib', '.vtk' and 'dpy' files using updated file

--- a/scripts/scil_filter_tractogram.py
+++ b/scripts/scil_filter_tractogram.py
@@ -11,10 +11,10 @@ from dipy.io.utils import is_header_compatible
 import nibabel as nib
 import numpy as np
 
+from scilpy.io.streamlines import load_tractogram_with_reference
 from scilpy.io.utils import (add_overwrite_arg, add_reference, add_verbose_arg,
                              assert_inputs_exist,
                              assert_outputs_exist,
-                             load_tractogram_with_reference,
                              read_info_from_mb_bdo)
 from scilpy.segment.streamlines import (filter_grid_roi,
                                         filter_ellipsoid,

--- a/scripts/scil_recognize_single_bundle.py
+++ b/scripts/scil_recognize_single_bundle.py
@@ -19,10 +19,10 @@ from dipy.tracking.streamline import transform_streamlines
 from nibabel.streamlines.array_sequence import ArraySequence
 import numpy as np
 
+from scilpy.io.streamlines import load_tractogram_with_reference
 from scilpy.io.utils import (add_overwrite_arg, add_reference, add_verbose_arg,
                              assert_inputs_exist,
-                             assert_outputs_exist,
-                             load_tractogram_with_reference)
+                             assert_outputs_exist)
 
 
 def _build_args_parser():

--- a/scripts/scil_remove_invalid_streamlines.py
+++ b/scripts/scil_remove_invalid_streamlines.py
@@ -5,9 +5,9 @@ import argparse
 
 from dipy.io.streamline import save_tractogram
 
+from scilpy.io.streamlines import load_tractogram_with_reference
 from scilpy.io.utils import (add_overwrite_arg, add_reference,
-                             assert_inputs_exist, assert_outputs_exist,
-                             load_tractogram_with_reference)
+                             assert_inputs_exist, assert_outputs_exist)
 
 DESCRIPTION = """
 Removal of streamlines that are out of the volume bounding box. In voxel space

--- a/scripts/scil_remove_invalid_streamlines.py
+++ b/scripts/scil_remove_invalid_streamlines.py
@@ -12,7 +12,7 @@ from scilpy.io.utils import (add_overwrite_arg, add_reference,
 DESCRIPTION = """
 Removal of streamlines that are out of the volume bounding box. In voxel space
 no negative coordinate and no above volume dimension coordinate are possible.
-Any streamlines that do not respect these two conditions are removed.
+Any streamline that do not respect these two conditions are removed.
 """
 
 

--- a/scripts/scil_streamlines_math.py
+++ b/scripts/scil_streamlines_math.py
@@ -38,10 +38,10 @@ from dipy.io.stateful_tractogram import Space, StatefulTractogram
 from dipy.io.streamline import save_tractogram
 import numpy as np
 
+from scilpy.io.streamlines import load_tractogram_with_reference
 from scilpy.io.utils import (add_overwrite_arg, add_reference, add_verbose_arg,
                              assert_inputs_exist,
-                             assert_outputs_exist,
-                             load_tractogram_with_reference)
+                             assert_outputs_exist)
 from scilpy.utils.streamlines import (perform_streamlines_operation,
                                       subtraction, intersection, union)
 


### PR DESCRIPTION
Following JC comment PR42 
load_tractogram_with_reference is now in `scilpy/io/streamlines.py`