### PR TITLE
 added a test to check if output folder exist

### DIFF
--- a/scilpy/io/utils.py
+++ b/scilpy/io/utils.py
@@ -146,7 +146,8 @@ def assert_inputs_exist(parser, required, optional=None):
             check(optional_file)
 
 
-def assert_outputs_exist(parser, args, required, optional=None):
+def assert_outputs_exist(parser, args, required, optional=None,
+                         check_dir_exist=False):
     """
     Assert that all outputs don't exist or that if they exist, -f was used.
     If not, print parser's usage and exit.
@@ -155,11 +156,18 @@ def assert_outputs_exist(parser, args, required, optional=None):
     :param required: string or list of paths
     :param optional: string or list of paths.
                      Each element will be ignored if None
+    :param check_dir_exist: test if output directory exist
     """
     def check(path):
         if os.path.isfile(path) and not args.overwrite:
             parser.error('Output file {} exists. Use -f to force '
                          'overwriting'.format(path))
+
+        if check_dir_exist:
+            path_dir = os.path.dirname(path)
+            if path_dir and not os.path.isdir(path_dir):
+                parser.error('Directory {}  for a given output file '
+                             'does not exists.'.format(path_dir))
 
     if isinstance(required, str):
         required = [required]

--- a/scilpy/io/utils.py
+++ b/scilpy/io/utils.py
@@ -156,7 +156,9 @@ def assert_outputs_exist(parser, args, required, optional=None,
     :param required: string or list of paths
     :param optional: string or list of paths.
                      Each element will be ignored if None
-    :param check_dir_exists: test if output directory exists
+    :param check_dir_exists: bool
+                             Test if output directory exists
+
     """
     def check(path):
         if os.path.isfile(path) and not args.overwrite:
@@ -166,7 +168,7 @@ def assert_outputs_exist(parser, args, required, optional=None,
         if check_dir_exists:
             path_dir = os.path.dirname(path)
             if path_dir and not os.path.isdir(path_dir):
-                parser.error('Directory {} for a given output file '
+                parser.error('Directory {} \n for a given output file '
                              'does not exists.'.format(path_dir))
 
     if isinstance(required, str):

--- a/scilpy/io/utils.py
+++ b/scilpy/io/utils.py
@@ -147,7 +147,7 @@ def assert_inputs_exist(parser, required, optional=None):
 
 
 def assert_outputs_exist(parser, args, required, optional=None,
-                         check_dir_exist=False):
+                         check_dir_exists=False):
     """
     Assert that all outputs don't exist or that if they exist, -f was used.
     If not, print parser's usage and exit.
@@ -156,17 +156,17 @@ def assert_outputs_exist(parser, args, required, optional=None,
     :param required: string or list of paths
     :param optional: string or list of paths.
                      Each element will be ignored if None
-    :param check_dir_exist: test if output directory exist
+    :param check_dir_exists: test if output directory exists
     """
     def check(path):
         if os.path.isfile(path) and not args.overwrite:
             parser.error('Output file {} exists. Use -f to force '
                          'overwriting'.format(path))
 
-        if check_dir_exist:
+        if check_dir_exists:
             path_dir = os.path.dirname(path)
             if path_dir and not os.path.isdir(path_dir):
-                parser.error('Directory {}  for a given output file '
+                parser.error('Directory {} for a given output file '
                              'does not exists.'.format(path_dir))
 
     if isinstance(required, str):


### PR DESCRIPTION
Added a check for "assert_outputs_exist", it test of the directory for the output file exist.
Since most our script assume that the folder for the output file exist, only few of them test it.
I think the default should be "check_dir_exist=True", however it would change the current behavior if so.

This could be move to annother function if prefered, eg
"assert_outputs_directories_exist(...)"

@GuillaumeTh  @jchoude  @frheault 
