### PR TITLE
Qbx clustering and cleaning

### DIFF
--- a/scilpy/io/utils.py
+++ b/scilpy/io/utils.py
@@ -166,8 +166,8 @@ def assert_output_dirs_exist_and_empty(parser, args, *dirs):
                     'overwritten. Use -f option if you want to continue.'
                     .format(path))
             else:
-                for the_file in os.listdir(args.output):
-                    file_path = os.path.join(args.output, the_file)
+                for the_file in os.listdir(path):
+                    file_path = os.path.join(path, the_file)
                     try:
                         if os.path.isfile(file_path):
                             os.unlink(file_path)

--- a/scilpy/io/utils.py
+++ b/scilpy/io/utils.py
@@ -147,7 +147,7 @@ def create_header_from_anat(reference, base_filetype=TrkFile):
     return new_header
 
 
-def assert_output_dirs_exist_and_empty(parser, args, *dirs):
+def assert_output_dirs_exist_and_empty(parser, args, *dirs, create_dir=False):
     """
     Assert that all output directories exist.
     If not, print parser's usage and exit.
@@ -158,7 +158,10 @@ def assert_output_dirs_exist_and_empty(parser, args, *dirs):
     """
     for path in dirs:
         if not os.path.isdir(path):
-            parser.error('Output directory {} doesn\'t exist.'.format(path))
+            if not create_dir:
+                parser.error('Output directory {} doesn\'t exist.'.format(path))
+            else:
+                os.mkdir(path)
         if os.listdir(path):
             if not args.overwrite:
                 parser.error(

--- a/scilpy/io/utils.py
+++ b/scilpy/io/utils.py
@@ -167,7 +167,7 @@ def assert_output_dirs_exist_and_empty(parser, args, *dirs, create_dir=False):
             if not create_dir:
                 parser.error('Output directory {} doesn\'t exist.'.format(path))
             else:
-                os.mkdir(path)
+                os.makedirs(path, exist_ok=True)
         if os.listdir(path):
             if not args.overwrite:
                 parser.error(

--- a/scripts/scil_clean_qbx_clusters.py
+++ b/scripts/scil_clean_qbx_clusters.py
@@ -52,14 +52,14 @@ def _build_args_parser():
 
     p.add_argument('--min_cluster_size', type=int, default=1,
                    help='Minimum cluster size for consideration [%(default)s].'
-                   'Must be at least 1.')
+                        'Must be at least 1.')
     p.add_argument('--background_opacity', type=float, default=0.1,
                    help='Opacity of the background streamlines.'
-                   'Keep low between 0 and 0.5 [%(default)s].')
+                        'Keep low between 0 and 0.5 [%(default)s].')
     p.add_argument('--background_linewidth', type=float, default=1,
-                   help='linewidth of the background streamlines [%(default)s].')
+                   help='Linewidth of the background streamlines [%(default)s].')
     p.add_argument('--clusters_linewidth', type=float, default=1,
-                   help='linewidth of the background streamlines [%(default)s].')
+                   help='Linewidth of the current cluster [%(default)s].')
 
     add_reference_arg(p)
     add_overwrite_arg(p)
@@ -75,8 +75,7 @@ def get_length_tuple(elem):
 def main():
     # Callback required for FURY
     def keypress_callback(obj, _):
-        key = obj.GetKeySym()
-        key = key.lower()
+        key = obj.GetKeySym().lower()
         nonlocal clusters_linewidth, background_linewidth
         nonlocal curr_streamlines_actor, concat_streamlines_actor, show_curr_actor
         iterator = len(accepted_streamlines) + len(rejected_streamlines)
@@ -128,7 +127,6 @@ def main():
                 logging.info('Rewind on step.')
 
                 iterator -= 1
-                renderer.rm(curr_streamlines_actor)
             else:
                 logging.warning('Cannot rewind, first element.')
 

--- a/scripts/scil_clean_qbx_clusters.py
+++ b/scripts/scil_clean_qbx_clusters.py
@@ -12,7 +12,7 @@ from dipy.io.utils import is_header_compatible
 
 from scilpy.io.streamlines import load_tractogram_with_reference
 from scilpy.io.utils import (add_overwrite_arg,
-                             add_reference,
+                             add_reference_arg,
                              add_verbose_arg,
                              assert_inputs_exist,
                              assert_outputs_exist,
@@ -58,7 +58,7 @@ def _build_args_parser():
                    'Keep low between 0 and 0.5 [%(default)s].')
 
     add_overwrite_arg(p)
-    add_reference(p)
+    add_reference_arg(p)
     add_verbose_arg(p)
 
     return p

--- a/scripts/scil_clean_qbx_clusters.py
+++ b/scripts/scil_clean_qbx_clusters.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import argparse
+import os
+import logging
+import shutil
+
+from fury import window, actor, interactor
+import nibabel as nib
+import numpy as np
+from dipy.io.stateful_tractogram import Space, StatefulTractogram
+from dipy.io.streamline import save_tractogram
+from dipy.io.utils import is_header_compatible
+
+from scilpy.io.streamlines import load_tractogram_with_reference
+from scilpy.io.utils import (add_overwrite_arg,
+                             add_reference,
+                             add_verbose_arg,
+                             assert_inputs_exist,
+                             assert_outputs_exist,
+                             assert_output_dirs_exist_and_empty)
+
+DESCRIPTION = """
+"""
+
+
+def _build_args_parser():
+    p = argparse.ArgumentParser(description=DESCRIPTION,
+                                formatter_class=argparse.RawTextHelpFormatter)
+
+    p.add_argument('in_bundles', nargs='+',
+                   help='Tractogram filename. Format must be readable'
+                   ' by the Nibabel.')
+    p.add_argument('out_accepted',
+                   help='')
+    p.add_argument('out_rejected',
+                   help='')
+
+    p.add_argument('--out_accepted_dir',
+                   help='')
+    p.add_argument('--out_rejected_dir',
+                   help='')
+
+    p.add_argument('--min_cluster_size', type=int, default=1,
+                   help='Minimum cluster size for consideration [%(default)s].'
+                   'Must be at least 1.')
+    p.add_argument('--show_all_opacity', type=float, default=0.01,
+                   help='Opacity, keep low [%(default)s].')
+
+    add_overwrite_arg(p)
+    add_reference(p)
+    add_verbose_arg(p)
+
+    return p
+
+
+def get_length_tuple(elem):
+    return len(elem[0])
+
+
+def main():
+    # Callback required for FURY
+    def keypress_callback(obj, ev):
+        key = obj.GetKeySym()
+        nonlocal curr_streamlines_actor
+        iterator = len(accepted_streamlines) + len(rejected_streamlines)
+        renwin = interactor_style.GetInteractor().GetRenderWindow()
+        renderer = interactor_style.GetCurrentRenderer()
+
+        if key == 'q':
+            show_manager.exit()
+            if iterator < len(sft_accepted_on_size):
+                logging.warning(
+                    'Early exit, everything remaining to be rejected.')
+            return
+        elif key in ['a', 'r']:
+            if iterator == len(sft_accepted_on_size):
+                logging.info('No more cluster, press q to exit')
+                return
+
+            if key == 'a':
+                accepted_streamlines.append(iterator)
+                choices.append('a')
+                logging.info('Accepted file {}.'.format(
+                    filename_accepted_on_size[iterator]))
+            elif key == 'r':
+                rejected_streamlines.append(iterator)
+                choices.append('r')
+                logging.info('Rejected file {}.'.format(
+                    filename_accepted_on_size[iterator]))
+            iterator += 1
+
+        if key == 'z':
+            if iterator > 0:
+                last_choice = choices.pop()
+                if last_choice == 'r':
+                    rejected_streamlines.pop()
+                else:
+                    accepted_streamlines.pop()
+                logging.info('Rewind on step.')
+
+                iterator -= 1
+                renderer.rm(curr_streamlines_actor)
+            else:
+                logging.warning('Cannot rewind, first element.')
+
+        if key in ['a', 'r', 'z'] and iterator < len(sft_accepted_on_size):
+            renderer.rm(curr_streamlines_actor)
+            curr_streamlines_actor = actor.line(sft_accepted_on_size[iterator].streamlines,
+                                                opacity=0.8,
+                                                linewidth=0.2)
+            renderer.add(curr_streamlines_actor)
+
+        if iterator == len(sft_accepted_on_size):
+            renderer.rm(curr_streamlines_actor)
+
+        renwin.Render()
+
+    parser = _build_args_parser()
+    args = parser.parse_args()
+
+    assert_inputs_exist(parser, args.in_bundles)
+    assert_outputs_exist(parser, args, [args.out_accepted, args.out_rejected])
+
+    if args.out_accepted_dir:
+        assert_output_dirs_exist_and_empty(parser, args, args.out_accepted_dir)
+    if args.out_rejected_dir:
+        assert_output_dirs_exist_and_empty(parser, args, args.out_rejected_dir)
+
+    if args.verbose:
+        logging.basicConfig(level=logging.INFO)
+
+    if args.min_cluster_size < 1:
+        parser.error('Minimum cluster size must be at least 1.')
+
+    # To accelerate procedure, clusters can be discarded based on size
+    # Concatenation is to give spatial context
+    sft_accepted_on_size, filename_accepted_on_size = [], []
+    sft_rejected_on_size, filename_rejected_on_size = [], []
+    concat_streamlines = []
+    for filename in args.in_bundles:
+        if not is_header_compatible(args.in_bundles[0], filename):
+            return
+        basename = os.path.basename(filename)
+        sft = load_tractogram_with_reference(parser, args, filename,
+                                             bbox_check=False)
+        if len(sft) >= args.min_cluster_size:
+            sft_accepted_on_size.append(sft)
+            filename_accepted_on_size.append(basename)
+            concat_streamlines.extend(sft.streamlines)
+        else:
+            logging.info(
+                'File {} has {} streamlines, automatically rejected.'.format(
+                    filename, len(sft)))
+            sft_rejected_on_size.append(sft)
+            filename_rejected_on_size.append(basename)
+
+    logging.info('{} clusters to be classified.'.format(
+        len(sft_accepted_on_size)))
+    # The clusters are sorted by size for simplicity/efficiency
+    tuple_accepted = zip(*sorted(zip(sft_accepted_on_size,
+                                     filename_accepted_on_size),
+                                 key=get_length_tuple, reverse=True))
+    sft_accepted_on_size, filename_accepted_on_size = tuple_accepted
+
+    # Initialize the actors, scene, window, observer
+    streamlines_actor = actor.line(concat_streamlines,
+                                   colors=(1, 1, 1),
+                                   opacity=args.show_all_opacity)
+    curr_streamlines_actor = actor.line(sft_accepted_on_size[0].streamlines,
+                                        opacity=0.8)
+
+    scene = window.Scene()
+    interactor_style = interactor.CustomInteractorStyle()
+    show_manager = window.ShowManager(scene, size=(800, 800),
+                                      reset_camera=False,
+                                      interactor_style=interactor_style)
+    scene.add(streamlines_actor)
+    scene.add(curr_streamlines_actor)
+    interactor_style.AddObserver('KeyPressEvent', keypress_callback)
+
+    # Lauch rendering and selection procedure
+    choices, accepted_streamlines, rejected_streamlines = [], [], []
+    show_manager.start()
+
+    # Early exit means everything else is rejected
+    output_accepted_streamlines, output_rejected_streamlines = [], []
+    missing = len(args.in_bundles) - len(choices) - len(sft_rejected_on_size)
+    len_accepted = len(sft_accepted_on_size)
+    rejected_streamlines.extend(range(len_accepted - missing,
+                                      len_accepted))
+
+    # Save accepted clusters (by GUI)
+    for idx in accepted_streamlines:
+        streamlines = sft_accepted_on_size[idx].streamlines
+        output_accepted_streamlines.extend(streamlines)
+
+        if args.out_accepted_dir:
+            tmp_sft = StatefulTractogram(streamlines,
+                                         sft_accepted_on_size[0],
+                                         Space.RASMM)
+            tmp_filename = os.path.join(args.out_accepted_dir,
+                                        filename_accepted_on_size[idx])
+            save_tractogram(tmp_sft, tmp_filename, bbox_valid_check=False)
+
+    accepted_sft = StatefulTractogram(output_accepted_streamlines,
+                                      sft_accepted_on_size[0],
+                                      Space.RASMM)
+    save_tractogram(accepted_sft, args.out_accepted, bbox_valid_check=False)
+
+    # Save rejected clusters (by GUI)
+    for idx in rejected_streamlines:
+        streamlines = sft_accepted_on_size[idx].streamlines
+        output_rejected_streamlines.extend(streamlines)
+
+        if args.out_rejected_dir:
+            tmp_sft = StatefulTractogram(streamlines,
+                                         sft_accepted_on_size[0],
+                                         Space.RASMM)
+            tmp_filename = os.path.join(args.out_rejected_dir,
+                                        filename_accepted_on_size[idx])
+            save_tractogram(tmp_sft, tmp_filename, bbox_valid_check=False)
+
+    # Save rejected clusters (by size)
+    for idx in range(len(sft_rejected_on_size)):
+        streamlines = sft_rejected_on_size[idx].streamlines
+        output_rejected_streamlines.extend(streamlines)
+
+        if args.out_rejected_dir:
+            tmp_sft = StatefulTractogram(streamlines,
+                                         sft_accepted_on_size[0],
+                                         Space.RASMM)
+            tmp_filename = os.path.join(args.out_rejected_dir,
+                                        filename_rejected_on_size[idx])
+            save_tractogram(tmp_sft, tmp_filename, bbox_valid_check=False)
+
+    rejected_sft = StatefulTractogram(output_rejected_streamlines,
+                                      sft_accepted_on_size[0],
+                                      Space.RASMM)
+    save_tractogram(rejected_sft, args.out_rejected, bbox_valid_check=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/scil_clean_qbx_clusters.py
+++ b/scripts/scil_clean_qbx_clusters.py
@@ -23,6 +23,7 @@ DESCRIPTION = """
     visual inspection. Useful for cleaning bundles for RBx, BST or for figures.
     The VTK window does not handle well opacity of streamlines, this is a normal
     rendering behavior.
+    Often use in pair with scil_compute_qbx.py.
 
     Key mapping:
     - a/A: accept displayed clusters

--- a/scripts/scil_clean_qbx_clusters.py
+++ b/scripts/scil_clean_qbx_clusters.py
@@ -53,7 +53,7 @@ def _build_args_parser():
     p.add_argument('--min_cluster_size', type=int, default=1,
                    help='Minimum cluster size for consideration [%(default)s].'
                    'Must be at least 1.')
-    p.add_argument('--background_opacity', type=float, default=0.02,
+    p.add_argument('--background_opacity', type=float, default=0.1,
                    help='Opacity of the background streamlines.'
                    'Keep low between 0 and 0.5 [%(default)s].')
     p.add_argument('--background_linewidth', type=float, default=1,
@@ -83,7 +83,7 @@ def main():
         renwin = interactor_style.GetInteractor().GetRenderWindow()
         renderer = interactor_style.GetCurrentRenderer()
 
-        if key == 'c':
+        if key == 'c' and iterator < len(sft_accepted_on_size):
             if show_curr_actor:
                 renderer.rm(concat_streamlines_actor)
                 renwin.Render()
@@ -105,7 +105,7 @@ def main():
                     'Early exit, everything remaining to be rejected.')
             return
 
-        if key in ['a', 'r']:
+        if key in ['a', 'r'] and iterator < len(sft_accepted_on_size):
             if key == 'a':
                 accepted_streamlines.append(iterator)
                 choices.append('a')

--- a/scripts/scil_clean_qbx_clusters.py
+++ b/scripts/scil_clean_qbx_clusters.py
@@ -61,8 +61,8 @@ def _build_args_parser():
     p.add_argument('--clusters_linewidth', type=float, default=1,
                    help='linewidth of the background streamlines [%(default)s].')
 
-    add_overwrite_arg(p)
     add_reference_arg(p)
+    add_overwrite_arg(p)
     add_verbose_arg(p)
 
     return p
@@ -106,10 +106,6 @@ def main():
             return
 
         if key in ['a', 'r']:
-            if iterator == len(sft_accepted_on_size):
-                print('No more cluster, press q to exit')
-                return
-
             if key == 'a':
                 accepted_streamlines.append(iterator)
                 choices.append('a')
@@ -145,6 +141,7 @@ def main():
             renderer.add(curr_streamlines_actor)
 
         if iterator == len(sft_accepted_on_size):
+            print('No more cluster, press q to exit')
             renderer.rm(curr_streamlines_actor)
 
         renwin.Render()

--- a/scripts/scil_compute_qbx.py
+++ b/scripts/scil_compute_qbx.py
@@ -28,10 +28,10 @@ def _build_args_parser():
 
     p.add_argument('in_tractogram',
                    help='Tractogram filename.\n'
-                   'Path of the input tractogram or bundle.')
+                        'Path of the input tractogram or bundle.')
     p.add_argument('dist_thresh', type=float,
                    help='Last QuickBundlesX threshold in mm. Typically \n'
-                   'the value are between 10-20mm.')
+                        'the value are between 10-20mm.')
     p.add_argument('output_clusters_dir',
                    help='Path to the clusters directory.')
 
@@ -40,7 +40,7 @@ def _build_args_parser():
                         'number of points [%(default)s].')
     p.add_argument('--output_centroids',
                    help='Output tractogram filename.\n'
-                   'Format must be readable by the Nibabel API.')
+                        'Format must be readable by the Nibabel API.')
 
     add_reference_arg(p)
     add_overwrite_arg(p)

--- a/scripts/scil_compute_qbx.py
+++ b/scripts/scil_compute_qbx.py
@@ -28,7 +28,7 @@ def _build_args_parser():
 
     p.add_argument('in_tractogram',
                    help='Tractogram filename.\n'
-                   'Format must be readable by Nibabel.')
+                   'Path of the input tractogram or bundle.')
     p.add_argument('dist_thresh', type=float,
                    help='Last QuickBundlesX threshold in mm. Typically \n'
                    'the value are between 10-20mm')

--- a/scripts/scil_compute_qbx.py
+++ b/scripts/scil_compute_qbx.py
@@ -11,7 +11,7 @@ from dipy.segment.clustering import qbx_and_merge
 
 from scilpy.io.streamlines import load_tractogram_with_reference
 from scilpy.io.utils import (add_overwrite_arg,
-                             add_reference,
+                             add_reference_arg,
                              assert_inputs_exist,
                              assert_outputs_exist,
                              assert_output_dirs_exist_and_empty)
@@ -42,7 +42,7 @@ def _build_args_parser():
                    help='Output tractogram filename.\n'
                    'Format must be readable by the Nibabel API.')
 
-    add_reference(p)
+    add_reference_arg(p)
     add_overwrite_arg(p)
 
     return p

--- a/scripts/scil_compute_qbx.py
+++ b/scripts/scil_compute_qbx.py
@@ -31,13 +31,13 @@ def _build_args_parser():
                    'Path of the input tractogram or bundle.')
     p.add_argument('dist_thresh', type=float,
                    help='Last QuickBundlesX threshold in mm. Typically \n'
-                   'the value are between 10-20mm')
+                   'the value are between 10-20mm.')
     p.add_argument('output_clusters_dir',
-                   help='Path to the clusters directory')
+                   help='Path to the clusters directory.')
 
     p.add_argument('--nb_points', type=int, default='20',
                    help='Streamlines will be resampled to have this '
-                        'number of points. [%(default)s]')
+                        'number of points [%(default)s].')
     p.add_argument('--output_centroids',
                    help='Output tractogram filename.\n'
                    'Format must be readable by the Nibabel API.')

--- a/scripts/scil_compute_qbx.py
+++ b/scripts/scil_compute_qbx.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import argparse
+from operator import itemgetter
+import os
+import shutil
+
+from dipy.segment.clustering import qbx_and_merge
+from dipy.io.stateful_tractogram import Space, StatefulTractogram
+from dipy.io.streamline import save_tractogram
+import nibabel as nib
+import numpy as np
+
+from scilpy.io.streamlines import load_tractogram_with_reference
+from scilpy.io.utils import (add_overwrite_arg,
+                             add_reference,
+                             assert_inputs_exist,
+                             assert_outputs_exist,
+                             assert_output_dirs_exist_and_empty)
+
+DESCRIPTION = """
+    Compute clusters using QuickBundlesX.
+    We cannot know the number of clusters in advance.
+"""
+
+
+def buildArgsParser():
+    p = argparse.ArgumentParser(description=DESCRIPTION,
+                                formatter_class=argparse.RawTextHelpFormatter)
+
+    p.add_argument('in_tractogram',
+                   help='Tractogram filename.\n'
+                   'Format must be readable by Nibabel.')
+    p.add_argument('dist_thresh', type=float,
+                   help='Last QuickBundlesX threshold in mm. Typically \n'
+                   'the value are between 10-20mm')
+    p.add_argument('output_clusters_dir',
+                   help='Path to the clusters directory')
+
+    p.add_argument('--nb_points', type=int, default='20',
+                   help='Streamlines will be resampled to have this '
+                        'number of points. [%(default)s]')
+    p.add_argument('--output_centroids',
+                   help='Output tractogram filename.\n'
+                   'Format must be readable by the Nibabel API.')
+
+    add_reference(p)
+    add_overwrite_arg(p)
+
+    return p
+
+
+def main():
+    parser = buildArgsParser()
+    args = parser.parse_args()
+
+    assert_inputs_exist(parser, args.in_tractogram)
+    assert_outputs_exist(parser, args, [], optional=args.output_centroids)
+    if args.output_clusters_dir:
+        assert_output_dirs_exist_and_empty(
+            parser, args, args.output_clusters_dir)
+
+    sft = load_tractogram_with_reference(parser, args, args.in_tractogram)
+    streamlines = sft.streamlines
+    thresholds = [40, 30, 20, args.dist_thresh]
+    clusters = qbx_and_merge(streamlines, thresholds,
+                             nb_pts=args.nb_points, verbose=False)
+
+    for i, cluster in enumerate(clusters):
+        if len(cluster.indices) > 1:
+            cluster_streamlines = itemgetter(*cluster.indices)(streamlines)
+        else:
+            cluster_streamlines = streamlines[cluster.indices]
+
+        new_sft = StatefulTractogram(cluster_streamlines, sft, Space.RASMM)
+        save_tractogram(new_sft, os.path.join(args.output_clusters_dir,
+                                              'cluster_{}.trk'.format(i)))
+
+    if args.output_centroids:
+        new_tractogram = nib.streamlines.Tractogram(clusters.centroids,
+                                                    affine_to_rasmm=np.eye(4))
+        nib.streamlines.save(new_tractogram, args.output_centroids,
+                             header=tractogram.header)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Transfert of QBx script (private bitbucket) and script for clusters cleaning (personal repo).

The QBx script split a tractogram or bundle into clusters (into a directory)
The cleaning script is similar to a MarcAlex script (but simplified) that iterate over a list of clusters and each can be rejected or accepted (useful for BST and RBx model preparation)