### PR TITLE
reorganize import on module io

### DIFF
--- a/scilpy/io/streamlines.py
+++ b/scilpy/io/streamlines.py
@@ -3,13 +3,12 @@
 
 from itertools import islice
 import os
-import six
 
 from dipy.io.streamline import load_tractogram
 import nibabel as nib
-from nibabel.streamlines import Field, Tractogram
-from nibabel.streamlines.trk import (get_affine_rasmm_to_trackvis,
-                                     get_affine_trackvis_to_rasmm)
+from nibabel.streamlines import Tractogram
+from nibabel.streamlines.trk import (get_affine_trackvis_to_rasmm)
+import six
 
 
 def check_tracts_same_format(parser, tractogram_1, tractogram_2):

--- a/scilpy/io/utils.py
+++ b/scilpy/io/utils.py
@@ -3,12 +3,12 @@
 
 import os
 import shutil
-import six
 import xml.etree.ElementTree as ET
 
 import nibabel as nib
 from nibabel.streamlines import TrkFile
 import numpy as np
+import six
 
 from scilpy.utils.bvec_bval_tools import DEFAULT_B0_THRESHOLD
 


### PR DESCRIPTION
Order imports alphabetically, in 3 groups (internal/external/scilpy)