### PR TITLE
reorganize import in preprocessing

### DIFF
--- a/scilpy/preprocessing/distortion_correction.py
+++ b/scilpy/preprocessing/distortion_correction.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from builtins import range
+
 import numpy as np
 
 


### PR DESCRIPTION
Order imports alphabetically, in 3 groups (internal/external/scilpy)