### PR TITLE
reorganize import in tractanalysis

### DIFF
--- a/scilpy/tractanalysis/features.py
+++ b/scilpy/tractanalysis/features.py
@@ -5,7 +5,7 @@ from builtins import range
 from itertools import count, takewhile
 import logging
 
-from dipy.segment.clustering import qbx_and_merge, QuickBundles, Cluster
+from dipy.segment.clustering import Cluster, QuickBundles, qbx_and_merge
 from dipy.tracking import metrics as tm
 import numpy as np
 

--- a/scilpy/tractanalysis/reproducibility_measures.py
+++ b/scilpy/tractanalysis/reproducibility_measures.py
@@ -3,12 +3,14 @@ import copy
 
 from dipy.segment.clustering import qbx_and_merge
 from dipy.tracking.distances import bundles_distances_mdf
-from dipy.tracking.streamline import set_number_of_points, length
+from dipy.tracking.streamline import length, set_number_of_points
 import numpy as np
 from numpy.random import RandomState
 from scipy.spatial import cKDTree
-from scilpy.utils.streamlines import (perform_streamlines_operation,
-                                      subtraction, intersection, union)
+
+from scilpy.utils.streamlines import (intersection,
+                                      perform_streamlines_operation,
+                                      subtraction, union)
 
 
 def get_endpoints_density_map(streamlines, dimensions, point_to_select=1):

--- a/scilpy/tractanalysis/tools.py
+++ b/scilpy/tractanalysis/tools.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import division
+
 from builtins import range
 
 import numpy as np


### PR DESCRIPTION
Order imports alphabetically, in 3 groups (internal/external/scilpy)