### PR TITLE
Improved the handling of invalid streamlines

### DIFF
--- a/scilpy/utils/streamlines.py
+++ b/scilpy/utils/streamlines.py
@@ -125,7 +125,7 @@ def perform_streamlines_operation(operation, streamlines, precision=None):
     return streamlines, indices
 
 
-def warp_streamlines(sft, deformation_data, source):
+def warp_streamlines(sft, deformation_data, source='ants'):
     """ Warp tractogram using a deformation map. Apply warp in-place.
     Support Ants and Dipy deformation map.
 

--- a/scripts/scil_apply_transform_to_tractogram.py
+++ b/scripts/scil_apply_transform_to_tractogram.py
@@ -8,7 +8,7 @@ For more information on how to use the various registration scripts
 see the doc/tractogram_registration.md readme file
 
 Applying transformation to tractogram can lead to invalid streamlines (out of
-the bbox), three strategies are available:
+the bounding box), three strategies are available:
 - default, crash at saving if invalid streamlines are present
 - --keep_invalid, save invalid streamlines. Leave it to the user to run
     scil_remove_invalid_streamlines.py if needed.
@@ -39,7 +39,7 @@ def _build_arg_parser():
                    help='Path of the reference target file (trk or nii).')
     p.add_argument('transformation',
                    help='Path of the file containing the 4x4 \n'
-                        'transformation, matrix (*.txt).'
+                        'transformation, matrix (*.txt).\n'
                         'See the script description for more information.')
     p.add_argument('out_tractogram',
                    help='Output tractogram filename (transformed data).')
@@ -49,9 +49,11 @@ def _build_arg_parser():
 
     invalid = p.add_mutually_exclusive_group()
     invalid.add_argument('--remove_invalid', action='store_true',
-                         help='Remove the streamlines landing out of the bbox.')
+                         help='Remove the streamlines landing out of the '
+                              'bounding box.')
     invalid.add_argument('--keep_invalid', action='store_true',
-                         help='Keep the streamlines landing out of the bbox.')
+                         help='Keep the streamlines landing out of the '
+                              'bounding box.')
 
     add_reference_arg(p)
     add_overwrite_arg(p)

--- a/scripts/scil_apply_transform_to_tractogram.py
+++ b/scripts/scil_apply_transform_to_tractogram.py
@@ -9,10 +9,10 @@ see the doc/tractogram_registration.md readme file
 
 Applying transformation to tractogram can lead to invalid streamlines (out of
 the bounding box), three strategies are available:
-- default, crash at saving if invalid streamlines are present
-- --keep_invalid, save invalid streamlines. Leave it to the user to run
+1) default, crash at saving if invalid streamlines are present
+2) --keep_invalid, save invalid streamlines. Leave it to the user to run
     scil_remove_invalid_streamlines.py if needed.
-- --remove_invalid, automatically remove invalid streamlines before saving.
+3) --remove_invalid, automatically remove invalid streamlines before saving.
     Should not remove more than a few streamlines.
 """
 

--- a/scripts/scil_apply_transform_to_tractogram.py
+++ b/scripts/scil_apply_transform_to_tractogram.py
@@ -6,6 +6,14 @@ Transform tractogram using an affine/rigid transformation.
 
 For more information on how to use the various registration scripts
 see the doc/tractogram_registration.md readme file
+
+Applying transformation to tractogram can lead to invalid streamlines (out of
+the bbox), three strategies are available:
+- default, crash at saving if invalid streamlines are present
+- --keep_invalid, save invalid streamlines. Leave it to the user to run
+    scil_remove_invalid_streamlines.py if needed.
+- --remove_invalid, automatically remove invalid streamlines before saving.
+    Should not remove more than a few streamlines.
 """
 
 import argparse
@@ -41,9 +49,9 @@ def _build_arg_parser():
 
     invalid = p.add_mutually_exclusive_group()
     invalid.add_argument('--remove_invalid', action='store_true',
-                   help='Remove the streamlines landing out of the bbox.')
+                         help='Remove the streamlines landing out of the bbox.')
     invalid.add_argument('--keep_invalid', action='store_true',
-                   help='Keep the streamlines landing out of the bbox.')
+                         help='Keep the streamlines landing out of the bbox.')
 
     add_reference_arg(p)
     add_overwrite_arg(p)

--- a/scripts/scil_apply_transform_to_tractogram.py
+++ b/scripts/scil_apply_transform_to_tractogram.py
@@ -60,7 +60,8 @@ def main():
     assert_outputs_exist(parser, args, args.out_tractogram)
 
     moving_sft = load_tractogram_with_reference(parser, args,
-                                                args.moving_tractogram)
+                                                args.moving_tractogram,
+                                                bbox_check=False)
 
     transfo = np.loadtxt(args.transformation)
     if args.inverse:

--- a/scripts/scil_apply_warp_to_tractogram.py
+++ b/scripts/scil_apply_warp_to_tractogram.py
@@ -2,13 +2,13 @@
 # -*- coding: utf-8 -*-
 
 """
-Warp tractogram using a non linear deformation from an ANTs deformation map.
+Warp tractogram using a non linear deformation from an ANTs deformation field.
 
 For more information on how to use the various registration scripts
 see the doc/tractogram_registration.md readme file
 
 Applying transformation to tractogram can lead to invalid streamlines (out of
-the bbox), three strategies are available:
+the bounding box), three strategies are available:
 - default, crash at saving if invalid streamlines are present
 - --keep_invalid, save invalid streamlines. Leave it to the user to run
     scil_remove_invalid_streamlines.py if needed.
@@ -46,9 +46,11 @@ def _build_arg_parser():
 
     invalid = p.add_mutually_exclusive_group()
     invalid.add_argument('--remove_invalid', action='store_true',
-                         help='Remove the streamlines landing out of the bbox.')
+                         help='Remove the streamlines landing out of the '
+                              'bounding box.')
     invalid.add_argument('--keep_invalid', action='store_true',
-                         help='Keep the streamlines landing out of the bbox.')
+                         help='Keep the streamlines landing out of the '
+                              'bounding box.')
 
     add_overwrite_arg(p)
     add_reference_arg(p)

--- a/scripts/scil_apply_warp_to_tractogram.py
+++ b/scripts/scil_apply_warp_to_tractogram.py
@@ -9,10 +9,10 @@ see the doc/tractogram_registration.md readme file
 
 Applying transformation to tractogram can lead to invalid streamlines (out of
 the bounding box), three strategies are available:
-- default, crash at saving if invalid streamlines are present
-- --keep_invalid, save invalid streamlines. Leave it to the user to run
+1) default, crash at saving if invalid streamlines are present
+2) --keep_invalid, save invalid streamlines. Leave it to the user to run
     scil_remove_invalid_streamlines.py if needed.
-- --remove_invalid, automatically remove invalid streamlines before saving.
+3) --remove_invalid, automatically remove invalid streamlines before saving.
     Should not remove more than a few streamlines.
 """
 

--- a/scripts/scil_apply_warp_to_tractogram.py
+++ b/scripts/scil_apply_warp_to_tractogram.py
@@ -6,9 +6,18 @@ Warp tractogram using a non linear deformation from an ANTs deformation map.
 
 For more information on how to use the various registration scripts
 see the doc/tractogram_registration.md readme file
+
+Applying transformation to tractogram can lead to invalid streamlines (out of
+the bbox), three strategies are available:
+- default, crash at saving if invalid streamlines are present
+- --keep_invalid, save invalid streamlines. Leave it to the user to run
+    scil_remove_invalid_streamlines.py if needed.
+- --remove_invalid, automatically remove invalid streamlines before saving.
+    Should not remove more than a few streamlines.
 """
 
 import argparse
+import logging
 
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
 from dipy.io.streamline import save_tractogram

--- a/scripts/scil_remove_invalid_streamlines.py
+++ b/scripts/scil_remove_invalid_streamlines.py
@@ -8,7 +8,9 @@ Any streamline that do not respect these two conditions are removed.
 """
 
 import argparse
+import logging
 
+from dipy.io.stateful_tractogram import StatefulTractogram
 from dipy.io.streamline import save_tractogram
 
 from scilpy.io.streamlines import load_tractogram_with_reference
@@ -23,10 +25,12 @@ def _build_arg_parser():
     p.add_argument('in_tractogram', metavar='IN_TRACTOGRAM',
                    help='Tractogram filename. Format must be one of \n'
                         'trk, tck, vtk, fib, dpy.')
-
     p.add_argument('output_name', metavar='OUTPUT_NAME',
                    help='Output filename. Format must be one of \n'
                         'trk, tck, vtk, fib, dpy.')
+
+    p.add_argument('--remove_single_point', action='store_true',
+                   help='Consider single point streamlines invalid.')
 
     add_reference_arg(p)
     add_overwrite_arg(p)
@@ -43,8 +47,22 @@ def main():
 
     sft = load_tractogram_with_reference(parser, args, args.in_tractogram,
                                          bbox_check=False)
+    ori_len = len(sft)
     sft.remove_invalid_streamlines()
-    save_tractogram(sft, args.output_name)
+
+    if args.remove_single_point:
+        # Will try to do a PR in Dipy
+        indices = [i for i in range(len(sft)) if len(sft.streamlines[i]) > 1]
+    else:
+        indices = range(len(sft))
+
+    new_sft = StatefulTractogram.from_sft(
+        sft.streamlines[indices], sft,
+        data_per_point=sft.data_per_point[indices],
+        data_per_streamline=sft.data_per_streamline[indices])
+    logging.warning('Removed {} invalid streamlines.'.format(
+        ori_len - len(new_sft)))
+    save_tractogram(new_sft, args.output_name)
 
 
 if __name__ == "__main__":

--- a/scripts/scil_remove_invalid_streamlines.py
+++ b/scripts/scil_remove_invalid_streamlines.py
@@ -23,10 +23,10 @@ def _build_arg_parser():
     p = argparse.ArgumentParser(description=__doc__,
                                 formatter_class=argparse.RawTextHelpFormatter)
 
-    p.add_argument('in_tractogram', metavar='IN_TRACTOGRAM',
+    p.add_argument('in_tractogram',
                    help='Tractogram filename. Format must be one of \n'
                         'trk, tck, vtk, fib, dpy.')
-    p.add_argument('out_tractogram', metavar='OUTPUT_NAME',
+    p.add_argument('out_tractogram',
                    help='Output filename. Format must be one of \n'
                         'trk, tck, vtk, fib, dpy.')
 

--- a/scripts/scil_remove_invalid_streamlines.py
+++ b/scripts/scil_remove_invalid_streamlines.py
@@ -26,7 +26,7 @@ def _build_arg_parser():
     p.add_argument('in_tractogram', metavar='IN_TRACTOGRAM',
                    help='Tractogram filename. Format must be one of \n'
                         'trk, tck, vtk, fib, dpy.')
-    p.add_argument('output_name', metavar='OUTPUT_NAME',
+    p.add_argument('out_tractogram', metavar='OUTPUT_NAME',
                    help='Output filename. Format must be one of \n'
                         'trk, tck, vtk, fib, dpy.')
 
@@ -46,20 +46,17 @@ def main():
     args = parser.parse_args()
 
     assert_inputs_exist(parser, args.in_tractogram, args.reference)
-    assert_outputs_exist(parser, args, args.output_name)
+    assert_outputs_exist(parser, args, args.out_tractogram)
 
     sft = load_tractogram_with_reference(parser, args, args.in_tractogram,
                                          bbox_check=False)
-    print('loaded')
     ori_len = len(sft)
     sft.remove_invalid_streamlines()
-    print('bbox')
 
     indices = []
     if args.remove_single_point:
         # Will try to do a PR in Dipy
         indices = [i for i in range(len(sft)) if len(sft.streamlines[i]) <= 1]
-        print('single')
 
     if args.remove_overlapping_points:
         for i in range(len(sft)):
@@ -75,7 +72,7 @@ def main():
         data_per_streamline=sft.data_per_streamline[indices])
     logging.warning('Removed {} invalid streamlines.'.format(
         ori_len - len(new_sft)))
-    save_tractogram(new_sft, args.output_name)
+    save_tractogram(new_sft, args.out_tractogram)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Applying transformation to tractograms can lead to invalid streamlines (out of
the bbox), three strategies are available:
    - default, crash at saving if invalid streamlines are present
    --keep_invalid, save invalid streamlines. Leave it to the user to run
        scil_remove_invalid_streamlines.py if needed.
    --remove_invalid, automatically remove invalid streamlines before saving.
        Should not remove more than a few streamlines.

The scil_remove_invalid_streamlines.py can now handle single point streamlines if desired.

Both of these enhancements were required for Kurt project, which is a nice large scale use case.