### PR TITLE
reorganize import in tracking

### DIFF
--- a/scilpy/tracking/tools.py
+++ b/scilpy/tracking/tools.py
@@ -3,11 +3,11 @@
 
 import logging
 
-import numpy as np
-from dipy.tracking.metrics import length, downsample
+from dipy.tracking.metrics import downsample, length
 from dipy.tracking.streamline import set_number_of_points
+import numpy as np
+from scipy.interpolate import splev, splprep
 from scipy.ndimage.filters import gaussian_filter1d
-from scipy.interpolate import splprep, splev
 
 
 def filter_streamlines_by_length(sft, min_length=0., max_length=np.inf):


### PR DESCRIPTION
Order imports alphabetically, in 3 groups (internal/external/scilpy)