### PR TITLE
Skip indices with single points

### DIFF
--- a/scripts/scil_apply_transform_to_tractogram.py
+++ b/scripts/scil_apply_transform_to_tractogram.py
@@ -90,7 +90,7 @@ def main():
                                  data_per_streamline=moving_sft.data_per_streamline)
 
     if args.cut_invalid:
-        new_sft = cut_invalid_streamlines(new_sft)
+        new_sft, _ = cut_invalid_streamlines(new_sft)
         save_tractogram(new_sft, args.out_tractogram)
     elif args.remove_invalid:
         ori_len = len(new_sft)

--- a/scripts/scil_apply_warp_to_tractogram.py
+++ b/scripts/scil_apply_warp_to_tractogram.py
@@ -87,7 +87,7 @@ def main():
                                  data_per_streamline=sft.data_per_streamline)
 
     if args.cut_invalid:
-        new_sft = cut_invalid_streamlines(new_sft)
+        new_sft, _ = cut_invalid_streamlines(new_sft)
         save_tractogram(new_sft, args.out_tractogram)
     elif args.remove_invalid:
         ori_len = len(new_sft)

--- a/scripts/scil_remove_invalid_streamlines.py
+++ b/scripts/scil_remove_invalid_streamlines.py
@@ -68,9 +68,10 @@ def main():
     if args.remove_single_point:
         # Will try to do a PR in Dipy
         indices = [i for i in range(len(sft)) if len(sft.streamlines[i]) <= 1]
+        remaining_indices = np.setdiff1d(range(len(sft)), indices)
 
     if args.remove_overlapping_points:
-        for i in range(len(sft)):
+        for i in remaining_indices:
             norm = np.linalg.norm(np.gradient(sft.streamlines[i],
                                               axis=0), axis=1)
             if (norm < 0.001).any():


### PR DESCRIPTION
Solves bug (Max) with SET output for Sami's project.

`ValueError: Shape of array too small to calculate a numerical gradient, at least (edge_order + 1) elements are required.`