### PR TITLE
Futurize bundle screenshot

### DIFF
--- a/scripts/scil_screenshot_bundle.py
+++ b/scripts/scil_screenshot_bundle.py
@@ -60,7 +60,6 @@ def _build_args_parser():
 def prepare_data_for_actors(bundle_filename, reference_filename,
                             target_template_filename):
     sft = load_tractogram(bundle_filename, reference_filename)
-    # sft.to_vox()
     streamlines = sft.streamlines
 
     # Load and prepare the data
@@ -71,7 +70,6 @@ def prepare_data_for_actors(bundle_filename, reference_filename,
     target_template_img = nib.load(target_template_filename)
     target_template_data = target_template_img.get_data()
     target_template_affine = target_template_img.affine
-    zooms = 1 / float(target_template_img.header.get_zooms()[0])
 
     # Register the DWI data to the template
     transformed_reference, transformation = register_image(target_template_data,
@@ -81,7 +79,6 @@ def prepare_data_for_actors(bundle_filename, reference_filename,
     # transformation = np.eye(4)
     streamlines = transform_streamlines(streamlines,
                                         np.linalg.inv(transformation))
-    # streamlines = transform_streamlines(streamlines, zooms * np.eye(4))
 
     return streamlines, transformed_reference
 
@@ -118,7 +115,6 @@ def main():
 
     # Get the relevant slices from the template
     target_template_img = nib.load(args.target_template)
-    zooms = 1
 
     x_slice = int(target_template_img.shape[0] / 2)
     y_slice = int(target_template_img.shape[1] / 2)
@@ -140,7 +136,7 @@ def main():
                   args.uniform_coloring[1] / 255.0,
                   args.uniform_coloring[2] / 255.0)
     elif args.reference_coloring:
-        colors = reference
+        colors = reference_data
     else:
         colors = None
 

--- a/scripts/scil_screenshot_bundle.py
+++ b/scripts/scil_screenshot_bundle.py
@@ -20,7 +20,9 @@ from scilpy.viz.screenshot import display_slices
 
 DESCRIPTION = """
    Register bundle to a template for screenshots using a reference.
-   The template are in /mnt/braindata/Other/simple_template_viz/
+   The template can be any MNI152 (any resolution, cropped or not)
+   If your in_anat has a skull, select a MNI152 template with a skull and
+   vice-versa.
    Axial, coronal and sagittal slices are captured.
    Sagittal can be capture from the left (default) or the right.
    """
@@ -35,8 +37,9 @@ def _build_args_parser():
     p.add_argument('in_anat',
                    help='Path of the reference file (.nii or nii.gz)')
     p.add_argument('target_template',
-                   help='Path to the target MNI152template for registration, '
-                        'Any choice of modality works')
+                   help='Path to the target MNI152template for registration. \n'
+                        'If in_anat has a skull, select a MNI152 template \n'
+                        'with a skull and vice-versa.')
 
     sub_color = p.add_mutually_exclusive_group()
     sub_color.add_argument('--local_coloring', action='store_true',

--- a/scripts/scil_screenshot_bundle.py
+++ b/scripts/scil_screenshot_bundle.py
@@ -33,9 +33,9 @@ def _build_args_parser():
         description=DESCRIPTION,
         formatter_class=argparse.RawTextHelpFormatter)
     p.add_argument('in_bundle',
-                   help='Path of the input bundle')
+                   help='Path of the input bundle.')
     p.add_argument('in_anat',
-                   help='Path of the reference file (.nii or nii.gz)')
+                   help='Path of the reference file (.nii or nii.gz).')
     p.add_argument('target_template',
                    help='Path to the target MNI152template for registration. \n'
                         'If in_anat has a skull, select a MNI152 template \n'
@@ -43,24 +43,24 @@ def _build_args_parser():
 
     sub_color = p.add_mutually_exclusive_group()
     sub_color.add_argument('--local_coloring', action='store_true',
-                           help='Color streamlines local segments orientation')
+                           help='Color streamlines local segments orientation.')
     sub_color.add_argument('--uniform_coloring', nargs=3, metavar=('R', 'G', 'B'),
                            type=int,
-                           help='Color streamlines with uniform coloring')
+                           help='Color streamlines with uniform coloring.')
     sub_color.add_argument('--reference_coloring',
                            metavar='COLORBAR',
-                           help='Color streamlines with reference coloring (0-255)')
+                           help='Color streamlines with reference coloring (0-255).')
 
     p.add_argument('--right', action='store_true',
                    help='Take screenshot from the right instead of the left \n'
-                        'for the sagittal plane')
+                        'for the sagittal plane.')
     p.add_argument('--anat_opacity', type=float, default=0.3,
-                   help='Set the opacity for the anatomy, use 0 for complete '
-                   'transparency, 1 for opaque')
+                   help='Set the opacity for the anatomy, use 0 for complete \n'
+                   'transparency, 1 for opaque.')
     p.add_argument('--output_suffix',
-                   help='Add a suffix to the output, else the axis name is used')
+                   help='Add a suffix to the output, else the axis name is used.')
     p.add_argument('--output_dir', default='',
-                   help='Put all images in a specific directory')
+                   help='Put all images in a specific directory.')
     add_overwrite_arg(p)
 
     return p

--- a/scripts/scil_screenshot_bundle.py
+++ b/scripts/scil_screenshot_bundle.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import argparse
+import os
+
+from dipy.io.streamline import load_tractogram
+from dipy.tracking.streamline import transform_streamlines
+from fury import actor
+import nibabel as nib
+import numpy as np
+
+from scilpy.io.utils import (add_overwrite_arg,
+                             assert_inputs_exist,
+                             assert_outputs_exist)
+from scilpy.utils.image import register_image
+from scilpy.viz.screenshot import display_slices
+
+DESCRIPTION = """
+   Register bundle to a template for screenshots using a reference.
+   The template are in /mnt/braindata/Other/simple_template_viz/
+   Axial, coronal and sagittal slices are captured.
+   Sagittal can be capture from the left (default) or the right.
+   """
+
+
+def _build_args_parser():
+    p = argparse.ArgumentParser(
+        description=DESCRIPTION,
+        formatter_class=argparse.RawTextHelpFormatter)
+    p.add_argument('in_bundle',
+                   help='Path of the input bundle')
+    p.add_argument('in_anat',
+                   help='Path of the reference file (.nii or nii.gz)')
+    p.add_argument('target_template',
+                   help='Path to the target MNI152template for registration, '
+                        'Any choice of modality works')
+
+    sub_color = p.add_mutually_exclusive_group()
+    sub_color.add_argument('--uniform_coloring', nargs=3, metavar=('R', 'G', 'B'),
+                           type=int,
+                           help='Color streamlines with uniform coloring')
+    sub_color.add_argument('--reference_coloring', action='store_true',
+                           help='Color streamlines with reference coloring (0-255)')
+
+    p.add_argument('--right', action='store_true',
+                   help='Take screenshot from the right instead of the left \n'
+                        'for the sagittal plane')
+    p.add_argument('--anat_opacity', type=float, default=0.3,
+                   help='Set the opacity for the anatomy, use 0 for complete '
+                   'transparency, 1 for opaque')
+    p.add_argument('--output_suffix',
+                   help='Add a suffix to the output, else the axis name is used')
+    p.add_argument('--output_dir', default='',
+                   help='Put all images in a specific directory, will overwrite')
+    add_overwrite_arg(p)
+
+    return p
+
+
+def prepare_data_for_actors(bundle_filename, reference_filename,
+                            target_template_filename):
+    sft = load_tractogram(bundle_filename, reference_filename)
+    # sft.to_vox()
+    streamlines = sft.streamlines
+
+    # Load and prepare the data
+    reference_img = nib.load(reference_filename)
+    reference_data = reference_img.get_data()
+    reference_affine = reference_img.get_affine()
+
+    target_template_img = nib.load(target_template_filename)
+    target_template_data = target_template_img.get_data()
+    target_template_affine = target_template_img.affine
+    zooms = 1 / float(target_template_img.header.get_zooms()[0])
+
+    # Register the DWI data to the template
+    transformed_reference, transformation = register_image(target_template_data,
+                                                           target_template_affine,
+                                                           reference_data,
+                                                           reference_affine)
+    # transformation = np.eye(4)
+    streamlines = transform_streamlines(streamlines,
+                                        np.linalg.inv(transformation))
+    # streamlines = transform_streamlines(streamlines, zooms * np.eye(4))
+
+    return streamlines, transformed_reference
+
+
+def main():
+    parser = _build_args_parser()
+    args = parser.parse_args()
+    required = [args.in_bundle, args.in_anat, args.target_template]
+    assert_inputs_exist(parser, required)
+
+    output_filenames = []
+    for axis_name in ['sagittal', 'coronal', 'axial']:
+        if args.output_suffix:
+            output_filenames.append(os.path.join(args.output_dir,
+                                                 '{0}_{1}.png'.format(
+                                                     axis_name,
+                                                     args.output_suffix)))
+        else:
+            output_filenames.append(os.path.join(args.output_dir,
+                                                 '{0}.png'.format(axis_name)))
+
+    assert_outputs_exist(parser, args, output_filenames)
+
+    if args.output_dir and not os.path.isdir(args.output_dir):
+        os.mkdir(args.output_dir)
+
+        if args.anat_opacity < 0.0 or args.anat_opacity > 1.0:
+            parser.error('Opacity must be between 0 and 1')
+
+    if args.uniform_coloring:
+        for val in args.uniform_coloring:
+            if val < 0 or val > 255:
+                parser.error('{0} is not a valid RGB value'.format(val))
+
+    # Get the relevant slices from the template
+    target_template_img = nib.load(args.target_template)
+    zooms = 1
+
+    x_slice = int(target_template_img.shape[0] / 2)
+    y_slice = int(target_template_img.shape[1] / 2)
+    z_slice = int(target_template_img.shape[2] / 2)
+    slices_choice = (x_slice, y_slice, z_slice)
+
+    subject_data = prepare_data_for_actors(args.in_bundle, args.in_anat,
+                                           args.target_template)
+
+    # Create actors from each dataset for Dipy
+    streamlines, reference_data = subject_data
+    volume_actor = actor.slicer(reference_data,
+                                affine=nib.load(args.target_template).affine,
+                                opacity=args.anat_opacity,
+                                interpolation='nearest')
+
+    if args.uniform_coloring:
+        colors = (args.uniform_coloring[0] / 255.0,
+                  args.uniform_coloring[1] / 255.0,
+                  args.uniform_coloring[2] / 255.0)
+    elif args.reference_coloring:
+        colors = reference
+    else:
+        colors = None
+
+    streamlines_actor = actor.line(streamlines, colors=colors, linewidth=0.2)
+
+    # Take a snapshot of each dataset, camera settings are fixed for the
+    # known template, won't work with another.
+    if args.right:
+        side_pos = (300, -10, 10)
+    else:
+        side_pos = (-300, 10, 10)
+    display_slices(volume_actor, slices_choice,
+                   output_filenames[0], 'sagittal',
+                   view_position=tuple([x for x in side_pos]),
+                   focal_point=tuple([x for x in (0, -10, 10)]),
+                   streamlines_actor=streamlines_actor)
+    display_slices(volume_actor, slices_choice,
+                   output_filenames[1], 'coronal',
+                   view_position=tuple([x for x in (0, 250, 15)]),
+                   focal_point=tuple([x for x in (0, 0, 15)]),
+                   streamlines_actor=streamlines_actor)
+    display_slices(volume_actor, slices_choice,
+                   output_filenames[2], 'axial',
+                   view_position=tuple([x for x in (0, -15, 350)]),
+                   focal_point=tuple([x for x in (0, -15, 0)]),
+                   streamlines_actor=streamlines_actor)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/scil_screenshot_bundle.py
+++ b/scripts/scil_screenshot_bundle.py
@@ -57,7 +57,7 @@ def _build_args_parser():
     p.add_argument('--output_suffix',
                    help='Add a suffix to the output, else the axis name is used')
     p.add_argument('--output_dir', default='',
-                   help='Put all images in a specific directory, will overwrite')
+                   help='Put all images in a specific directory')
     add_overwrite_arg(p)
 
     return p
@@ -114,8 +114,8 @@ def main():
     if args.output_dir and not os.path.isdir(args.output_dir):
         os.mkdir(args.output_dir)
 
-        if args.anat_opacity < 0.0 or args.anat_opacity > 1.0:
-            parser.error('Opacity must be between 0 and 1')
+    if args.anat_opacity < 0.0 or args.anat_opacity > 1.0:
+        parser.error('Opacity must be between 0 and 1')
 
     if args.uniform_coloring:
         for val in args.uniform_coloring:

--- a/scripts/scil_screenshot_dti.py
+++ b/scripts/scil_screenshot_dti.py
@@ -172,26 +172,32 @@ def main():
                                                shells=args.shells)
 
     # Create actors from each dataset for Dipy
-    volume_actor = actor.slicer(FA, opacity=0.3, interpolation='nearest')
-    peaks_actor = actor.peak_slicer(evecs, peaks_values=evals,
+    volume_actor = actor.slicer(FA,
+                                affine=nib.load(args.target_template).affine,
+                                opacity=0.3,
+                                interpolation='nearest')
+    peaks_actor = actor.peak_slicer(evecs,
+                                    affine=nib.load(
+                                        args.target_template).affine,
+                                    peaks_values=evals,
                                     colors=None, linewidth=1)
 
     # Take a snapshot of each dataset, camera setting are fixed for the
     # known template, won't work with another.
     display_slices(volume_actor, slices_choice,
                    output_filenames[0], 'sagittal',
-                   view_position=tuple([zooms*x for x in (-50, 120, 100)]),
-                   focal_point=tuple([zooms*x for x in (80, 120, 100)]),
+                   view_position=tuple([x for x in (-125, 10, 10)]),
+                   focal_point=tuple([x for x in (0, -10, 10)]),
                    peaks_actor=peaks_actor)
     display_slices(volume_actor, slices_choice,
                    output_filenames[1], 'coronal',
-                   view_position=tuple([zooms*x for x in (95, 200, 100)]),
-                   focal_point=tuple([zooms*x for x in (95, 100, 100)]),
+                   view_position=tuple([x for x in (0, 150, 30)]),
+                   focal_point=tuple([x for x in (0, 0, 30)]),
                    peaks_actor=peaks_actor)
     display_slices(volume_actor, slices_choice,
                    output_filenames[2], 'axial',
-                   view_position=tuple([zooms*x for x in (100, 100, -75)]),
-                   focal_point=tuple([zooms*x for x in (100, 100, 90)]),
+                   view_position=tuple([x for x in (0, 25, 150)]),
+                   focal_point=tuple([x for x in (0, 25, 0)]),
                    peaks_actor=peaks_actor)
 
 


### PR DESCRIPTION
Transfert of the scripts, adapted to dipy 1.0.

Switched the template to any mni152 for simplicity for dti and bundle screenshot
The visualisation is now all in rasmm, meaning the mni152 template can be cropped or resampled and it will work.

Added the local_coloring option and the reference coloring now support any colormap instead of the default JET.

data for testing:
https://drive.google.com/open?id=1imRdCPI0KTymLw7TEKSEjkfVqt9s_5lk