### PR TITLE
Switch DESCRIPTION to __doc__

### DIFF
--- a/scripts/scil_add_tracking_mask_to_pft_maps.py
+++ b/scripts/scil_add_tracking_mask_to_pft_maps.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+
+"""
+Modify PFT maps to allow PFT tracking in given mask.
+"""
+
 import argparse
 
 import nibabel as nib
@@ -10,7 +15,7 @@ from scilpy.io.utils import (
 
 def _build_arg_parser():
     parser = argparse.ArgumentParser(
-        description='Modify PFT maps to allow PFT tracking in given mask.',
+        description=__doc__,
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('map_include',
                         help='PFT map include.')

--- a/scripts/scil_assign_color_to_trk.py
+++ b/scripts/scil_assign_color_to_trk.py
@@ -1,6 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+"""
+Assign an hexadecimal RGB color to a Trackvis TRK tractogram.
+The hexadecimal RGB color should be formatted as 0xRRGGBB or
+"#RRGGBB".
+"""
+
 import argparse
 
 from dipy.io.stateful_tractogram import StatefulTractogram
@@ -16,9 +22,7 @@ from scilpy.io.utils import (assert_inputs_exist,
 
 def _build_arg_parser():
     p = argparse.ArgumentParser(
-        description='Assign an hexadecimal RGB color to a Trackvis TRK '
-                    'tractogram. The hexadecimal RGB color should be '
-                    'formatted as 0xRRGGBB or "#RRGGBB"',
+        description=__doc__,
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
     p.add_argument('in_tractogram',

--- a/scripts/scil_clean_qbx_clusters.py
+++ b/scripts/scil_clean_qbx_clusters.py
@@ -1,6 +1,22 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+"""
+    Render clusters sequentially to either accept or reject them based on
+    visual inspection. Useful for cleaning bundles for RBx, BST or for figures.
+    The VTK window does not handle well opacity of streamlines, this is a normal
+    rendering behavior.
+    Often use in pair with scil_compute_qbx.py.
+
+    Key mapping:
+    - a/A: accept displayed clusters
+    - r/R: reject displayed clusters
+    - z/Z: Rewing one element
+    - c/C: Stop rendering of the background concatenation of streamlines
+    - q/Q: Early window exist, everything remaining will be rejected
+"""
+
+
 import argparse
 import os
 import logging
@@ -18,24 +34,9 @@ from scilpy.io.utils import (add_overwrite_arg,
                              assert_outputs_exist,
                              assert_output_dirs_exist_and_empty)
 
-DESCRIPTION = """
-    Render clusters sequentially to either accept or reject them based on
-    visual inspection. Useful for cleaning bundles for RBx, BST or for figures.
-    The VTK window does not handle well opacity of streamlines, this is a normal
-    rendering behavior.
-    Often use in pair with scil_compute_qbx.py.
-
-    Key mapping:
-    - a/A: accept displayed clusters
-    - r/R: reject displayed clusters
-    - z/Z: Rewing one element
-    - c/C: Stop rendering of the background concatenation of streamlines
-    - q/Q: Early window exist, everything remaining will be rejected
-"""
-
 
 def _build_args_parser():
-    p = argparse.ArgumentParser(description=DESCRIPTION,
+    p = argparse.ArgumentParser(description=__doc__,
                                 formatter_class=argparse.RawTextHelpFormatter)
 
     p.add_argument('in_bundles', nargs='+',

--- a/scripts/scil_combine_labels.py
+++ b/scripts/scil_combine_labels.py
@@ -1,6 +1,17 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+"""
+    Script to combine labels from multiple volumes,
+        if there is overlap, it will overwrite them based on the input order.
+
+    >>> scil_combine_labels.py out_labels.nii.gz  -v animal_labels.nii 20\\
+            DKT_labels.nii.gz 44 53  --out_labels_indices 20 44 53
+    >>> scil_combine_labels.py slf_labels.nii.gz  -v a2009s_aseg.nii.gz all\\
+            -v clean/s1__DKT.nii.gz 1028 2028
+"""
+
+
 import argparse
 import logging
 
@@ -11,15 +22,6 @@ import numpy as np
 from scilpy.io.utils import (add_overwrite_arg, assert_inputs_exist,
                              assert_outputs_exist)
 
-DESCRIPTION = """
-    Script to combine labels from multiple volumes,
-        if there is overlap, it will overwrite them based on the input order.
-
-    >>> scil_combine_labels.py out_labels.nii.gz  -v animal_labels.nii 20\\
-            DKT_labels.nii.gz 44 53  --out_labels_indices 20 44 53
-    >>> scil_combine_labels.py slf_labels.nii.gz  -v a2009s_aseg.nii.gz all\\
-            -v clean/s1__DKT.nii.gz 1028 2028
-    """
 
 EPILOG = """
     References:
@@ -30,7 +32,7 @@ EPILOG = """
 
 
 def _build_args_parser():
-    p = argparse.ArgumentParser(description=DESCRIPTION, epilog=EPILOG,
+    p = argparse.ArgumentParser(description=__doc__, epilog=EPILOG,
                                 formatter_class=argparse.RawTextHelpFormatter)
 
     p.add_argument('output',

--- a/scripts/scil_compute_qbx.py
+++ b/scripts/scil_compute_qbx.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+"""
+    Compute clusters using QuickBundlesX and save them separately.
+    We cannot know the number of clusters in advance.
+"""
+
 import argparse
 from operator import itemgetter
 import os
@@ -16,14 +21,9 @@ from scilpy.io.utils import (add_overwrite_arg,
                              assert_outputs_exist,
                              assert_output_dirs_exist_and_empty)
 
-DESCRIPTION = """
-    Compute clusters using QuickBundlesX and save them separately.
-    We cannot know the number of clusters in advance.
-"""
-
 
 def _build_args_parser():
-    p = argparse.ArgumentParser(description=DESCRIPTION,
+    p = argparse.ArgumentParser(description=__doc__,
                                 formatter_class=argparse.RawTextHelpFormatter)
 
     p.add_argument('in_tractogram',

--- a/scripts/scil_compute_streamlines_length_stats.py
+++ b/scripts/scil_compute_streamlines_length_stats.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+
+"""
+Compute streamlines min, mean and max length, as well as
+standard deviation of length in mm.
+"""
+
 import argparse
 import json
 
@@ -14,8 +20,7 @@ from scilpy.io.utils import (add_json_args,
 
 def _build_arg_parser():
     p = argparse.ArgumentParser(
-        description='Compute streamlines min, mean and max length, as well as '
-                    'standard deviation of length in mm.',
+        description=__doc__,
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
     p.add_argument('in_bundle',

--- a/scripts/scil_compute_todi.py
+++ b/scripts/scil_compute_todi.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+"""
+Compute a length-weighted Track Orientation Density Image (TODI).
+This script can afterwards output a length-weighted Track Density Image
+(TDI) or a length-weighted TODI, based on streamlines' segments.\n\n
+"""
 
 import argparse
 import logging
@@ -14,12 +19,6 @@ from scilpy.io.utils import (add_overwrite_arg, add_reference_arg,
 from scilpy.tractanalysis.todi import TrackOrientationDensityImaging
 
 
-DESCRIPTION = """
-    Compute a length-weighted Track Orientation Density Image (TODI).
-    This script can afterwards output a length-weighted Track Density Image
-    (TDI) or a length-weighted TODI, based on streamlines' segments.\n\n
-    """
-
 EPILOG = """
     References:
         [1] Dhollander T, Emsell L, Van Hecke W, Maes F, Sunaert S, Suetens P.
@@ -30,7 +29,7 @@ EPILOG = """
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(description=DESCRIPTION, epilog=EPILOG,
+    p = argparse.ArgumentParser(description=__doc__, epilog=EPILOG,
                                 formatter_class=argparse.RawTextHelpFormatter)
 
     p.add_argument('tract_filename',

--- a/scripts/scil_convert_gradients_fsl_to_mrtrix.py
+++ b/scripts/scil_convert_gradients_fsl_to_mrtrix.py
@@ -1,18 +1,20 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+"""
+Script to convert bval/bvec FSL style to MRtrix style.
+"""
+
 import argparse
 
 from scilpy.io.utils import (assert_inputs_exist, assert_outputs_exist,
                              add_overwrite_arg)
 from scilpy.utils.bvec_bval_tools import fsl2mrtrix
 
-DESCRIPTION = "Script to convert bval/bvec FSL style to MRtrix style."
-
 
 def _build_args_parser():
     p = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
-                                description=DESCRIPTION)
+                                description=__doc__)
 
     p.add_argument('fsl_bval',
                    help='path to FSL b-value file.')

--- a/scripts/scil_convert_gradients_mrtrix_to_fsl.py
+++ b/scripts/scil_convert_gradients_mrtrix_to_fsl.py
@@ -1,5 +1,8 @@
 #! /usr/bin/env python
 # -*- coding: utf-8 -*-
+"""
+Script to convert bval/bvec MRtrix style to FSL style.
+"""
 
 import argparse
 
@@ -7,12 +10,10 @@ from scilpy.io.utils import (assert_inputs_exist, assert_outputs_exist,
                              add_overwrite_arg)
 from scilpy.utils.bvec_bval_tools import mrtrix2fsl
 
-DESCRIPTION = "Script to convert bval/bvec MRtrix style to FSL style."
-
 
 def _build_args_parser():
     p = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
-                                description=DESCRIPTION)
+                                description=__doc__)
 
     p.add_argument('mrtrix_enc',
                    help='Gradient directions encoding file. (.b)')

--- a/scripts/scil_convert_sh_basis.py
+++ b/scripts/scil_convert_sh_basis.py
@@ -1,6 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+"""
+    Convert a SH file between the two commonly used bases
+    ('descoteaux07' or 'tournier07'). The specified basis corresponds to the
+    input data basis.
+"""
+
 import argparse
 
 from dipy.data import get_sphere
@@ -12,16 +18,10 @@ from scilpy.reconst.utils import find_order_from_nb_coeff
 from scilpy.io.utils import (add_overwrite_arg, add_sh_basis_args,
                              assert_inputs_exist, assert_outputs_exist)
 
-DESCRIPTION = """
-    Convert a SH file between the two commonly used bases
-    ('descoteaux07' or 'tournier07'). The specified basis corresponds to the
-    input data basis.
-"""
-
 
 def _build_arg_parser():
     p = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
-                                description=DESCRIPTION)
+                                description=__doc__)
 
     p.add_argument('input_sh',
                    help='Input SH filename. (nii or nii.gz)')

--- a/scripts/scil_convert_tractogram.py
+++ b/scripts/scil_convert_tractogram.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+"""
+Conversion of '.tck', '.trk', '.fib', '.vtk' and 'dpy' files using updated file
+format standard. TRK file always needs a reference file, a NIFTI, for
+conversion. The FIB file format is in fact a VTK, MITK Diffusion supports it.
+"""
 
 import argparse
 import os
@@ -10,15 +15,9 @@ from scilpy.io.streamlines import load_tractogram_with_reference
 from scilpy.io.utils import (add_overwrite_arg, add_reference_arg,
                              assert_inputs_exist, assert_outputs_exist)
 
-DESCRIPTION = """
-Conversion of '.tck', '.trk', '.fib', '.vtk' and 'dpy' files using updated file
-format standard. TRK file always needs a reference file, a NIFTI, for
-conversion. The FIB file format is in fact a VTK, MITK Diffusion supports it.
-"""
-
 
 def _build_args_parser():
-    p = argparse.ArgumentParser(description=DESCRIPTION,
+    p = argparse.ArgumentParser(description=__doc__,
                                 formatter_class=argparse.RawTextHelpFormatter)
 
     p.add_argument('in_tractogram', metavar='IN_TRACTOGRAM',

--- a/scripts/scil_detect_streamlines_loops.py
+++ b/scripts/scil_detect_streamlines_loops.py
@@ -1,20 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import argparse
-import logging
-
-import nibabel as nib
-import numpy as np
-
-from scilpy.io.utils import (add_overwrite_arg,
-                             assert_inputs_exist,
-                             assert_outputs_exist,
-                             check_tracts_same_format)
-from scilpy.tractanalysis.features import remove_loops_and_sharp_turns
-
-
-DESCRIPTION = """
+"""
 This script can be used to remove loops in two types of streamline datasets:
 
   - Whole brain: For this type, the script removes streamlines if they
@@ -31,10 +18,22 @@ QuickBundles based on [Garyfallidis12] Frontiers in Neuroscience, 2012.
 ----------------------------------------------------------------------------
 """
 
+import argparse
+import logging
+
+import nibabel as nib
+import numpy as np
+
+from scilpy.io.utils import (add_overwrite_arg,
+                             assert_inputs_exist,
+                             assert_outputs_exist,
+                             check_tracts_same_format)
+from scilpy.tractanalysis.features import remove_loops_and_sharp_turns
+
 
 def _build_arg_parser():
     p = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
-                                description=DESCRIPTION)
+                                description=__doc__)
     p.add_argument('in_tractogram',
                    help='Tractogram input file name.')
     p.add_argument('out_tractogram',

--- a/scripts/scil_dilate_labels.py
+++ b/scripts/scil_dilate_labels.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+"""
+Dilate regions (with or without masking) from a labeled volume:
+- "label_to_dilate" are regions that will dilate over
+    "label_to_fill" if close enough to it ("distance").
+- "label_to_dilate", by default (None) will be all
+        non-"label_to_fill" and non-"label_not_to_dilate".
+- "label_not_to_dilate" will not be changed, but will not dilate.
+- "mask" is where the dilation is allowed (constrained)
+    in addition to "background_label" (logical AND)
+
+>>> scil_dilate_labels.py wmparc_t1.nii.gz wmparc_dil.nii.gz \\
+    --label_to_fill 0 5001 5002 \\
+    --label_not_to_dilate 4 43 10 11 12 49 50 51
+"""
 
 import argparse
 import logging
@@ -11,22 +25,6 @@ from scipy.spatial.ckdtree import cKDTree
 from scilpy.io.utils import (add_overwrite_arg, assert_inputs_exist,
                              assert_outputs_exist)
 
-
-DESCRIPTION = """
-    Dilate regions (with or without masking) from a labeled volume:
-    - "label_to_dilate" are regions that will dilate over
-        "label_to_fill" if close enough to it ("distance").
-    - "label_to_dilate", by default (None) will be all
-         non-"label_to_fill" and non-"label_not_to_dilate".
-    - "label_not_to_dilate" will not be changed, but will not dilate.
-    - "mask" is where the dilation is allowed (constrained)
-        in addition to "background_label" (logical AND)
-
-    >>> scil_dilate_labels.py wmparc_t1.nii.gz wmparc_dil.nii.gz \\
-        --label_to_fill 0 5001 5002 \\
-        --label_not_to_dilate 4 43 10 11 12 49 50 51
-    """
-
 EPILOG = """
     References:
         [1] Al-Sharif N.B., St-Onge E., Vogel J.W., Theaud G.,
@@ -36,7 +34,7 @@ EPILOG = """
 
 
 def _build_args_parser():
-    p = argparse.ArgumentParser(description=DESCRIPTION, epilog=EPILOG,
+    p = argparse.ArgumentParser(description=__doc__, epilog=EPILOG,
                                 formatter_class=argparse.RawTextHelpFormatter)
 
     p.add_argument('in_file',

--- a/scripts/scil_endpoints_map.py
+++ b/scripts/scil_endpoints_map.py
@@ -1,5 +1,17 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+
+"""
+Computes the endpoint map of a bundle. The endpoint map
+is simply a count of the number of streamlines that
+start or end in each voxel. The idea is to estimate the
+cortical areas affected by the bundle (assuming
+streamlines start/end in the cortex).
+Note: If the streamlines are not aligned in X, Y or Z directions
+the head/tail are random and not really two coherent groups.
+"""
+
+
 import argparse
 import logging
 import json
@@ -15,20 +27,10 @@ from scilpy.io.utils import (add_json_args,
                              assert_inputs_exist,
                              assert_outputs_exist)
 
-DESCRIPTION = '''
-Computes the endpoint map of a bundle. The endpoint map
-is simply a count of the number of streamlines that
-start or end in each voxel. The idea is to estimate the
-cortical areas affected by the bundle (assuming
-streamlines start/end in the cortex).
-Note: If the streamlines are not aligned in X, Y or Z directions
-the head/tail are random and not really two coherent groups.
-'''
-
 
 def _build_arg_parser():
     p = argparse.ArgumentParser(
-        description=DESCRIPTION,
+        description=__doc__,
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
     p.add_argument('in_bundle',

--- a/scripts/scil_filter_streamlines_by_length.py
+++ b/scripts/scil_filter_streamlines_by_length.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+
+"""
+Filter streamlines by length.
+"""
 import argparse
 import json
 import logging
@@ -21,7 +25,7 @@ from scilpy.io.utils import (add_json_args,
 def _build_args_parser():
     p = argparse.ArgumentParser(
         formatter_class=argparse.RawTextHelpFormatter,
-        description='Filter streamlines by length.')
+        description=__doc__)
     p.add_argument('in_tractogram',
                    help='Streamlines input file name.')
     p.add_argument('out_tractogram',

--- a/scripts/scil_flip_gradients.py
+++ b/scripts/scil_flip_gradients.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
 # -*- coding: utf-8 -*-
-
+"""
+Flip one or more axes of the encoding scheme matrix.
+"""
 import argparse
 
 from scilpy.io.utils import (add_overwrite_arg, assert_inputs_exist,
@@ -11,8 +13,7 @@ from scilpy.utils.util import str_to_index
 
 def _build_arg_parser():
     p = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
-                                description='Flip one or more axes of the '
-                                            'encoding scheme matrix.')
+                                description=__doc__)
 
     p.add_argument('encoding_file',
                    help='Path to encoding file.')

--- a/scripts/scil_flip_volume.py
+++ b/scripts/scil_flip_volume.py
@@ -1,15 +1,15 @@
 #! /usr/bin/env python
 
+"""
+Flip the volume according to the specified axis.
+"""
+
 import argparse
 
 import nibabel as nib
 
 from scilpy.io.utils import (add_overwrite_arg, assert_inputs_exist,
                              assert_outputs_exist)
-
-"""
-Flip the volume according to the specified axis.
-"""
 
 
 def _build_arg_parser():

--- a/scripts/scil_generate_priors_from_bundle.py
+++ b/scripts/scil_generate_priors_from_bundle.py
@@ -1,6 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+"""
+Generation of priors and enhanced-FOD from an example/template bundle.
+The bundle must have been cleaned thorougly before use. The E-FOD can then
+be used for bundle-specific tractography, but not for FOD metrics.
+"""
+
 import argparse
 import logging
 import os
@@ -19,12 +25,6 @@ from scilpy.reconst.utils import find_order_from_nb_coeff
 from scilpy.tractanalysis.todi import TrackOrientationDensityImaging
 
 
-DESCRIPTION = """
-    Generation of priors and enhanced-FOD from an example/template bundle.
-    The bundle must have been cleaned thorougly before use. The E-FOD can then
-    be used for bundle-specific tractography, but not for FOD metrics.
-"""
-
 EPILOG = """
     References:
         [1] Rheault, Francois, et al. "Bundle-specific tractography with
@@ -35,7 +35,7 @@ EPILOG = """
 
 def _build_arg_parser():
     p = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
-                                description=DESCRIPTION, epilog=EPILOG,)
+                                description=__doc__, epilog=EPILOG,)
     p.add_argument('bundle_filename',
                    help='Input bundle filename.')
 

--- a/scripts/scil_generate_sampling_scheme.py
+++ b/scripts/scil_generate_sampling_scheme.py
@@ -1,6 +1,16 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+"""
+Generate multi-shell sampling schemes with various processing to accelerate
+acquisition and help artefact correction.
+
+Multi-shell schemes are generated as in [1], the bvecs are then flipped
+to maximize spread for eddy current correction, b0s are interleaved
+at equal spacing and the non-b0 samples are finally shuffled
+to minimize the total diffusion gradient amplitude over a few TR.
+"""
+
 import argparse
 import logging
 import numpy as np
@@ -22,16 +32,6 @@ from scilpy.samplingscheme.save_scheme import (save_scheme_bvecs_bvals,
                                                save_scheme_mrtrix)
 
 
-DESCRIPTION = """
-Generate multi-shell sampling schemes with various processing to accelerate
-acquisition and help artefact correction.
-
-Multi-shell schemes are generated as in [1], the bvecs are then flipped
-to maximize spread for eddy current correction, b0s are interleaved
-at equal spacing and the non-b0 samples are finally shuffled
-to minimize the total diffusion gradient amplitude over a few TR.
-    """
-
 EPILOG = """
 References: [1] Emmanuel Caruyer, Christophe Lenglet, Guillermo Sapiro,
 Rachid Deriche. Design of multishell sampling schemes with uniform coverage
@@ -43,7 +43,7 @@ pp. 1534-1540. <http://dx.doi.org/10.1002/mrm.24736>
 def _build_args_parser():
     p = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        description=DESCRIPTION,
+        description=__doc__,
         epilog=EPILOG)
     p._optionals.title = "Options and Parameters"
 

--- a/scripts/scil_get_subset_streamlines.py
+++ b/scripts/scil_get_subset_streamlines.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+
+"""
+Get a subset of streamlines.
+"""
+
 import argparse
 
 from nibabel.streamlines import load, save, Tractogram
@@ -13,7 +18,7 @@ from scilpy.io.utils import (assert_inputs_exist, assert_outputs_exist,
 def _build_args_parser():
     p = argparse.ArgumentParser(
         formatter_class=argparse.RawTextHelpFormatter,
-        description='Get a subset of streamlines.')
+        description=__doc__)
     p.add_argument('in_tractogram',
                    help='Streamlines input file name.')
     p.add_argument('max_num_streamlines', type=int,

--- a/scripts/scil_mask_math.py
+++ b/scripts/scil_mask_math.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+"""
+Performs an operation on a list of mask images. The supported
+operations are:
+
+    subtraction:  Keep the voxels from the first file that are not in
+                  any of the following files.
+
+    intersection: Keep the voxels that are present in all files.
+
+    union:        Keep voxels that are in any file.
+
+This script handles both probabilistic masks and binary masks.
+"""
+
 
 from __future__ import division
 from builtins import next
@@ -14,20 +28,6 @@ import numpy as np
 
 from scilpy.io.utils import (add_overwrite_arg, assert_outputs_exist,
                              assert_inputs_exist)
-
-DESCRIPTION = """
-Performs an operation on a list of mask images. The supported
-operations are:
-
-    subtraction:  Keep the voxels from the first file that are not in
-                  any of the following files.
-
-    intersection: Keep the voxels that are present in all files.
-
-    union:        Keep voxels that are in any file.
-
-This script handles both probabilistic masks and binary masks.
-"""
 
 
 def mask_union(left, right):
@@ -53,7 +53,7 @@ def build_args_parser():
 
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawTextHelpFormatter,
-        description=DESCRIPTION)
+        description=__doc__)
 
     parser.add_argument('operation',
                         choices=list(OPERATIONS.keys()),

--- a/scripts/scil_merge_sh.py
+++ b/scripts/scil_merge_sh.py
@@ -1,15 +1,5 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-
-import argparse
-
-import nibabel as nb
-import numpy as np
-
-from scilpy.io.image import assert_same_resolution
-from scilpy.io.utils import (add_overwrite_arg, assert_inputs_exist,
-                             assert_outputs_exist)
-
 """
 Merge a list of Spherical Harmonics files.
 
@@ -21,6 +11,15 @@ conserving the most relevant information.
 
 Based on [1].
 """
+
+import argparse
+
+import nibabel as nb
+import numpy as np
+
+from scilpy.io.image import assert_same_resolution
+from scilpy.io.utils import (add_overwrite_arg, assert_inputs_exist,
+                             assert_outputs_exist)
 
 
 EPILOG = """

--- a/scripts/scil_outlier_rejection.py
+++ b/scripts/scil_outlier_rejection.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+"""
+Clean a bundle (inliers/outliers) using hiearchical clustering.
+http://archive.ismrm.org/2015/2844.html
+"""
 
 import argparse
 import logging
@@ -16,15 +20,10 @@ from scilpy.tractanalysis.features import (
     outliers_removal_using_hierarchical_quickbundles,
     prune)
 
-DESCRIPTION = """
-Clean a bundle (inliers/outliers) using hiearchical clustering.
-http://archive.ismrm.org/2015/2844.html
-"""
-
 
 def _build_arg_parser():
     parser = argparse.ArgumentParser(
-        description=DESCRIPTION,
+        description=__doc__,
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('in_bundle',
                         help='Fiber bundle file to remove outliers from.')

--- a/scripts/scil_perform_majority_vote.py
+++ b/scripts/scil_perform_majority_vote.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+"""
+Use multiple bundles to perform a voxel-wise vote (occurence across input).
+If streamlines originate from the same tractogram, streamline-wise vote
+is available.
+Input tractograms have to have identical header (register).
+"""
+
 
 import argparse
 
@@ -20,18 +27,11 @@ from scilpy.tractanalysis.streamlines_metrics import compute_tract_counts_map
 from scilpy.utils.streamlines import (perform_streamlines_operation,
                                       intersection, union)
 
-DESCRIPTION = """
-Use multiple bundles to perform a voxel-wise vote (occurence across input).
-If streamlines originate from the same tractogram, streamline-wise vote
-is available.
-Input tractograms have to have identical header (register).
-"""
-
 
 def _build_args_parser():
     p = argparse.ArgumentParser(
         formatter_class=argparse.RawTextHelpFormatter,
-        description=DESCRIPTION)
+        description=__doc__)
 
     p.add_argument('in_bundles', nargs='+',
                    help='Input bundles filename.')

--- a/scripts/scil_prepare_eddy_command.py
+++ b/scripts/scil_prepare_eddy_command.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+"""
+Prepare a typical command for eddy and create the necessary files.
+"""
 
 from __future__ import print_function
 import argparse
@@ -16,13 +19,8 @@ from scilpy.preprocessing.distortion_correction import create_acqparams, \
     create_index, create_non_zero_norm_bvecs
 
 
-DESCRIPTION = """
-Prepare a typical command for eddy and create the necessary files.
- """
-
-
 def _build_arg_parser():
-    p = argparse.ArgumentParser(description=DESCRIPTION,
+    p = argparse.ArgumentParser(description=__doc__,
                                 formatter_class=argparse.RawTextHelpFormatter)
 
     p.add_argument('input_dwi',

--- a/scripts/scil_prepare_topup_command.py
+++ b/scripts/scil_prepare_topup_command.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+"""
+Prepare a typical command for topup and create the necessary files.
+The reversed b0 must be in a different file.
+"""
+
 from __future__ import print_function
 import argparse
 import logging
@@ -14,14 +19,9 @@ from scilpy.io.utils import add_overwrite_arg, \
     assert_inputs_exist, assert_outputs_exist
 from scilpy.preprocessing.distortion_correction import create_acqparams
 
-DESCRIPTION = """
-Prepare a typical command for topup and create the necessary files.
-The reversed b0 must be in a different file.
- """
-
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(description=DESCRIPTION,
+    p = argparse.ArgumentParser(description=__doc__,
                                 formatter_class=argparse.RawTextHelpFormatter)
 
     p.add_argument('input_dwi',

--- a/scripts/scil_register_tractogram.py
+++ b/scripts/scil_register_tractogram.py
@@ -1,6 +1,15 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+"""
+Generate a linear transformation matrix from the registration of
+2 tractograms. Typically, this script is run before
+scil_apply_transform_to_tractogram.py.
+
+For more informations on how to use the various registration scripts
+see the doc/tractogram_registration.md readme file
+"""
+
 import argparse
 import os
 
@@ -10,17 +19,9 @@ import numpy as np
 
 
 from scilpy.io.streamlines import ichunk, load_tractogram_with_reference
-from scilpy.io.utils import (add_overwrite_arg, add_reference_arg, add_verbose_arg,
-                             assert_inputs_exist, assert_outputs_exist)
-
-DESCRIPTION = """
-Generate a linear transformation matrix from the registration of
-2 tractograms. Typically, this script is run before
-scil_apply_transform_to_tractogram.py.
-
-For more informations on how to use the various registration scripts
-see the doc/tractogram_registration.md readme file
-"""
+from scilpy.io.utils import (add_overwrite_arg, add_reference_arg,
+                             add_verbose_arg, assert_inputs_exist,
+                             assert_outputs_exist)
 
 EPILOG = """
 References:
@@ -59,7 +60,7 @@ def register_tractogram(moving_tractogram, static_tractogram,
 
 def _build_args_parser():
     p = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
-                                description=DESCRIPTION, epilog=EPILOG)
+                                description=__doc__, epilog=EPILOG)
 
     p.add_argument('moving_tractogram',
                    help='Path of the moving tractogram.')

--- a/scripts/scil_remove_invalid_streamlines.py
+++ b/scripts/scil_remove_invalid_streamlines.py
@@ -1,6 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+"""
+Removal of streamlines that are out of the volume bounding box. In voxel space
+no negative coordinate and no above volume dimension coordinate are possible.
+Any streamline that do not respect these two conditions are removed.
+"""
+
 import argparse
 
 from dipy.io.streamline import save_tractogram
@@ -9,15 +15,9 @@ from scilpy.io.streamlines import load_tractogram_with_reference
 from scilpy.io.utils import (add_overwrite_arg, add_reference_arg,
                              assert_inputs_exist, assert_outputs_exist)
 
-DESCRIPTION = """
-Removal of streamlines that are out of the volume bounding box. In voxel space
-no negative coordinate and no above volume dimension coordinate are possible.
-Any streamline that do not respect these two conditions are removed.
-"""
-
 
 def _build_args_parser():
-    p = argparse.ArgumentParser(description=DESCRIPTION,
+    p = argparse.ArgumentParser(description=__doc__,
                                 formatter_class=argparse.RawTextHelpFormatter)
 
     p.add_argument('in_tractogram', metavar='IN_TRACTOGRAM',

--- a/scripts/scil_remove_labels.py
+++ b/scripts/scil_remove_labels.py
@@ -1,6 +1,13 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+"""
+    Script to remove specific labels from a atlas volumes.
+
+    >>> scil_remove_labels.py DKT_labels.nii out_labels.nii.gz -i 5001 5002
+"""
+
+
 import argparse
 import logging
 
@@ -9,13 +16,6 @@ import numpy as np
 
 from scilpy.io.utils import (add_overwrite_arg, assert_inputs_exist,
                              assert_outputs_exist)
-
-DESCRIPTION = """
-    Script to remove specific labels from a atlas volumes.
-
-    >>> scil_remove_labels.py DKT_labels.nii out_labels.nii.gz -i 5001 5002
-    """
-
 EPILOG = """
     References:
         [1] Al-Sharif N.B., St-Onge E., Vogel J.W., Theaud G.,
@@ -25,7 +25,7 @@ EPILOG = """
 
 
 def _build_args_parser():
-    p = argparse.ArgumentParser(description=DESCRIPTION, epilog=EPILOG,
+    p = argparse.ArgumentParser(description=__doc__, epilog=EPILOG,
                                 formatter_class=argparse.RawTextHelpFormatter)
 
     p.add_argument('input',

--- a/scripts/scil_reorder_dwi_philips.py
+++ b/scripts/scil_reorder_dwi_philips.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+"""
+Re-order gradient according to original table
+"""
+
 import argparse
 import logging
 
@@ -15,13 +19,8 @@ from scilpy.io.utils import (add_overwrite_arg,
 from scilpy.utils.filenames import split_name_with_nii
 
 
-DESCRIPTION = """
-Re-order gradient according to original table
- """
-
-
 def _build_arg_parser():
-    p = argparse.ArgumentParser(description=DESCRIPTION,
+    p = argparse.ArgumentParser(description=__doc__,
                                 formatter_class=argparse.RawTextHelpFormatter)
 
     p.add_argument('dwi',

--- a/scripts/scil_resample_streamlines.py
+++ b/scripts/scil_resample_streamlines.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+
+"""
+Resample a set of streamlines.
+'WARNING: data_per_point is not carried
+"""
+
 import argparse
 
 from nibabel.streamlines import load, save, Tractogram
@@ -13,8 +19,7 @@ from scilpy.io.utils import (assert_inputs_exist, assert_outputs_exist,
 def _build_args_parser():
     p = argparse.ArgumentParser(
         formatter_class=argparse.RawTextHelpFormatter,
-        description='Resample a set of streamlines.\n'
-                    'WARNING: data_per_point is not carried')
+        description=__doc__)
     p.add_argument('in_tractogram',
                    help='Streamlines input file name.')
     p.add_argument('nb_pts_per_streamline', type=int,

--- a/scripts/scil_reshape_to_reference.py
+++ b/scripts/scil_reshape_to_reference.py
@@ -1,6 +1,15 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+"""
+Reshape / reslice / resample *.nii or *.nii.gz using a reference.
+For more information on how to use the various registration scripts
+see the doc/tractogram_registration.md readme file.
+
+>>> scil_reshape_to_reference.py wmparc.mgz t1.nii.gz wmparc_t1.nii.gz \\
+    --interpolation nearest
+"""
+
 import argparse
 
 import numpy as np
@@ -10,18 +19,8 @@ from scilpy.io.utils import (add_overwrite_arg, assert_inputs_exist,
 from scilpy.utils.image import transform_anatomy
 
 
-DESCRIPTION = """
-    Reshape / reslice / resample *.nii or *.nii.gz using a reference.
-    For more information on how to use the various registration scripts
-    see the doc/tractogram_registration.md readme file.
-
-    >>> scil_reshape_to_reference.py wmparc.mgz t1.nii.gz wmparc_t1.nii.gz \\
-        --interpolation nearest
-"""
-
-
 def _build_args_parser():
-    p = argparse.ArgumentParser(description=DESCRIPTION,
+    p = argparse.ArgumentParser(description=__doc__,
                                 formatter_class=argparse.RawTextHelpFormatter)
 
     p.add_argument('in_file',

--- a/scripts/scil_set_response_function.py
+++ b/scripts/scil_set_response_function.py
@@ -1,6 +1,14 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+"""
+Replace the fiber response function in the FRF file.
+Use this script when you want to use a fixed response function
+and keep the mean b0.
+
+The FRF file is obtained from scil_compute_ssst_frf.py
+"""
+
 from __future__ import division, print_function
 
 import argparse
@@ -10,18 +18,10 @@ import numpy as np
 from scilpy.io.utils import (
     add_overwrite_arg, assert_inputs_exist, assert_outputs_exist)
 
-DESCRIPTION = """
-Replace the fiber response function in the FRF file.
-Use this script when you want to use a fixed response function
-and keep the mean b0.
-
-The FRF file is obtained from scil_compute_ssst_frf.py
-"""
-
 
 def _build_arg_parser():
     p = argparse.ArgumentParser(
-        description=DESCRIPTION, formatter_class=argparse.RawTextHelpFormatter)
+        description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
 
     p.add_argument('frf_file', metavar='input',
                    help='Path of the FRF file.')

--- a/scripts/scil_split_tractograms.py
+++ b/scripts/scil_split_tractograms.py
@@ -1,6 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+"""
+Split a tractogram into multiple files, 2 options available :
+Split into X files, or split into files of Y streamlines
+"""
+
+
 import argparse
 import os
 
@@ -12,16 +18,11 @@ from scilpy.io.streamlines import load_tractogram_with_reference
 from scilpy.io.utils import (add_overwrite_arg, assert_inputs_exist,
                              assert_outputs_exist, add_reference_arg)
 
-DESCRIPTION = """
-    Split a tractogram into multiple files, 2 options available :
-    Split into X files, or split into files of Y streamlines
-"""
-
 
 def _build_args_parser():
     p = argparse.ArgumentParser(
         formatter_class=argparse.RawTextHelpFormatter,
-        description=DESCRIPTION)
+        description=__doc__)
 
     p.add_argument('in_tractogram',
                    help='Tractogram input file name.')

--- a/scripts/scil_summarize_bundles_similarity_measures.py
+++ b/scripts/scil_summarize_bundles_similarity_measures.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+"""
+Compute pair-wise similarity measures of bundles.
+All tractograms must be in the same space (aligned to one reference)
+"""
+
 import argparse
 import copy
 import hashlib
@@ -33,15 +38,9 @@ from scilpy.tractanalysis.reproducibility_measures \
 from scilpy.tractanalysis.streamlines_metrics import compute_tract_counts_map
 
 
-DESCRIPTION = """
-Compute pair-wise similarity measures of bundles.
-All tractograms must be in the same space (aligned to one reference)
-"""
-
-
 def _build_args_parser():
     p = argparse.ArgumentParser(
-        description=DESCRIPTION,
+        description=__doc__,
         formatter_class=argparse.RawTextHelpFormatter)
     p.add_argument('in_bundles', nargs='+',
                    help='Path of the input bundles.')

--- a/scripts/scil_visualize_multi_shell.py
+++ b/scripts/scil_visualize_multi_shell.py
@@ -1,6 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+"""
+Vizualisation for sampling schemes.
+Only supports .caru, .txt (Philips), .dir or .dvs (Siemens), .bvecs/.bvals
+and .b (MRtrix).
+"""
+
 import argparse
 import logging
 import numpy as np
@@ -15,17 +21,10 @@ from scilpy.viz.sampling_scheme import (build_ms_from_shell_idx,
                                         plot_proj_shell)
 
 
-DESCRIPTION = """
-Vizualisation for sampling schemes.
-Only supports .caru, .txt (Philips), .dir or .dvs (Siemens), .bvecs/.bvals
-and .b (MRtrix).
-"""
-
-
 def _build_args_parser():
     p = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        description=DESCRIPTION)
+        description=__doc__)
 
     p.add_argument(
         'scheme_file', action='store', metavar='scheme_file',


### PR DESCRIPTION
From the scilpy_cleanup_crew tasks, we uniformized the descriptions as  description=__doc__ rather than description=DESCRIPTION. And we put the doc above everything.