### PR TITLE
Revert import ordering

### DIFF
--- a/scilpy/io/streamlines.py
+++ b/scilpy/io/streamlines.py
@@ -2,12 +2,13 @@
 
 from itertools import islice
 import os
+import six
 
 from dipy.io.streamline import load_tractogram
 import nibabel as nib
-from nibabel.streamlines import Tractogram
-from nibabel.streamlines.trk import (get_affine_trackvis_to_rasmm)
-import six
+from nibabel.streamlines import Field, Tractogram
+from nibabel.streamlines.trk import (get_affine_rasmm_to_trackvis,
+                                     get_affine_trackvis_to_rasmm)
 
 
 def check_tracts_same_format(parser, tractogram_1, tractogram_2):

--- a/scilpy/io/utils.py
+++ b/scilpy/io/utils.py
@@ -2,12 +2,12 @@
 
 import os
 import shutil
+import six
 import xml.etree.ElementTree as ET
 
 import nibabel as nib
 from nibabel.streamlines import TrkFile
 import numpy as np
-import six
 
 from scilpy.utils.bvec_bval_tools import DEFAULT_B0_THRESHOLD
 

--- a/scilpy/preprocessing/distortion_correction.py
+++ b/scilpy/preprocessing/distortion_correction.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from builtins import range
-
 import numpy as np
 
 

--- a/scilpy/reconst/raw_signal.py
+++ b/scilpy/reconst/raw_signal.py
@@ -2,13 +2,13 @@
 
 import logging
 
+import numpy as np
 from dipy.core.sphere import Sphere
 from dipy.reconst.shm import sf_to_sh
-import numpy as np
 
-from scilpy.utils.bvec_bval_tools import (DEFAULT_B0_THRESHOLD,
-                                          check_b0_threshold, identify_shells,
-                                          is_normalized_bvecs, normalize_bvecs)
+from scilpy.utils.bvec_bval_tools import (check_b0_threshold, identify_shells,
+                                          is_normalized_bvecs, normalize_bvecs,
+                                          DEFAULT_B0_THRESHOLD)
 
 
 def compute_sh_coefficients(dwi, gradient_table, sh_order=4,

--- a/scilpy/samplingscheme/multiple_shell_energy.py
+++ b/scilpy/samplingscheme/multiple_shell_energy.py
@@ -9,10 +9,8 @@
 # et al., MRM 69(6), pp. 1534-1540, 2013.      #
 # This software comes with no warranty, etc.   #
 ################################################
-
-import numpy as np
-
 from scipy import optimize
+import numpy as np
 
 
 def equality_constraints(bvecs, *args):

--- a/scilpy/samplingscheme/optimize_scheme.py
+++ b/scilpy/samplingscheme/optimize_scheme.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
 import logging
-
 import numpy as np
+
 from scipy.spatial.distance import cdist, pdist, squareform
 
 

--- a/scilpy/samplingscheme/save_scheme.py
+++ b/scilpy/samplingscheme/save_scheme.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import logging
-
 import numpy as np
 
 from scilpy.utils.filenames import split_name_with_nii

--- a/scilpy/segment/models.py
+++ b/scilpy/segment/models.py
@@ -2,11 +2,11 @@
 
 import logging
 
+import numpy as np
 from dipy.align.bundlemin import distance_matrix_mdf
+from dipy.tracking.streamline import set_number_of_points
 from dipy.segment.clustering import QuickBundles
 from dipy.segment.metric import AveragePointwiseEuclideanMetric
-from dipy.tracking.streamline import set_number_of_points
-import numpy as np
 
 
 def remove_similar_streamlines(streamlines, threshold=5, do_avg=False):

--- a/scilpy/segment/recobundlesx.py
+++ b/scilpy/segment/recobundlesx.py
@@ -3,8 +3,8 @@
 from itertools import chain
 import logging
 
-from dipy.align.streamlinear import (BundleMinDistanceMetric,
-                                     StreamlineLinearRegistration)
+from dipy.align.streamlinear import (StreamlineLinearRegistration,
+                                     BundleMinDistanceMetric)
 from dipy.segment.clustering import qbx_and_merge
 from dipy.tracking.distances import bundles_distances_mdf
 from dipy.tracking.streamline import (select_random_set_of_streamlines,

--- a/scilpy/segment/voting_scheme.py
+++ b/scilpy/segment/voting_scheme.py
@@ -9,11 +9,12 @@ import random
 import tempfile
 from time import time
 
-from dipy.segment.clustering import qbx_and_merge
-from dipy.tracking.streamline import transform_streamlines
 import nibabel as nib
 import numpy as np
 from scipy.sparse import lil_matrix
+
+from dipy.segment.clustering import qbx_and_merge
+from dipy.tracking.streamline import transform_streamlines
 
 from scilpy.segment.recobundlesx import RecobundlesX
 

--- a/scilpy/tracking/tools.py
+++ b/scilpy/tracking/tools.py
@@ -2,11 +2,11 @@
 
 import logging
 
-from dipy.tracking.metrics import downsample, length
-from dipy.tracking.streamline import set_number_of_points
 import numpy as np
-from scipy.interpolate import splev, splprep
+from dipy.tracking.metrics import length, downsample
+from dipy.tracking.streamline import set_number_of_points
 from scipy.ndimage.filters import gaussian_filter1d
+from scipy.interpolate import splprep, splev
 
 
 def filter_streamlines_by_length(sft, min_length=0., max_length=np.inf):

--- a/scilpy/tractanalysis/features.py
+++ b/scilpy/tractanalysis/features.py
@@ -4,7 +4,7 @@ from builtins import range
 from itertools import count, takewhile
 import logging
 
-from dipy.segment.clustering import Cluster, QuickBundles, qbx_and_merge
+from dipy.segment.clustering import qbx_and_merge, QuickBundles, Cluster
 from dipy.tracking import metrics as tm
 import numpy as np
 

--- a/scilpy/tractanalysis/reproducibility_measures.py
+++ b/scilpy/tractanalysis/reproducibility_measures.py
@@ -3,14 +3,12 @@ import copy
 
 from dipy.segment.clustering import qbx_and_merge
 from dipy.tracking.distances import bundles_distances_mdf
-from dipy.tracking.streamline import length, set_number_of_points
+from dipy.tracking.streamline import set_number_of_points, length
 import numpy as np
 from numpy.random import RandomState
 from scipy.spatial import cKDTree
-
-from scilpy.utils.streamlines import (intersection,
-                                      perform_streamlines_operation,
-                                      subtraction, union)
+from scilpy.utils.streamlines import (perform_streamlines_operation,
+                                      subtraction, intersection, union)
 
 
 def get_endpoints_density_map(streamlines, dimensions, point_to_select=1):

--- a/scilpy/tractanalysis/tools.py
+++ b/scilpy/tractanalysis/tools.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import division
-
 from builtins import range
 
 import numpy as np

--- a/scilpy/version.py
+++ b/scilpy/version.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import, division, print_function
-
 import glob
 
 # Format expected by setup.py and doc/source/conf.py: string of form "X.Y.Z"


### PR DESCRIPTION
The auto-ordering from Fred modified the agreed import convention.
Reverted the 8 commits rather than reverting individually from GitHub interface.

Numerous instance of `from future import ...`, `from past import ...` or `from builtins import ...` would have to be fixed in the future.