### PR TITLE
Encapsulating extract_dwi_shell

### DIFF
--- a/scilpy/utils/bvec_bval_tools.py
+++ b/scilpy/utils/bvec_bval_tools.py
@@ -143,13 +143,19 @@ def extract_dwi_shell(dwi_img, bvals, bvecs, bvals_to_extract, tol=10,
     """
     Parameters
     ----------
-    dwi_img: nib.Nifti1image of the DWI image.
-    bvals: loaded bvals
-    bvecs: loaded bvecs
-    tol:
-    block_size:
-        Note. Was previously always set to img.shape[-1] if None.
+    dwi_img: nib.Nifti1image
+        Loaded DWI image.
+    bvals: array (N,)
+        loaded bvals
+    bvecs: array (N,D)
+        loaded bvecs
+    tol: int
+        Tolerance to accept a bval
+    block_size: int
+        Loads the data using this block size. Useful when the data is too large
+        to be loaded in memory.
     """
+    
     # Finding the volume indices that correspond to the shells to extract.
     indices = [get_shell_indices(bvals, shell, tol=tol)
                for shell in bvals_to_extract]

--- a/scilpy/utils/bvec_bval_tools.py
+++ b/scilpy/utils/bvec_bval_tools.py
@@ -155,7 +155,7 @@ def extract_dwi_shell(dwi_img, bvals, bvecs, bvals_to_extract, tol=10,
         Loads the data using this block size. Useful when the data is too large
         to be loaded in memory.
     """
-    
+
     # Finding the volume indices that correspond to the shells to extract.
     indices = [get_shell_indices(bvals, shell, tol=tol)
                for shell in bvals_to_extract]
@@ -178,9 +178,7 @@ def extract_dwi_shell(dwi_img, bvals, bvecs, bvals_to_extract, tol=10,
             in_data = np.array([i in indices for i in vi])
             shell_data[..., in_volume] = data[..., in_data]
 
-    bvals = bvals[indices].astype(int)
-    bvals.shape = (1, len(bvals))
-
+    bvals = bvals[indices]
     bvecs = bvecs[indices, :]
 
     return shell_data, bvals, bvecs, indices

--- a/scripts/scil_extract_dwi_shell.py
+++ b/scripts/scil_extract_dwi_shell.py
@@ -12,7 +12,7 @@ from dipy.io import read_bvals_bvecs
 
 from scilpy.io.utils import (assert_inputs_exist, assert_outputs_exist,
                              add_overwrite_arg)
-from scilpy.utils.bvec_bval_tools import get_shell_indices
+from scilpy.utils.bvec_bval_tools import extract_dwi_shell
 
 DESCRIPTION = """
 Extracts the DWI volumes that are on specific b-value shells. Many shells
@@ -79,25 +79,6 @@ def build_args_parser():
     return parser
 
 
-def volumes(img, size):
-    """Generator that iterates on gradient volumes of data"""
-
-    nb_volumes = img.shape[-1]
-
-    if size == nb_volumes:
-        yield list(range(nb_volumes)), img.get_data()
-    else:
-        for i in range(0, nb_volumes - size, size):
-            logging.info('Loading volumes {} to {}.'.format(i, i + size - 1))
-            yield list(range(i, i + size)), img.dataobj[..., i:i + size]
-        if i + size < nb_volumes:
-            logging.info(
-                'Loading volumes {} to {}.'
-                .format(i + size, nb_volumes - 1))
-            yield list(range(i + size, nb_volumes)), \
-                img.dataobj[..., i + size:]
-
-
 def main():
 
     parser = build_args_parser()
@@ -108,46 +89,24 @@ def main():
 
     assert_inputs_exist(parser, [args.dwi, args.bvals, args.bvecs])
     assert_outputs_exist(parser, args, [args.output_dwi, args.output_bvals,
-                                         args.output_bvecs])
+                                        args.output_bvecs])
 
     bvals, bvecs = read_bvals_bvecs(args.bvals, args.bvecs)
-
-    # Find the volume indices that correspond to the shells to extract.
-    tol = args.tolerance
-    indices = [get_shell_indices(bvals, shell, tol=tol)
-               for shell in args.bvals_to_extract]
-    indices = np.unique(np.sort(np.hstack(indices)))
-
-    if len(indices) == 0:
-        parser.error('There are no volumes that have the supplied b-values.')
+    img = nib.load(args.dwi)
 
     logging.info(
-        'Extracting shells [{}], with number of images per shell [{}], '
-        'from {} images from {}.'
+        'Extracted shells [{}] from {} images from {}.'
         .format(' '.join([str(b) for b in args.bvals_to_extract]),
-                ' '.join([str(len(get_shell_indices(bvals, shell)))
-                          for shell in args.bvals_to_extract]),
                 len(bvals),
                 args.dwi))
 
-    img = nib.load(args.dwi)
+    shell_data, bvals, bvecs, indices = extract_dwi_shell(img, bvals, bvecs,
+                                                          args.bvals_to_extract,
+                                                          args.tolerance,
+                                                          args.block_size)
 
-    if args.block_size is None:
-        args.block_size = img.shape[-1]
-
-    # Load the shells by iterating through blocks of volumes. This approach
-    # is slower for small files, but allows very big files to be split
-    # with less memory usage.
-    shell_data = np.zeros((img.shape[:-1] + (len(indices),)))
-    for vi, data in volumes(img, args.block_size):
-        in_volume = np.array([i in vi for i in indices])
-        in_data = np.array([i in indices for i in vi])
-        shell_data[..., in_volume] = data[..., in_data]
-
-    bvals = bvals[indices].astype(int)
-    bvals.shape = (1, len(bvals))
     np.savetxt(args.output_bvals, bvals, '%d')
-    np.savetxt(args.output_bvecs, bvecs[indices, :].T, '%0.15f')
+    np.savetxt(args.output_bvecs, bvecs.T, '%0.15f')
     nib.save(nib.Nifti1Image(shell_data, img.affine, img.header),
              args.output_dwi)
 

--- a/scripts/scil_extract_dwi_shell.py
+++ b/scripts/scil_extract_dwi_shell.py
@@ -105,6 +105,9 @@ def main():
                                                           args.tolerance,
                                                           args.block_size)
 
+    bvals = bvals.astype(int)
+    bvals.shape = (1, len(bvals))
+
     np.savetxt(args.output_bvals, bvals, '%d')
     np.savetxt(args.output_bvecs, bvecs.T, '%0.15f')
     nib.save(nib.Nifti1Image(shell_data, img.affine, img.header),


### PR DESCRIPTION
Note:

- added if,else to run it without the loop on volumes if no block_size is used.
- changed get_data to get_fdata because former is deprecated.
- allowed optional 'dtype' arg. I don't know if you usually accept it but it would be usefull for us. Default is float64, but we like to save memory with float32.
- I had to change the logging message. Is that ok?
