### PR TITLE
ENH: Remove `future` `dvision` and `print_function` imports

### DIFF
--- a/scripts/scil_compute_fodf.py
+++ b/scripts/scil_compute_fodf.py
@@ -14,8 +14,6 @@ See [Tournier et al. NeuroImage 2007] and [Cote et al Tractometer MedIA 2013]
 for quantitative comparisons with Sharpening Deconvolution Transform (SDT)
 """
 
-from __future__ import division
-
 import argparse
 import logging
 

--- a/scripts/scil_compute_mean_frf.py
+++ b/scripts/scil_compute_mean_frf.py
@@ -6,8 +6,6 @@ Compute the mean Fiber Response Function from a set of individually
 computed Response Functions.
 """
 
-from __future__ import division, print_function
-
 import argparse
 import logging
 

--- a/scripts/scil_compute_ssst_frf.py
+++ b/scripts/scil_compute_ssst_frf.py
@@ -8,8 +8,6 @@ A DTI fit is made, and voxels containing a single fiber population are
 found using a threshold on the FA.
 """
 
-from __future__ import division
-
 import argparse
 import logging
 

--- a/scripts/scil_set_response_function.py
+++ b/scripts/scil_set_response_function.py
@@ -9,8 +9,6 @@ and keep the mean b0.
 The FRF file is obtained from scil_compute_ssst_frf.py
 """
 
-from __future__ import division, print_function
-
 import argparse
 from ast import literal_eval
 import numpy as np


### PR DESCRIPTION
Remove `future` `division` and `print_function` imports, which are not necessary
in Python 3.x.