### PR TITLE
ENH: Fix version normalization warning

### DIFF
--- a/scilpy/version.py
+++ b/scilpy/version.py
@@ -6,8 +6,7 @@ import glob
 _version_major = 0
 _version_minor = 1
 _version_micro = ''  # use '' for first of series, number for 1 and above
-_version_extra = 'dev'
-# _version_extra = ''  # Uncomment this for full releases
+_version_extra = 'dev0'
 
 # Construct full version string from these.
 _ver = [_version_major, _version_minor]


### PR DESCRIPTION
Fix version normalization warning.

Fixes:
```
$ python setup.py install_scripts

/home/travis/virtualenv/python3.5.6/lib/python3.5/site-packages/setuptools/dist.py:397:
UserWarning: Normalizing '0.1.dev' to '0.1.dev0'

  normalized_version,
```

reported when running `setup.py`, e.g. in our CI builds:
https://travis-ci.org/github/scilus/scilpy/jobs/662482838#L1283