### PR TITLE
reorganize import in viz

### DIFF
--- a/scilpy/version.py
+++ b/scilpy/version.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, division, print_function
+
 import glob
 
 # Format expected by setup.py and doc/source/conf.py: string of form "X.Y.Z"


### PR DESCRIPTION
Order imports alphabetically, in 3 groups (internal/external/scilpy)