### PR TITLE
FIX: WM mask argument in scil_compute_ssst_frf.py

### DIFF
--- a/scripts/scil_compute_ssst_frf.py
+++ b/scripts/scil_compute_ssst_frf.py
@@ -103,7 +103,7 @@ def main():
 
     mask_wm = None
     if args.mask_wm:
-        mask_wm = get_data_as_mask(nib.load(args.wm_mask), dtype=np.bool)
+        mask_wm = get_data_as_mask(nib.load(args.mask_wm), dtype=np.bool)
 
     full_response = compute_ssst_frf(data, bvals, bvecs, mask=mask,
                                      mask_wm=mask_wm, fa_thresh=args.fa_thresh,


### PR DESCRIPTION
WM mask argument was not extracted properly from argparser
Data: https://drive.google.com/drive/folders/1CeKuVZZCbLSgZK1BI6kv9Plg6yzO7VXL?usp=sharing

`./scripts/scil_compute_ssst_frf.py fibercup_dwi.nii.gz fibercup_dwi.bvals fibercup_dwi.bvecs frf.txt --min_fa 0.10 --mask_wm fibercup_wm.nii.gz -f`
