### PR TITLE
Normalize connectivity scripts

### DIFF
--- a/scilpy/image/operations.py
+++ b/scilpy/image/operations.py
@@ -9,7 +9,6 @@ to apply simple operations on nibabel images or numpy arrays.
 from collections import OrderedDict
 from copy import copy
 import logging
-import sys
 
 import numpy as np
 from scipy.ndimage.filters import gaussian_filter
@@ -19,7 +18,7 @@ from scipy.ndimage.morphology import (binary_closing, binary_dilation,
 from scilpy.utils.util import is_float
 
 
-EPSILON = sys.float_info.epsilon
+EPSILON = np.finfo(float).eps
 
 
 def get_array_ops():

--- a/scilpy/image/operations.py
+++ b/scilpy/image/operations.py
@@ -9,6 +9,7 @@ to apply simple operations on nibabel images or numpy arrays.
 from collections import OrderedDict
 from copy import copy
 import logging
+import sys
 
 import numpy as np
 from scipy.ndimage.filters import gaussian_filter
@@ -16,6 +17,9 @@ from scipy.ndimage.morphology import (binary_closing, binary_dilation,
                                       binary_erosion, binary_opening)
 
 from scilpy.utils.util import is_float
+
+
+EPSILON = sys.float_info.epsilon
 
 
 def get_array_ops():
@@ -235,28 +239,32 @@ def normalize_max(input_list):
 
 def base_10_log(input_list):
     """
-    base_10_log: IMG
+    log_10: IMG
         Apply a log (base 10) to all non zeros values of an image.
     """
     _validate_length(input_list, 1)
     _validate_dtype(input_list[0], np.ndarray)
 
     output_data = np.zeros(input_list[0].shape)
-    output_data[input_list[0] > 0] = np.log10(input_list[0][input_list[0] > 0])
+    output_data[input_list[0] > EPSILON] = np.log10(
+        input_list[0][input_list[0] > EPSILON])
+    output_data[np.abs(output_data) < EPSILON] = -65536
 
     return output_data
 
 
 def natural_log(input_list):
     """
-    natural_log: IMG
+    log_e: IMG
         Apply a natural log to all non zeros values of an image.
     """
     _validate_length(input_list, 1)
     _validate_dtype(input_list[0], np.ndarray)
 
     output_data = np.zeros(input_list[0].shape)
-    output_data[input_list[0] > 0] = np.log(input_list[0][input_list[0] > 0])
+    output_data[input_list[0] > EPSILON] = np.log(
+        input_list[0][input_list[0] > EPSILON])
+    output_data[np.abs(output_data) < EPSILON] = -65536
 
     return output_data
 

--- a/scilpy/io/utils.py
+++ b/scilpy/io/utils.py
@@ -218,7 +218,8 @@ def assert_output_dirs_exist_and_empty(parser, args, *dirs, create_dir=False):
     for cur_dir in dirs:
         if not os.path.isdir(cur_dir):
             if not create_dir:
-                parser.error('Output directory {} doesn\'t exist.'.format(cur_dir))
+                parser.error(
+                    'Output directory {} doesn\'t exist.'.format(cur_dir))
             else:
                 os.makedirs(cur_dir, exist_ok=True)
         if os.listdir(cur_dir):
@@ -265,3 +266,27 @@ def read_info_from_mb_bdo(filename):
     radius = np.asarray(radius, dtype=np.float32)
     center = np.asarray(center, dtype=np.float32)
     return geometry, radius, center
+
+
+def load_matrix_in_any_format(filepath):
+    _, ext = os.path.splitext(filepath)
+    if ext == '.txt':
+        data = np.loadtxt(filepath)
+    elif ext == '.npy':
+        data = np.load(filepath)
+    else:
+        parser.error('Extension {} is not supported'.format(ext))
+        raise ValueError
+
+    return data
+
+
+def save_matrix_in_any_format(filepath, output_data):
+    _, ext = os.path.splitext(filepath)
+    if ext == '.txt':
+        np.savetxt(filepath, output_data)
+    elif ext == '.npy' or ext == '':
+        np.save(filepath, output_data)
+    else:
+        parser.error('Extension {} is not supported'.format(ext))
+        raise ValueError

--- a/scilpy/io/utils.py
+++ b/scilpy/io/utils.py
@@ -284,7 +284,9 @@ def save_matrix_in_any_format(filepath, output_data):
     _, ext = os.path.splitext(filepath)
     if ext == '.txt':
         np.savetxt(filepath, output_data)
-    elif ext == '.npy' or ext == '':
+    elif ext == '.npy':
         np.save(filepath, output_data)
+    elif ext == '':
+        np.save('{}.npy'.format(filepath), output_data)
     else:
         raise ValueError('Extension {} is not supported'.format(ext))

--- a/scilpy/io/utils.py
+++ b/scilpy/io/utils.py
@@ -275,8 +275,7 @@ def load_matrix_in_any_format(filepath):
     elif ext == '.npy':
         data = np.load(filepath)
     else:
-        parser.error('Extension {} is not supported'.format(ext))
-        raise ValueError
+        raise ValueError('Extension {} is not supported'.format(ext))
 
     return data
 
@@ -288,5 +287,4 @@ def save_matrix_in_any_format(filepath, output_data):
     elif ext == '.npy' or ext == '':
         np.save(filepath, output_data)
     else:
-        parser.error('Extension {} is not supported'.format(ext))
-        raise ValueError
+        raise ValueError('Extension {} is not supported'.format(ext))

--- a/scilpy/tractanalysis/reproducibility_measures.py
+++ b/scilpy/tractanalysis/reproducibility_measures.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import copy
-
 from dipy.segment.clustering import qbx_and_merge
 from dipy.tracking.distances import bundles_distances_mdf
 from dipy.tracking.streamline import length, set_number_of_points
@@ -282,6 +280,35 @@ def compute_dice_voxel(density_1, density_2):
         w_dice = np.nan
 
     return dice, w_dice
+
+
+def compute_correlation(density_1, density_2):
+    """
+    Compute the overlap (dice coefficient) between two density maps (or binary).
+    Correlation being less robust to extreme case (no overlap, identical array),
+    a lot of check a needed to prevent NaN.
+    Parameters
+    ----------
+    density_1: ndarray
+        Density (or binary) map computed from the first bundle
+    density_1: ndarray of ndarray
+        Density (or binary) map computed from the second bundle
+    Returns
+    -------
+    float: Value between 0 and 1 that represent the spatial aggrement
+        between both bundles taking into account density.
+    """
+    indices = np.where(density_1 + density_2 > 0)
+    if np.array_equal(density_1, density_2):
+        density_correlation = 1
+    elif (np.sum(density_1) > 0 and np.sum(density_2) > 0) \
+            and np.count_nonzero(density_1 * density_2):
+        density_correlation = np.corrcoef(density_1[indices],
+                                          density_2[indices])[0, 1]
+    else:
+        density_correlation = 0
+
+    return max(0, density_correlation)
 
 
 def compute_dice_streamlines(bundle_1, bundle_2):

--- a/scilpy/tractanalysis/reproducibility_measures.py
+++ b/scilpy/tractanalysis/reproducibility_measures.py
@@ -251,7 +251,7 @@ def compute_dice_voxel(density_1, density_2):
     ----------
     density_1: ndarray
         Density (or binary) map computed from the first bundle
-    density_1: ndarray of ndarray
+    density_2: ndarray
         Density (or binary) map computed from the second bundle
     Returns
     -------
@@ -291,7 +291,7 @@ def compute_correlation(density_1, density_2):
     ----------
     density_1: ndarray
         Density (or binary) map computed from the first bundle
-    density_1: ndarray of ndarray
+    density_2: ndarray
         Density (or binary) map computed from the second bundle
     Returns
     -------

--- a/scripts/scil_compute_connectivity.py
+++ b/scripts/scil_compute_connectivity.py
@@ -42,7 +42,7 @@ from dipy.tracking.streamlinespeed import length
 import nibabel as nib
 import numpy as np
 
-from scilpy.tractanalysis.reproducibility_measures import compute_dice_voxel
+from scilpy.tractanalysis.reproducibility_measures import compute_bundle_adjacency_voxel
 from scilpy.tractanalysis.streamlines_metrics import compute_tract_counts_map
 from scilpy.io.utils import (add_overwrite_arg, add_processes_arg,
                              add_verbose_arg, add_reference_arg,
@@ -67,37 +67,37 @@ def load_node_nifti(directory, in_label, out_label, ref_filename):
             raise IOError
         return nib.load(in_filename).get_data()
 
-    _, dims, _, _=get_reference_info(ref_filename)
+    _, dims, _, _ = get_reference_info(ref_filename)
     return np.zeros(dims)
 
 
 def _processing_wrapper(args):
-    bundles_dir=args[0]
-    in_label, out_label=args[1]
-    measures_to_compute=copy.copy(args[2])
-    weighted=args[3]
+    bundles_dir = args[0]
+    in_label, out_label = args[1]
+    measures_to_compute = copy.copy(args[2])
+    weighted = args[3]
     if args[4] is not None:
-        similarity_directory=args[4][0]
+        similarity_directory = args[4][0]
 
-    in_filename_1=os.path.join(bundles_dir,
+    in_filename_1 = os.path.join(bundles_dir,
                                  '{}_{}.trk'.format(in_label, out_label))
-    in_filename_2=os.path.join(bundles_dir,
+    in_filename_2 = os.path.join(bundles_dir,
                                  '{}_{}.trk'.format(out_label, in_label))
     if os.path.isfile(in_filename_1):
-        in_filename=in_filename_1
+        in_filename = in_filename_1
     elif os.path.isfile(in_filename_2):
-        in_filename=in_filename_2
+        in_filename = in_filename_2
     else:
         return
 
-    sft=load_tractogram(in_filename, 'same')
-    affine, dimensions, voxel_sizes, _=sft.space_attributes
-    measures_to_return={}
+    sft = load_tractogram(in_filename, 'same')
+    affine, dimensions, voxel_sizes, _ = sft.space_attributes
+    measures_to_return = {}
 
     # Precompute to save one transformation, insert later
     if 'length' in measures_to_compute:
-        streamlines_copy=list(sft.get_streamlines_copy())
-        mean_length=np.average(length(streamlines_copy))
+        streamlines_copy = list(sft.get_streamlines_copy())
+        mean_length = np.average(length(streamlines_copy))
 
     # If density is not required, do not compute it
     # Only required for volume, similarity and any metrics
@@ -109,56 +109,58 @@ def _processing_wrapper(args):
               'streamline_count' in measures_to_compute))):
         sft.to_vox()
         sft.to_corner()
-        density=compute_tract_counts_map(sft.streamlines,
+        density = compute_tract_counts_map(sft.streamlines,
                                            dimensions)
 
     if 'volume' in measures_to_compute:
-        measures_to_return['volume']=np.count_nonzero(density) * \
+        measures_to_return['volume'] = np.count_nonzero(density) * \
             np.prod(voxel_sizes)
         measures_to_compute.remove('volume')
     if 'streamline_count' in measures_to_compute:
-        measures_to_return['streamline_count']=len(sft)
+        measures_to_return['streamline_count'] = len(sft)
         measures_to_compute.remove('streamline_count')
     if 'length' in measures_to_compute:
-        measures_to_return['length']=mean_length
+        measures_to_return['length'] = mean_length
         measures_to_compute.remove('length')
     if 'similarity' in measures_to_compute and similarity_directory:
-        density_sim=load_node_nifti(
-            similarity_directory, in_label, out_label, in_filename)
-        _, w_dice=compute_dice_voxel(density, density_sim)
+        density_sim = load_node_nifti(similarity_directory,
+                                      in_label, out_label,
+                                      in_filename)
 
-        measures_to_return['similarity']=w_dice
+        ba_vox = compute_bundle_adjacency_voxel(density, density_sim)
+
+        measures_to_return['similarity'] = ba_vox
         measures_to_compute.remove('similarity')
 
     for measure in measures_to_compute:
         if os.path.isdir(measure):
-            map_dirname=measure
-            map_data=load_node_nifti(
+            map_dirname = measure
+            map_data = load_node_nifti(
                 map_dirname, in_label, out_label, in_filename)
-            measures_to_return[map_dirname]=np.average(
+            measures_to_return[map_dirname] = np.average(
                 map_data[map_data > 0])
         elif os.path.isfile(measure):
-            metric_filename=measure
+            metric_filename = measure
             if not is_header_compatible(metric_filename, sft):
                 logging.error('{} and {} do not have a compatible header'.format(
                     in_filename, metric_filename))
                 raise IOError
 
-            metric_data=nib.load(metric_filename).get_data()
+            metric_data = nib.load(metric_filename).get_data()
             if weighted:
-                density=density / np.max(density)
-                voxels_value=metric_data * density
-                voxels_value=voxels_value[voxels_value > 0]
+                density = density / np.max(density)
+                voxels_value = metric_data * density
+                voxels_value = voxels_value[voxels_value > 0]
             else:
-                voxels_value=metric_data[density > 0]
+                voxels_value = metric_data[density > 0]
 
-            measures_to_return[metric_filename]=np.average(voxels_value)
+            measures_to_return[metric_filename] = np.average(voxels_value)
 
     return {(in_label, out_label): measures_to_return}
 
 
 def _build_arg_parser():
-    p=argparse.ArgumentParser(
+    p = argparse.ArgumentParser(
         description=__doc__,
         formatter_class=argparse.RawTextHelpFormatter,)
     p.add_argument('in_bundles_dir',
@@ -206,14 +208,14 @@ def main():
         parser.error('The directory {} does not exist.'.format(
             args.in_bundles_dir))
 
-    log_level=logging.WARNING
+    log_level = logging.WARNING
     if args.verbose:
-        log_level=logging.INFO
+        log_level = logging.INFO
     logging.basicConfig(level=log_level)
     coloredlogs.install(level=log_level)
 
-    measures_to_compute=[]
-    measures_output_filename=[]
+    measures_to_compute = []
+    measures_output_filename = []
     if args.volume:
         measures_to_compute.append('volume')
         measures_output_filename.append(args.volume)
@@ -227,14 +229,14 @@ def main():
         measures_to_compute.append('similarity')
         measures_output_filename.append(args.similarity[1])
 
-    dict_maps_out_name={}
+    dict_maps_out_name = {}
     if args.maps is not None:
         for in_folder, out_name in args.maps:
             measures_to_compute.append(in_folder)
-            dict_maps_out_name[in_folder]=out_name
+            dict_maps_out_name[in_folder] = out_name
             measures_output_filename.append(out_name)
 
-    dict_metrics_out_name={}
+    dict_metrics_out_name = {}
     if args.metrics is not None:
         for in_name, out_name in args.metrics:
             # Verify that all metrics are compatible with each other
@@ -242,7 +244,7 @@ def main():
                 continue
 
             # This is necessary to support more than one map for weighting
-            dict_metrics_out_name[in_name]=out_name
+            dict_metrics_out_name[in_name] = out_name
             measures_output_filename.append(out_name)
 
     assert_outputs_exist(parser, args, measures_output_filename)
@@ -252,14 +254,14 @@ def main():
     logging.info('The following measures will be computed and save: {}'.format(
         measures_to_compute))
 
-    labels_list=np.loadtxt(args.labels_list, dtype=int).tolist()
+    labels_list = np.loadtxt(args.labels_list, dtype=int).tolist()
 
-    comb_list=list(itertools.combinations(labels_list, r=2))
+    comb_list = list(itertools.combinations(labels_list, r=2))
     if not args.no_self_connection:
         comb_list.extend(zip(labels_list, labels_list))
 
-    pool=multiprocessing.Pool(args.nbr_processes)
-    measures_dict_list=pool.map(_processing_wrapper,
+    pool = multiprocessing.Pool(args.nbr_processes)
+    measures_dict_list = pool.map(_processing_wrapper,
                                   zip(itertools.repeat(args.in_bundles_dir),
                                       comb_list,
                                       itertools.repeat(measures_to_compute),
@@ -268,45 +270,45 @@ def main():
 
     # Removing None entries (combinaisons that do not exist)
     # Fusing the multiprocessing output into a single dictionary
-    measures_dict_list=[it for it in measures_dict_list if it is not None]
-    measures_dict=measures_dict_list[0]
+    measures_dict_list = [it for it in measures_dict_list if it is not None]
+    measures_dict = measures_dict_list[0]
     for dix in measures_dict_list[1:]:
         measures_dict.update(dix)
 
     if args.no_self_connection:
-        total_elem=len(measures_dict.keys())*2
+        total_elem = len(measures_dict.keys())*2
     else:
-        total_elem=len(measures_dict.keys())*2 - len(labels_list)
+        total_elem = len(measures_dict.keys())*2 - len(labels_list)
 
     logging.info('Out of {} node, {} contain values'.format(
         total_elem, len(measures_dict.keys())*2))
 
     # Filling out all the matrices (symmetric) in the order of labels_list
-    nbr_of_measures=len(measures_to_compute)
-    matrix=np.zeros((len(labels_list), len(labels_list), nbr_of_measures))
+    nbr_of_measures = len(measures_to_compute)
+    matrix = np.zeros((len(labels_list), len(labels_list), nbr_of_measures))
     for in_label, out_label in measures_dict:
-        curr_node_dict=measures_dict[(in_label, out_label)]
-        measures_ordering=list(curr_node_dict.keys())
+        curr_node_dict = measures_dict[(in_label, out_label)]
+        measures_ordering = list(curr_node_dict.keys())
         for i, measure in enumerate(curr_node_dict):
-            in_pos=labels_list.index(in_label)
-            out_pos=labels_list.index(out_label)
-            matrix[in_pos, out_pos, i]=curr_node_dict[measure]
-            matrix[out_pos, in_pos, i]=curr_node_dict[measure]
+            in_pos = labels_list.index(in_label)
+            out_pos = labels_list.index(out_label)
+            matrix[in_pos, out_pos, i] = curr_node_dict[measure]
+            matrix[out_pos, in_pos, i] = curr_node_dict[measure]
 
     # Saving the matrices separatly with the specified name
     for i, measure in enumerate(measures_ordering):
         if measure == 'volume':
-            matrix_basename=args.volume
+            matrix_basename = args.volume
         elif measure == 'streamline_count':
-            matrix_basename=args.streamline_count
+            matrix_basename = args.streamline_count
         elif measure == 'length':
-            matrix_basename=args.length
+            matrix_basename = args.length
         elif measure == 'similarity':
-            matrix_basename=args.similarity[1]
+            matrix_basename = args.similarity[1]
         elif measure in dict_metrics_out_name:
-            matrix_basename=dict_metrics_out_name[measure]
+            matrix_basename = dict_metrics_out_name[measure]
         elif measure in dict_maps_out_name:
-            matrix_basename=dict_maps_out_name[measure]
+            matrix_basename = dict_maps_out_name[measure]
 
         np.save(matrix_basename, matrix[:, :, i])
 

--- a/scripts/scil_connectivity_math.py
+++ b/scripts/scil_connectivity_math.py
@@ -10,7 +10,9 @@ import numpy as np
 from scilpy.image.operations import (get_array_ops, get_operations_doc)
 from scilpy.io.utils import (add_overwrite_arg,
                              add_verbose_arg,
-                             assert_outputs_exist)
+                             assert_outputs_exist,
+                             load_matrix_in_any_format,
+                             save_matrix_in_any_format)
 from scilpy.utils.util import is_float
 
 OPERATIONS = get_array_ops()
@@ -64,14 +66,7 @@ def load_data(arg):
             logging.error('Input file %s does not exist', arg)
             raise ValueError
 
-        _, ext = os.path.splitext(arg)
-        if ext == '.txt':
-            data = np.loadtxt(arg)
-        elif ext == '.npy':
-            data = np.load(arg)
-        else:
-            logging.error('Extension {} is not supported'.format(ext))
-            raise ValueError
+        data = load_matrix_in_any_format(arg)
         logging.info('Loaded %s of shape %s and data_type %s',
                      arg, data.shape, data.dtype)
 
@@ -138,13 +133,7 @@ def main():
         output_data = output_data.astype(np.float64)
 
     # Saving in the right format
-    _, ext = os.path.splitext(args.output)
-    if ext == '.txt':
-        np.savetxt(args.output, output_data)
-    elif ext == '.npy' or ext == '':
-        np.save(args.output, output_data)
-    else:
-        parser.error('Extension {} is not supported'.format(ext))
+    save_matrix_in_any_format(args.output, output_data)
 
 
 if __name__ == "__main__":

--- a/scripts/scil_decompose_connectivity.py
+++ b/scripts/scil_decompose_connectivity.py
@@ -235,7 +235,7 @@ def main():
     time2 = time.time()
     logging.info(
         '    Discarded {} streamlines from filtering in {} sec.'.format(
-          original_len - len(sft), round(time2 - time1, 2)))
+            original_len - len(sft), round(time2 - time1, 2)))
     logging.info('    Number of streamlines to process: {}'.format(len(sft)))
 
     # Get all streamlines intersection indices
@@ -267,6 +267,7 @@ def main():
 
     # Saving will be done from streamlines already in the right space
     comb_list = list(itertools.combinations(real_labels, r=2))
+    comb_list.extend(zip(real_labels, real_labels))
 
     iteration_counter = 0
     for in_label, out_label in comb_list:
@@ -379,7 +380,7 @@ def main():
     time2 = time.time()
     logging.info(
         '    Connections post-processing and saving took {} sec.'.format(
-          round(time2 - time1, 2)))
+            round(time2 - time1, 2)))
 
 
 if __name__ == "__main__":

--- a/scripts/scil_normalize_connectivity.py
+++ b/scripts/scil_normalize_connectivity.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+"""
+
+import argparse
+from copy import copy
+import itertools
+
+import nibabel as nib
+import numpy as np
+from sklearn.neighbors import KDTree
+
+from scilpy.io.utils import (add_overwrite_arg,
+                             load_matrix_in_any_format,
+                             save_matrix_in_any_format,
+                             assert_inputs_exist,
+                             assert_outputs_exist)
+
+
+def _build_arg_parser():
+    p = argparse.ArgumentParser(
+        formatter_class=argparse.RawTextHelpFormatter,
+        description=__doc__,)
+
+    p.add_argument('in_matrix',
+                   help='')
+    p.add_argument('out_matrix',
+                   help='')
+
+    node_p = p.add_argument_group('Node-wise options')
+    length = node_p.add_mutually_exclusive_group()
+    length.add_argument('--length', metavar='LENGTH_MATRIX',
+                        help='CORRECT BIAS FOR WM')
+    length.add_argument('--inverse_length', metavar='LENGTH_MATRIX',
+                        help='BOOST FOR INT')
+
+    node_p.add_argument('--bundle_volume', metavar='VOLUME_MATRIX',
+                        help='WM')
+
+    vol = node_p.add_mutually_exclusive_group()
+    vol.add_argument('--parcel_volume', metavar='ATLAS',
+                     help='ALL')
+    vol.add_argument('--parcel_surface', metavar='ATLAS',
+                     help='ALL')
+
+    scaling_p = p.add_argument_group('Scaling options')
+    scale = scaling_p.add_mutually_exclusive_group()
+    scale.add_argument('--max_at_one', action='store_true',
+                       help='')
+    scale.add_argument('--sum_to_one', action='store_true',
+                       help='')
+    scale.add_argument('--log_10', action='store_true',
+                       help='')
+    scale.add_argument('--log_e', action='store_true',
+                       help='')
+
+    add_overwrite_arg(p)
+
+    return p
+
+
+def approximate_surface_node(atlas, node_id):
+    roi = np.zeros(atlas.shape)
+    roi[atlas == node_id] = 1
+    ind = np.argwhere(roi > 0)
+    tree = KDTree(ind)
+    count = np.sum(7 - tree.query_radius(ind, r=1.0, count_only=True))
+
+    return count
+
+
+def main():
+    parser = _build_arg_parser()
+    args = parser.parse_args()
+
+    assert_inputs_exist(parser, args.in_matrix, [args.length,
+                                                 args.inverse_length,
+                                                 args.bundle_volume,
+                                                 args.parcel_volume,
+                                                 args.parcel_surface])
+    assert_outputs_exist(parser, args, args.out_matrix)
+
+    in_matrix = load_matrix_in_any_format(args.in_matrix)
+
+    # Parcel volume and surface normalization require the atlas
+    # This script should be used directly after scil_decompose_connectivity.py
+    if args.parcel_volume or args.parcel_surface:
+        atlas_filepath = args.parcel_volume if args.parcel_volume \
+            else args.parcel_surface
+        atlas_img = nib.load(atlas_filepath)
+        atlas_data = atlas_img.get_fdata().astype(np.int)
+
+        voxels_size = atlas_img.header.get_zooms()[:3]
+        if voxels_size[0] != voxels_size[1] or voxels_size[0] != voxels_size[2]:
+            parser.error('Atlas must have an isotropic resolution.')
+
+        voxels_vol = np.prod(atlas_img.header.get_zooms()[:3])
+        voxels_sur = np.prod(atlas_img.header.get_zooms()[:2])
+
+        # Excluding background (0)
+        labels_list = np.unique(atlas_data)[1:]
+        if len(labels_list) != in_matrix.shape[0] \
+                and len(labels_list) != in_matrix.shape[1]:
+            parser.error('Atlas should have the same number of label as the '
+                         'input matrix.')
+
+    # Normalization can be combined together
+    out_matrix = in_matrix
+    if args.length:
+        length_mat = load_matrix_in_any_format(args.length)
+        out_matrix[length_mat > 0] *= length_mat[length_mat > 0]
+    elif args.inverse_length:
+        length_mat = load_matrix_in_any_format(args.inverse_length)
+        out_matrix[length_mat > 0] /= length_mat[length_mat > 0]
+
+    if args.bundle_volume:
+        volume_mat = load_matrix_in_any_format(args.bundle_volume)
+        out_matrix[volume_mat > 0] /= volume_mat[volume_mat > 0]
+
+    # Node-wise computation are necessary for this type of normalize
+    if args.parcel_volume or args.parcel_surface:
+        out_matrix = copy(in_matrix)
+        pos_list = range(len(labels_list))
+        all_comb = list(itertools.combinations(pos_list, r=2))
+        all_comb.extend(zip(pos_list, pos_list))
+
+        # Prevent useless computions for approximate_surface_node()
+        factor_list = []
+        for label in labels_list:
+            if args.parcel_volume:
+                factor_list.append(np.count_nonzero(
+                    atlas_data == label) * voxels_vol)
+            else:
+                factor_list.append(approximate_surface_node(
+                    atlas_data, label) * voxels_sur)
+
+        for pos_1, pos_2 in all_comb:
+            factor = factor_list[pos_1] + factor_list[pos_2]
+            out_matrix[pos_1, pos_2] /= factor
+            out_matrix[pos_2, pos_1] /= factor
+
+    # Simple scaling of the whole matrix, facilitate comparison across subject
+    if args.max_at_one:
+        out_matrix /= np.max(out_matrix)
+    elif args.sum_to_one:
+        out_matrix /= np.sum(out_matrix)
+    elif args.log_10:
+        out_matrix = np.log10(out_matrix)
+    elif args.log_e:
+        out_matrix = np.log(out_matrix)
+
+    save_matrix_in_any_format(args.out_matrix, out_matrix)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/scil_normalize_connectivity.py
+++ b/scripts/scil_normalize_connectivity.py
@@ -4,24 +4,31 @@
 """
 Normalize a connectivity matrix coming from scil_decompose_connectivity.py.
 3 categories of normalization are avaiable:
-- Edge attributes
-    - length: Multiply each edge by the average bundle length.
-      Compensate for far away connection when using INT seeding.
-    - inverse_length: Divide each edge by the average bundle length.
-      Compensate for big connection when using WM seeding.
-    - bundle_volume: Divide each edge by the average bundle length.
-      Compensate for big connection when using WM seeding.
-- Node attribute
-    - parcel_volume: Divide each edge by the sum of node volume.
-      Compensate for the likelyhood of ending in the node.
-      Compensate seeding bias connection when using INT seeding.
-    - parcel_surface: Divide each edge by the sum of node surface.
-      Compensate for the likelyhood of ending in the node.
-      Compensate for seeding bias connection when using INT seeding.
-- Matrix scaling
-    - max_at_one: Maximum value of the matrix will be set to one.
-    - sum_to_one: Ensure the sum of all edges weight is one
-    - log_10: Apply a base 10 logarithm to all edges weight
+-- Edge attributes
+ - length: Multiply each edge by the average bundle length.
+   Compensate for far away connection when using INT seeding.
+   Cannot be used with inverse_length.
+
+ - inverse_length: Divide each edge by the average bundle length.
+   Compensate for big connection when using WM seeding.
+   Cannot be used with length.
+
+ - bundle_volume: Divide each edge by the average bundle length.
+   Compensate for big connection when using WM seeding.
+
+-- Node attribute (Mutually exclusive)
+ - parcel_volume: Divide each edge by the sum of node volume.
+   Compensate for the likelyhood of ending in the node.
+   Compensate seeding bias connection when using INT seeding.
+
+ - parcel_surface: Divide each edge by the sum of node surface.
+   Compensate for the likelyhood of ending in the node.
+   Compensate for seeding bias connection when using INT seeding.
+
+-- Matrix scaling (Mutually exclusive)
+ - max_at_one: Maximum value of the matrix will be set to one.
+ - sum_to_one: Ensure the sum of all edges weight is one
+ - log_10: Apply a base 10 logarithm to all edges weight
 
 The volume and length matrix should come from the scil_decompose_connectivity.py
 script.
@@ -42,6 +49,7 @@ import nibabel as nib
 import numpy as np
 from sklearn.neighbors import KDTree
 
+from scilpy.image.operations import normalize_max, normalize_sum, base_10_log
 from scilpy.io.utils import (add_overwrite_arg,
                              load_matrix_in_any_format,
                              save_matrix_in_any_format,
@@ -173,11 +181,11 @@ def main():
 
     # Simple scaling of the whole matrix, facilitate comparison across subject
     if args.max_at_one:
-        out_matrix /= np.max(out_matrix)
+        out_matrix = normalize_max([out_matrix])
     elif args.sum_to_one:
-        out_matrix /= np.sum(out_matrix)
+        out_matrix = normalize_sum([out_matrix])
     elif args.log_10:
-        out_matrix = np.log10(out_matrix)
+        out_matrix = base_10_log([out_matrix])
 
     save_matrix_in_any_format(args.out_matrix, out_matrix)
 

--- a/scripts/scil_normalize_connectivity.py
+++ b/scripts/scil_normalize_connectivity.py
@@ -3,7 +3,7 @@
 
 """
 Normalize a connectivity matrix coming from scil_decompose_connectivity.py.
-3 categories of normalization are avaiable:
+3 categories of normalization are available:
 -- Edge attributes
  - length: Multiply each edge by the average bundle length.
    Compensate for far away connection when using INT seeding.
@@ -18,11 +18,11 @@ Normalize a connectivity matrix coming from scil_decompose_connectivity.py.
 
 -- Node attribute (Mutually exclusive)
  - parcel_volume: Divide each edge by the sum of node volume.
-   Compensate for the likelyhood of ending in the node.
+   Compensate for the likelihood of ending in the node.
    Compensate seeding bias connection when using INT seeding.
 
- - parcel_surface: Divide each edge by the sum of node surface.
-   Compensate for the likelyhood of ending in the node.
+ - parcel_surface: Divide each edge by the sum of the node surface.
+   Compensate for the likelihood of ending in the node.
    Compensate for seeding bias connection when using INT seeding.
 
 -- Matrix scaling (Mutually exclusive)
@@ -34,7 +34,7 @@ The volume and length matrix should come from the scil_decompose_connectivity.py
 script.
 
 A review of the type of normalization is available in:
-Colon-Perez, Luis M., et al. "Dimensionless, scale invariant, edge weight
+Colon-Perez, Luis M., et al. "Dimensionless, scale-invariant, edge weight
 metric for the study of complex structural networks." PLOS one 10.7 (2015).
 
 However, the proposed weighting of edge presented in this publication is not
@@ -64,7 +64,7 @@ def _build_arg_parser():
 
     p.add_argument('in_matrix',
                    help='Input connectivity matrix. This is typically a '
-                   'streamline_count matrix.')
+                        'streamline_count matrix.')
     p.add_argument('out_matrix',
                    help='Output matrix.')
 
@@ -78,7 +78,8 @@ def _build_arg_parser():
                         help='Volume matrix use for edge-wise division.')
 
     vol = edge_p.add_mutually_exclusive_group()
-    vol.add_argument('--parcel_volume', nargs=2, metavar=('ATLAS', 'LABELS_LIST'),
+    vol.add_argument('--parcel_volume', nargs=2,
+                     metavar=('ATLAS', 'LABELS_LIST'),
                      help='Atlas and labels list for edge-wise division.')
     vol.add_argument('--parcel_surface', metavar='ATLAS',
                      help='Atlas and labels list for edge-wise division.')

--- a/scripts/scil_normalize_connectivity.py
+++ b/scripts/scil_normalize_connectivity.py
@@ -6,24 +6,24 @@ Normalize a connectivity matrix coming from scil_decompose_connectivity.py.
 3 categories of normalization are available:
 -- Edge attributes
  - length: Multiply each edge by the average bundle length.
-   Compensate for far away connection when using INT seeding.
+   Compensate for far away connections when using interface seeding.
    Cannot be used with inverse_length.
 
  - inverse_length: Divide each edge by the average bundle length.
-   Compensate for big connection when using WM seeding.
+   Compensate for big connections when using white matter seeding.
    Cannot be used with length.
 
  - bundle_volume: Divide each edge by the average bundle length.
-   Compensate for big connection when using WM seeding.
+   Compensate for big connections when using white matter seeding.
 
--- Node attribute (Mutually exclusive)
+-- Node attributes (Mutually exclusive)
  - parcel_volume: Divide each edge by the sum of node volume.
    Compensate for the likelihood of ending in the node.
-   Compensate seeding bias connection when using INT seeding.
+   Compensate seeding bias when using interface seeding.
 
  - parcel_surface: Divide each edge by the sum of the node surface.
    Compensate for the likelihood of ending in the node.
-   Compensate for seeding bias connection when using INT seeding.
+   Compensate for seeding bias when using interface seeding.
 
 -- Matrix scaling (Mutually exclusive)
  - max_at_one: Maximum value of the matrix will be set to one.
@@ -64,24 +64,25 @@ def _build_arg_parser():
 
     p.add_argument('in_matrix',
                    help='Input connectivity matrix. This is typically a '
-                        'streamline_count matrix.')
+                        'streamline_count matrix (.npy).')
     p.add_argument('out_matrix',
-                   help='Output matrix.')
+                   help='Output normalized matrix (.npy).')
 
     edge_p = p.add_argument_group('Edge-wise options')
     length = edge_p.add_mutually_exclusive_group()
     length.add_argument('--length', metavar='LENGTH_MATRIX',
-                        help='Length matrix use for edge-wise multiplication.')
+                        help='Length matrix used for edge-wise multiplication.')
     length.add_argument('--inverse_length', metavar='LENGTH_MATRIX',
-                        help='Length matrix use for edge-wise division.')
+                        help='Length matrix used for edge-wise division.')
     edge_p.add_argument('--bundle_volume', metavar='VOLUME_MATRIX',
-                        help='Volume matrix use for edge-wise division.')
+                        help='Volume matrix used for edge-wise division.')
 
     vol = edge_p.add_mutually_exclusive_group()
     vol.add_argument('--parcel_volume', nargs=2,
                      metavar=('ATLAS', 'LABELS_LIST'),
                      help='Atlas and labels list for edge-wise division.')
-    vol.add_argument('--parcel_surface', metavar='ATLAS',
+    vol.add_argument('--parcel_surface', nargs=2,
+                     metavar=('ATLAS', 'LABELS_LIST'),
                      help='Atlas and labels list for edge-wise division.')
 
     scaling_p = p.add_argument_group('Scaling options')
@@ -89,7 +90,7 @@ def _build_arg_parser():
     scale.add_argument('--max_at_one', action='store_true',
                        help='Scale matrix with maximum value at one.')
     scale.add_argument('--sum_to_one', action='store_true',
-                       help='Scale matrix with sum of all element at one.')
+                       help='Scale matrix with sum of all elements at one.')
     scale.add_argument('--log_10', action='store_true',
                        help='Apply a base 10 logarithm to the matrix.')
 

--- a/scripts/scil_normalize_connectivity.py
+++ b/scripts/scil_normalize_connectivity.py
@@ -51,10 +51,10 @@ from sklearn.neighbors import KDTree
 
 from scilpy.image.operations import normalize_max, normalize_sum, base_10_log
 from scilpy.io.utils import (add_overwrite_arg,
-                             load_matrix_in_any_format,
-                             save_matrix_in_any_format,
                              assert_inputs_exist,
-                             assert_outputs_exist)
+                             assert_outputs_exist,
+                             load_matrix_in_any_format,
+                             save_matrix_in_any_format)
 
 
 def _build_arg_parser():

--- a/scripts/scil_summarize_bundles_similarity_measures.py
+++ b/scripts/scil_summarize_bundles_similarity_measures.py
@@ -33,6 +33,7 @@ from scilpy.tractanalysis.reproducibility_measures \
     import (compute_dice_voxel,
             compute_bundle_adjacency_streamlines,
             compute_bundle_adjacency_voxel,
+            compute_correlation,
             compute_dice_streamlines,
             get_endpoints_density_map)
 from scilpy.tractanalysis.streamlines_metrics import compute_tract_counts_map
@@ -199,18 +200,14 @@ def compute_all_measures(args):
                                                  centroids_2=centroids_2,
                                                  non_overlap=True)
     # These measures are between 0 and 1
-    dice_vox, w_dice_vox = compute_dice_voxel(density_1,
-                                              density_2)
-    indices = np.where(density_1 + density_2 > 0)
-    indices_endpoints = np.where(endpoints_density_1 + endpoints_density_2 > 0)
+    dice_vox, w_dice_vox = compute_dice_voxel(density_1, density_2)
+
     dice_vox_endpoints, w_dice_vox_endpoints = compute_dice_voxel(
         endpoints_density_1,
         endpoints_density_2)
-    density_correlation = np.corrcoef(
-        density_1[indices], density_2[indices])[0, 1]
-    corrcoef = np.corrcoef(endpoints_density_1[indices_endpoints],
-                           endpoints_density_2[indices_endpoints])
-    density_correlation_endpoints = corrcoef[0, 1]
+    density_correlation = compute_correlation(density_1, density_2)
+    density_correlation_endpoints = compute_correlation(endpoints_density_1,
+                                                        endpoints_density_2)
 
     measures_name = ['bundle_adjacency_voxels',
                      'dice_voxels', 'w_dice_voxels',

--- a/scripts/scil_visualize_connectivity.py
+++ b/scripts/scil_visualize_connectivity.py
@@ -95,7 +95,8 @@ def main():
     args = parser.parse_args()
 
     assert_inputs_exist(parser, args.in_matrix)
-    assert_outputs_exist(parser, args, args.out_png)
+    if not args.show_only:
+        assert_outputs_exist(parser, args, args.out_png)
 
     matrix = load_matrix_in_any_format(args.in_matrix)
 

--- a/scripts/tests/test_normalize_connectivity.py
+++ b/scripts/tests/test_normalize_connectivity.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+def test_help_option(script_runner):
+    ret = script_runner.run('scil_normalize_connectivity.py', '--help')
+    assert ret.success


### PR DESCRIPTION
For Sami's project, we needed a script to normalize connectivity matrices.
Some of the options could be achieved through multiple calls to `scil_connectivity_math.py`, but not all (i.e `parcel_volume` and `parcel_surface`)

Other scripts have been modified to handle the usage of logarithm correctly (Around 0) and to make it easier to load/save connectivity matrices. Now that there are more 3-4 scripts related to connectivity, some refactoring was required to avoid duplicated code.

Minor modification to scil_compute_connectivity.py and scil_visualize_connectivity.py (scripts typically being called before and after so they work well together for Sami's project)

These scripts will likely be modified in the future, right now it is being designed with only two projects in mind as an example use case (retroactively Jasmeen, currently Sami)

Data for testing:
https://drive.google.com/open?id=1kdAZlTmz667XdgKkYysQmksH_HZPSGPY

(Sorry about `scripts/scil_compute_connectivity.py`, pep8 was messed up (by me) in a previous PR and now autopep8 added back all the space between operators, 99% of diff in that file are just that. The 1% was to switch the similarity measure from `w_dice` to `bundle_adjency_voxel`)