### PR TITLE
Added the cut options for streamlines

### DIFF
--- a/scilpy/utils/streamlines.py
+++ b/scilpy/utils/streamlines.py
@@ -289,7 +289,22 @@ def compress_sft(sft, tol_error=0.01):
 
 
 def cut_invalid_streamlines(sft):
-    """ Cut streamlines so their longest segment are within the bounding box """
+    """ Cut streamlines so their longest segment are within the bounding box.
+    This function keeps the data_per_point and data_per_streamline.
+
+    Parameters
+    ----------
+    sft: StatefulTractogram
+        The sft to remove invalid points from.
+
+    Returns
+    -------
+    new_sft : StatefulTractogram
+        New object with the invalid points removed from each streamline.
+    cutting_counter : int
+        Number of streamlines that were cut.
+    """
+
     sft.to_vox()
     sft.to_corner()
 
@@ -302,6 +317,7 @@ def cut_invalid_streamlines(sft):
     for key in sft.data_per_point.keys():
         new_data_per_point[key] = []
 
+    cutting_counter = 0
     for ind in range(len(sft.streamlines)):
         # No reason to try to cut if all points are within the volume
         if ind in indices_to_remove:
@@ -317,6 +333,7 @@ def cut_invalid_streamlines(sft):
             if not best_pos == [0, 0]:
                 new_streamlines.append(
                     sft.streamlines[ind][best_pos[0]:best_pos[1]])
+                cutting_counter += 1
                 for key in sft.data_per_point.keys():
                     new_data_per_point[key].append(
                         sft.data_per_point[key][ind][best_pos[0]:best_pos[1]])
@@ -330,4 +347,4 @@ def cut_invalid_streamlines(sft):
                                           data_per_streamline=sft.data_per_streamline,
                                           data_per_point=new_data_per_point)
 
-    return new_sft
+    return new_sft, cutting_counter

--- a/scilpy/utils/streamlines.py
+++ b/scilpy/utils/streamlines.py
@@ -343,7 +343,7 @@ def cut_invalid_streamlines(sft):
                         sft.data_per_streamline[key][ind])
                 for key in sft.data_per_point.keys():
                     new_data_per_point[key].append(
-                        sft.data_per_point[key][ind][best_pos[0]:best_pos[1]])
+                        sft.data_per_point[key][ind][best_pos[0]:best_pos[1]-1])
             else:
                 logging.warning('Streamlines entirely out of the volume.')
         else:

--- a/scilpy/utils/streamlines.py
+++ b/scilpy/utils/streamlines.py
@@ -312,8 +312,8 @@ def cut_invalid_streamlines(sft):
     sft.to_corner()
 
     copy_sft = copy.deepcopy(sft)
-    indices_to_remove, indices_to_keep = copy_sft.remove_invalid_streamlines()
     epsilon = 0.001
+    indices_to_remove, indices_to_keep = copy_sft.remove_invalid_streamlines()
 
     new_streamlines = []
     new_data_per_point = {}
@@ -328,7 +328,7 @@ def cut_invalid_streamlines(sft):
             best_pos = [0, 0]
             cur_pos = [0, 0]
             for pos, point in enumerate(sft.streamlines[ind]):
-                if (point < epsilon).any() or (point >= sft.dimensions).any():
+                if (point < epsilon).any() or (point >= sft.dimensions - epsilon).any():
                     cur_pos = [pos+1, pos+1]
                 if cur_pos[1] - cur_pos[0] > best_pos[1] - best_pos[0]:
                     best_pos = cur_pos
@@ -336,7 +336,7 @@ def cut_invalid_streamlines(sft):
 
             if not best_pos == [0, 0]:
                 new_streamlines.append(
-                    sft.streamlines[ind][best_pos[0]:best_pos[1]])
+                    sft.streamlines[ind][best_pos[0]:best_pos[1]-1])
                 cutting_counter += 1
                 for key in sft.data_per_streamline.keys():
                     new_data_per_streamline[key].append(

--- a/scilpy/utils/streamlines.py
+++ b/scilpy/utils/streamlines.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import copy
 from functools import reduce
 import itertools
 import logging
@@ -285,3 +286,48 @@ def compress_sft(sft, tol_error=0.01):
     compressed_sft.to_space(orig_space)
 
     return compressed_sft
+
+
+def cut_invalid_streamlines(sft):
+    """ Cut streamlines so their longest segment are within the bounding box """
+    sft.to_vox()
+    sft.to_corner()
+
+    copy_sft = copy.deepcopy(sft)
+    indices_to_remove, indices_to_keep = copy_sft.remove_invalid_streamlines()
+    epsilon = 0.001
+
+    new_streamlines = []
+    new_data_per_point = {}
+    for key in sft.data_per_point.keys():
+        new_data_per_point[key] = []
+
+    for ind in range(len(sft.streamlines)):
+        # No reason to try to cut if all points are within the volume
+        if ind in indices_to_remove:
+            best_pos = [0, 0]
+            cur_pos = [0, 0]
+            for pos, point in enumerate(sft.streamlines[ind]):
+                if (point < epsilon).any() or (point >= sft.dimensions).any():
+                    cur_pos = [pos+1, pos+1]
+                if cur_pos[1] - cur_pos[0] > best_pos[1] - best_pos[0]:
+                    best_pos = cur_pos
+                cur_pos[1] += 1
+
+            if not best_pos == [0, 0]:
+                new_streamlines.append(
+                    sft.streamlines[ind][best_pos[0]:best_pos[1]])
+                for key in sft.data_per_point.keys():
+                    new_data_per_point[key].append(
+                        sft.data_per_point[key][ind][best_pos[0]:best_pos[1]])
+            else:
+                logging.warning('Streamlines entirely out of the volume.')
+        else:
+            new_streamlines.append(sft.streamlines[ind])
+            for key in sft.data_per_point.keys():
+                new_data_per_point[key].append(sft.data_per_point[key][ind])
+    new_sft = StatefulTractogram.from_sft(new_streamlines, sft,
+                                          data_per_streamline=sft.data_per_streamline,
+                                          data_per_point=new_data_per_point)
+
+    return new_sft

--- a/scripts/scil_apply_transform_to_tractogram.py
+++ b/scripts/scil_apply_transform_to_tractogram.py
@@ -26,11 +26,9 @@ import numpy as np
 
 from scilpy.io.streamlines import load_tractogram_with_reference
 from scilpy.io.utils import (add_overwrite_arg, add_reference_arg,
-                             assert_inputs_exist, assert_outputs_exist)
-from scilpy.utils.streamlines import (assert_inputs_exist,
-                                      assert_outputs_exist,
-                                      cut_invalid_streamlines,
-                                      load_matrix_in_any_format)
+                             assert_inputs_exist, assert_outputs_exist,
+                             load_matrix_in_any_format)
+from scilpy.utils.streamlines import cut_invalid_streamlines
 
 
 def _build_arg_parser():

--- a/scripts/scil_apply_transform_to_tractogram.py
+++ b/scripts/scil_apply_transform_to_tractogram.py
@@ -27,6 +27,7 @@ import numpy as np
 from scilpy.io.streamlines import load_tractogram_with_reference
 from scilpy.io.utils import (add_overwrite_arg, add_reference_arg,
                              assert_inputs_exist, assert_outputs_exist)
+from scilpy.utils.streamlines import cut_invalid_streamlines
 
 
 def _build_arg_parser():
@@ -48,6 +49,9 @@ def _build_arg_parser():
                    help='Apply the inverse transformation.')
 
     invalid = p.add_mutually_exclusive_group()
+    invalid.add_argument('--cut_invalid', action='store_true',
+                         help='Cut invalid streamlines rather than removing them.\n'
+                         'Keep the longest segment only.')
     invalid.add_argument('--remove_invalid', action='store_true',
                          help='Remove the streamlines landing out of the '
                               'bounding box.')
@@ -84,7 +88,10 @@ def main():
                                  data_per_point=moving_sft.data_per_point,
                                  data_per_streamline=moving_sft.data_per_streamline)
 
-    if args.remove_invalid:
+    if args.cut_invalid:
+        new_sft = cut_invalid_streamlines(new_sft)
+        save_tractogram(new_sft, args.out_tractogram)
+    elif args.remove_invalid:
         ori_len = len(new_sft)
         new_sft.remove_invalid_streamlines()
         logging.warning('Removed {} invalid streamlines.'.format(

--- a/scripts/scil_apply_warp_to_tractogram.py
+++ b/scripts/scil_apply_warp_to_tractogram.py
@@ -28,7 +28,7 @@ import numpy as np
 from scilpy.io.streamlines import load_tractogram_with_reference
 from scilpy.io.utils import (add_overwrite_arg, add_reference_arg,
                              assert_inputs_exist, assert_outputs_exist)
-from scilpy.utils.streamlines import warp_streamlines
+from scilpy.utils.streamlines import warp_streamlines, cut_invalid_streamlines
 
 
 def _build_arg_parser():
@@ -45,6 +45,9 @@ def _build_arg_parser():
                    help='Output filename of the transformed tractogram.')
 
     invalid = p.add_mutually_exclusive_group()
+    invalid.add_argument('--cut_invalid', action='store_true',
+                         help='Cut invalid streamlines rather than removing them.\n'
+                         'Keep the longest segment only.')
     invalid.add_argument('--remove_invalid', action='store_true',
                          help='Remove the streamlines landing out of the '
                               'bounding box.')
@@ -83,7 +86,10 @@ def main():
                                  data_per_point=sft.data_per_point,
                                  data_per_streamline=sft.data_per_streamline)
 
-    if args.remove_invalid:
+    if args.cut_invalid:
+        new_sft = cut_invalid_streamlines(new_sft)
+        save_tractogram(new_sft, args.out_tractogram)
+    elif args.remove_invalid:
         ori_len = len(new_sft)
         new_sft.remove_invalid_streamlines()
         logging.warning('Removed {} invalid streamlines.'.format(

--- a/scripts/scil_remove_invalid_streamlines.py
+++ b/scripts/scil_remove_invalid_streamlines.py
@@ -22,6 +22,7 @@ from scilpy.io.utils import (add_overwrite_arg, add_reference_arg,
                              assert_inputs_exist, assert_outputs_exist)
 from scilpy.utils.streamlines import cut_invalid_streamlines
 
+
 def _build_arg_parser():
     p = argparse.ArgumentParser(description=__doc__,
                                 formatter_class=argparse.RawTextHelpFormatter)
@@ -58,7 +59,8 @@ def main():
                                          bbox_check=False)
     ori_len = len(sft)
     if args.cut_invalid:
-        sft = cut_invalid_streamlines(sft)
+        sft, cutting_counter = cut_invalid_streamlines(sft)
+        logging.warning('Cut {} invalid streamlines.'.format(cutting_counter))
     else:
         sft.remove_invalid_streamlines()
 

--- a/scripts/scil_remove_invalid_streamlines.py
+++ b/scripts/scil_remove_invalid_streamlines.py
@@ -6,7 +6,7 @@ Removal of streamlines that are out of the volume bounding box. In voxel space
 no negative coordinate and no above volume dimension coordinate are possible.
 Any streamline that do not respect these two conditions are removed.
 
-The --cut_invalid option will cut streamlines so their longest segment are
+The --cut_invalid option will cut streamlines so that their longest segment are
 within the bounding box
 """
 

--- a/scripts/scil_remove_invalid_streamlines.py
+++ b/scripts/scil_remove_invalid_streamlines.py
@@ -22,7 +22,6 @@ from scilpy.io.utils import (add_overwrite_arg, add_reference_arg,
                              assert_inputs_exist, assert_outputs_exist)
 from scilpy.utils.streamlines import cut_invalid_streamlines
 
-
 def _build_arg_parser():
     p = argparse.ArgumentParser(description=__doc__,
                                 formatter_class=argparse.RawTextHelpFormatter)

--- a/scripts/scil_remove_invalid_streamlines.py
+++ b/scripts/scil_remove_invalid_streamlines.py
@@ -5,6 +5,9 @@
 Removal of streamlines that are out of the volume bounding box. In voxel space
 no negative coordinate and no above volume dimension coordinate are possible.
 Any streamline that do not respect these two conditions are removed.
+
+The --cut_invalid option will cut streamlines so their longest segment are
+within the bounding box
 """
 
 import argparse
@@ -17,6 +20,7 @@ import numpy as np
 from scilpy.io.streamlines import load_tractogram_with_reference
 from scilpy.io.utils import (add_overwrite_arg, add_reference_arg,
                              assert_inputs_exist, assert_outputs_exist)
+from scilpy.utils.streamlines import cut_invalid_streamlines
 
 
 def _build_arg_parser():
@@ -30,6 +34,9 @@ def _build_arg_parser():
                    help='Output filename. Format must be one of \n'
                         'trk, tck, vtk, fib, dpy.')
 
+    p.add_argument('--cut_invalid', action='store_true',
+                   help='Cut invalid streamlines rather than removing them.\n'
+                        'Keep the longest segment only.')
     p.add_argument('--remove_single_point', action='store_true',
                    help='Consider single point streamlines invalid.')
     p.add_argument('--remove_overlapping_points', action='store_true',
@@ -51,7 +58,10 @@ def main():
     sft = load_tractogram_with_reference(parser, args, args.in_tractogram,
                                          bbox_check=False)
     ori_len = len(sft)
-    sft.remove_invalid_streamlines()
+    if args.cut_invalid:
+        sft = cut_invalid_streamlines(sft)
+    else:
+        sft.remove_invalid_streamlines()
 
     indices = []
     if args.remove_single_point:


### PR DESCRIPTION
Here is a small addition to `scil_remove_invalid_streamlines.py` that will cut streamlines that are out of the volume bounding box (and remove the streamline if it is 100% out). It is optional with `--cut_invalid`, however it could be argued that it should be our default.

In order to keep the data_per_point on the rest of the streamline, I am not resampling or using a line-based strategy. This will simply remove the entire segment if one of their points is out. So if the step-size is 10mm, and the segment is out of the bounding box by 1mm it means the 9mm that is perfectly valid will be removed too.

This is only a slight upgrade from removing the entire streamline.
[tiny_test_cut_PR.zip](https://github.com/scilus/scilpy/files/4595447/tiny_test_cut_PR.zip)

