### PR TITLE
BF: Fixed scil_mask_math.py ignoring zero threshold

### DIFF
--- a/scripts/scil_mask_math.py
+++ b/scripts/scil_mask_math.py
@@ -126,7 +126,7 @@ def main():
         'Performing operation \'{}\'.'.format(args.operation))
     mask = reduce(OPERATIONS[args.operation], masks)
 
-    if args.threshold:
+    if args.threshold is not None:
         mask = (mask > args.threshold).astype(np.uint8)
 
     affine = next(nibabel.load(f).affine for f in args.inputs if os.path.isfile(f))


### PR DESCRIPTION
Small bugfix to `scil_mask_math.py`. If a threshold of zero is given, it is ignored (e.g. when converting a probabilistic map to a binary mask).