### PR TITLE
reorganize import in reconst

### DIFF
--- a/scilpy/reconst/raw_signal.py
+++ b/scilpy/reconst/raw_signal.py
@@ -2,13 +2,13 @@
 
 import logging
 
-import numpy as np
 from dipy.core.sphere import Sphere
 from dipy.reconst.shm import sf_to_sh
+import numpy as np
 
-from scilpy.utils.bvec_bval_tools import (check_b0_threshold, identify_shells,
-                                          is_normalized_bvecs, normalize_bvecs,
-                                          DEFAULT_B0_THRESHOLD)
+from scilpy.utils.bvec_bval_tools import (DEFAULT_B0_THRESHOLD,
+                                          check_b0_threshold, identify_shells,
+                                          is_normalized_bvecs, normalize_bvecs)
 
 
 def compute_sh_coefficients(dwi, gradient_table, sh_order=4,


### PR DESCRIPTION
Order imports alphabetically, in 3 groups (internal/external/scilpy)