### PR TITLE
Remove normalisation COMMIT

### DIFF
--- a/scilpy/io/fetcher.py
+++ b/scilpy/io/fetcher.py
@@ -35,7 +35,7 @@ def get_testing_files_dict():
              '12e901e899ee48bdf31b25f22d39ee48'],
             'connectivity.zip':
             ['1lZqiOKmwTluPIRqblthOnBc4KI2kfKUC',
-             '2fed405d8241b9b5fc43e6d640008ae9'],
+             'c5e68da9d60c7ebff920144ba602ad66'],
             'filtering.zip':
             ['1yzHSL4tBtmm_aeI1i0qJhrA9z040k0im',
              'dbe796fb75c3e1e5559fad3308982769'],
@@ -53,7 +53,7 @@ def get_testing_files_dict():
              '78129871fbefadf5cede7b1c6a7c9cc5'],
             'tractometry.zip':
             ['130mxBo4IJWPnDFyOELSYDif1puRLGHMX',
-             '32f938ae33a6c185346d2574240ebf3b']}
+             '3e27625a1e7f2484b7fa5028c95324cc']}
 
 
 def _get_file_md5(filename):
@@ -141,6 +141,7 @@ def fetch_data(files_dict, keys=None):
             gdd.download_file_from_google_drive(file_id=url,
                                                 dest_path=full_path,
                                                 unzip=False)
+
             if check_md5(full_path, md5):
                 break
             else:

--- a/scripts/scil_run_commit.py
+++ b/scripts/scil_run_commit.py
@@ -258,7 +258,7 @@ def main():
         # Setting up the tractogram and nifti files
         trk2dictionary.run(filename_tractogram=args.in_tractogram,
                            filename_peaks=args.in_peaks,
-                           peaks_use_affine=False,
+                           peaks_use_affine=True,
                            filename_mask=args.in_tracking_mask,
                            ndirs=args.nbr_dir,
                            gen_trk=False,
@@ -267,6 +267,7 @@ def main():
         # Preparation for fitting
         commit.core.setup(ndirs=args.nbr_dir)
         mit = commit.Evaluation('.', '.')
+        mit.set_config('doNormalizeSignal', False)
         mit.load_data(args.in_dwi, tmp_scheme_filename)
         mit.set_model('StickZeppelinBall')
 

--- a/scripts/scil_run_commit.py
+++ b/scripts/scil_run_commit.py
@@ -117,8 +117,7 @@ def _build_arg_parser():
     g1.add_argument('--perp_diff', nargs='+', type=float,
                     help='Perpendicular diffusivity in mm^2/s.\n'
                          'Default for ball_stick: None\n'
-                         'Default for stick_zeppelin_ball: '
-                         '[1.19E-3, 0.85E-3, 0.51E-3, 0.17E-3]')
+                         'Default for stick_zeppelin_ball: [0.85E-3, 0.51E-3]')
     g1.add_argument('--iso_diff', nargs='+', type=float,
                     help='Istropic diffusivity in mm^2/s.\n'
                          'Default for ball_stick: [2.0E-3]\n'
@@ -280,8 +279,7 @@ def main():
         else:
             logging.debug('Using the Stick Zeppelin Ball model.')
             para_diff = args.para_diff or 1.7E-3
-            perp_diff = args.perp_diff or \
-                [1.19E-3, 0.85E-3, 0.51E-3, 0.17E-3]
+            perp_diff = args.perp_diff or [0.85E-3, 0.51E-3]
             isotropc_diff = args.iso_diff or [1.7E-3, 3.0E-3]
             mit.model.set(para_diff, perp_diff, isotropc_diff)
 

--- a/scripts/scil_run_commit.py
+++ b/scripts/scil_run_commit.py
@@ -271,7 +271,7 @@ def main():
         # (based on order of magnitude of signal)
         img = nib.load(args.in_dwi)
         data = img.get_fdata(dtype=np.float32)
-        data[data < (0.001*10**np.floor(np.log10(np.mean(data))))] = 0
+        data[data < (0.001*10**np.floor(np.log10(np.mean(data[data>0]))))] = 0
         nib.save(nib.Nifti1Image(data, img.affine),
                  os.path.join(tmp_dir.name, 'dwi_zero_fix.nii.gz'))
 

--- a/scripts/scil_visualize_connectivity.py
+++ b/scripts/scil_visualize_connectivity.py
@@ -194,10 +194,8 @@ def main():
     if args.histogram:
         fig, ax = plt.subplots()
         if args.exclude_zeros:
-            min_value = EPSILON
-        N, bins, patches = ax.hist(matrix.ravel(),
-                                   range=(min_value, matrix.max()),
-                                   bins=args.nb_bins)
+            matrix = matrix[matrix != 0]
+        _, _, patches = ax.hist(matrix.ravel(), bins=args.nb_bins)
         nbr_bins = len(patches)
         color = plt.cm.get_cmap(args.colormap)(np.linspace(0, 1, nbr_bins))
         for i in range(0, nbr_bins):


### PR DESCRIPTION
This is an update for my first try running connectoflow on 105 HCP subjects.
Some stuff went wrong in COMMIT:
Following discussion with Ale I changed the default param for perp_diff and fix a bug due to bad normalization when close to zeros voxel where present.

Tiny fix in visualize_connectivity to support negative values and exclude zeros (more robust for connectoflow)

Also fix an error in the test fetcher (probably due to a previous merge error on my part)