### PR TITLE
Improving font of mosaic

### DIFF
--- a/scripts/scil_visualize_bundles_mosaic.py
+++ b/scripts/scil_visualize_bundles_mosaic.py
@@ -59,6 +59,20 @@ def get_font(args):
             print('Font {} was not found. '
                   'Default font will be used.'.format(args.ttf))
             font = ImageFont.load_default()
+    elif args.ttf_size is not None:
+        # default font is not a truetype font, so size can't be changed.
+        # to allow users to change the size without having to know where fonts
+        # are in their computer, we could try to find a truetype font ourselves.
+        # They are often present in /usr/share/fonts/
+        font_path = '/usr/share/fonts/truetype/freefont/FreeSans.ttf'
+        try:
+            font = ImageFont.truetype(font_path, args.ttf_size)
+        except Exception:
+            print('You did not specify a font. It is difficult'
+                  'for us to adjust size. We tried on font {} '
+                  'but it was not found.'
+                  'Default font will be used, for which font cannot be changed.'.format(font_path))
+            font = ImageFont.load_default()
     else:
         font = ImageFont.load_default()
     return font

--- a/scripts/scil_visualize_bundles_mosaic.py
+++ b/scripts/scil_visualize_bundles_mosaic.py
@@ -9,6 +9,7 @@ The script will output a mosaic (image) with screenshots,
 
 from __future__ import division, print_function
 import argparse
+import logging
 import os
 import shutil
 
@@ -57,7 +58,7 @@ def get_font(args):
             font = ImageFont.truetype(args.ttf, args.ttf_size)
         except Exception:
             logging.error('Font {} was not found. '
-                  'Default font will be used.'.format(args.ttf))
+                          'Default font will be used.'.format(args.ttf))
             font = ImageFont.load_default()
     elif args.ttf_size is not None:
         # default font is not a truetype font, so size can't be changed.
@@ -69,10 +70,10 @@ def get_font(args):
             font = ImageFont.truetype(font_path, args.ttf_size)
         except Exception:
             logging.error('You did not specify a font. It is difficult'
-                  'for us to adjust size. We tried on font {} '
-                  'but it was not found.'
-                  'Default font will be used, for which font '
-                  'cannot be changed.'.format(font_path))
+                          'for us to adjust size. We tried on font {} '
+                          'but it was not found.'
+                          'Default font will be used, for which font '
+                          'cannot be changed.'.format(font_path))
             font = ImageFont.load_default()
     else:
         font = ImageFont.load_default()

--- a/scripts/scil_visualize_bundles_mosaic.py
+++ b/scripts/scil_visualize_bundles_mosaic.py
@@ -56,22 +56,23 @@ def get_font(args):
         try:
             font = ImageFont.truetype(args.ttf, args.ttf_size)
         except Exception:
-            print('Font {} was not found. '
+            logging.error('Font {} was not found. '
                   'Default font will be used.'.format(args.ttf))
             font = ImageFont.load_default()
     elif args.ttf_size is not None:
         # default font is not a truetype font, so size can't be changed.
         # to allow users to change the size without having to know where fonts
-        # are in their computer, we could try to find a truetype font ourselves.
-        # They are often present in /usr/share/fonts/
+        # are in their computer, we could try to find a truetype font
+        # ourselves. They are often present in /usr/share/fonts/
         font_path = '/usr/share/fonts/truetype/freefont/FreeSans.ttf'
         try:
             font = ImageFont.truetype(font_path, args.ttf_size)
         except Exception:
-            print('You did not specify a font. It is difficult'
+            logging.error('You did not specify a font. It is difficult'
                   'for us to adjust size. We tried on font {} '
                   'but it was not found.'
-                  'Default font will be used, for which font cannot be changed.'.format(font_path))
+                  'Default font will be used, for which font '
+                  'cannot be changed.'.format(font_path))
             font = ImageFont.load_default()
     else:
         font = ImageFont.load_default()


### PR DESCRIPTION
The font was really small on my screen for the mosaic of the bundles.

As is, the script does not consider the arg "font size" if no font name was given, but it is not explained in the -h help.

I added a try: exception that tries to find a truetype font on the computer. This way you don't have to remember where the fonts are everytime you want to use the script and change the size. Should work on most linux versions. Else, explains that it can't and uses default, like before.