### PR TITLE
Adding saving options to save connectivity

### DIFF
--- a/scripts/scil_save_connections_from_hdf5.py
+++ b/scripts/scil_save_connections_from_hdf5.py
@@ -44,10 +44,11 @@ def _build_arg_parser():
                        help='Keys to identify the sub-network of interest.')
 
     group.add_argument('--node_keys', nargs='+',
-                       help='Node keys to identify the sub-network of interest.')
+                       help='Node keys to identify the'
+                            'sub-network of interest.')
 
     p.add_argument('--save_empty', action='store_true',
-                   help='Save the empty tractograms.')
+                   help='If true, save also empty tractograms.')
 
     add_overwrite_arg(p)
     return p
@@ -79,15 +80,16 @@ def main():
         dimensions = hdf5_file.attrs['dimensions']
         voxel_sizes = hdf5_file.attrs['voxel_sizes']
         streamlines = reconstruct_streamlines_from_hdf5(hdf5_file, key)
-        header = create_nifti_header(affine, dimensions, voxel_sizes)
-        sft = StatefulTractogram(streamlines, header, Space.VOX,
-                                 origin=Origin.TRACKVIS)
-        if args.include_dps:
-            for dps_key in hdf5_file[key].keys():
-                if dps_key not in ['data', 'offsets', 'lengths']:
-                    sft.data_per_streamline[dps_key] = hdf5_file[key][dps_key]
+        if args.save_empty or streamlines:
+            header = create_nifti_header(affine, dimensions, voxel_sizes)
+            sft = StatefulTractogram(streamlines, header, Space.VOX,
+                                    origin=Origin.TRACKVIS)
+            if args.include_dps:
+                for dps_key in hdf5_file[key].keys():
+                    if dps_key not in ['data', 'offsets', 'lengths']:
+                        sft.data_per_streamline[dps_key] = hdf5_file[key][dps_key]
 
-        save_tractogram(sft, '{}.trk'.format(os.path.join(args.out_dir, key)))
+            save_tractogram(sft, '{}.trk'.format(os.path.join(args.out_dir, key)))
 
     hdf5_file.close()
 

--- a/scripts/scil_save_connections_from_hdf5.py
+++ b/scripts/scil_save_connections_from_hdf5.py
@@ -44,14 +44,12 @@ def _build_arg_parser():
 
     group = p.add_mutually_exclusive_group()
     group.add_argument('--edge_keys', nargs='+',
-                       help='Keys to identify the sub-network of interest.')
+                       help='Keys to identify the edges of '
+                            'interest (LABEL1_LABEL2).')
 
     group.add_argument('--node_keys', nargs='+',
-                       help='Node keys to identify the'
+                       help='Node keys to identify the '
                             'sub-network of interest.')
-
-    p.add_argument('--save_empty', action='store_true',
-                   help='If true, save also empty tractograms.')
 
     add_overwrite_arg(p)
     return p
@@ -83,14 +81,13 @@ def main():
         dimensions = hdf5_file.attrs['dimensions']
         voxel_sizes = hdf5_file.attrs['voxel_sizes']
         streamlines = reconstruct_streamlines_from_hdf5(hdf5_file, key)
-        if args.save_empty or streamlines:
-            header = create_nifti_header(affine, dimensions, voxel_sizes)
-            sft = StatefulTractogram(streamlines, header, Space.VOX,
-                                     origin=Origin.TRACKVIS)
-            if args.include_dps:
-                for dps_key in hdf5_file[key].keys():
-                    if dps_key not in ['data', 'offsets', 'lengths']:
-                        sft.data_per_streamline[dps_key] = hdf5_file[key][dps_key]
+        header = create_nifti_header(affine, dimensions, voxel_sizes)
+        sft = StatefulTractogram(streamlines, header, Space.VOX,
+                                    origin=Origin.TRACKVIS)
+        if args.include_dps:
+            for dps_key in hdf5_file[key].keys():
+                if dps_key not in ['data', 'offsets', 'lengths']:
+                    sft.data_per_streamline[dps_key] = hdf5_file[key][dps_key]
 
             save_tractogram(sft, '{}.trk'
                             .format(os.path.join(args.out_dir, key)))

--- a/scripts/scil_save_connections_from_hdf5.py
+++ b/scripts/scil_save_connections_from_hdf5.py
@@ -86,13 +86,14 @@ def main():
         if args.save_empty or streamlines:
             header = create_nifti_header(affine, dimensions, voxel_sizes)
             sft = StatefulTractogram(streamlines, header, Space.VOX,
-                                    origin=Origin.TRACKVIS)
+                                     origin=Origin.TRACKVIS)
             if args.include_dps:
                 for dps_key in hdf5_file[key].keys():
                     if dps_key not in ['data', 'offsets', 'lengths']:
                         sft.data_per_streamline[dps_key] = hdf5_file[key][dps_key]
 
-            save_tractogram(sft, '{}.trk'.format(os.path.join(args.out_dir, key)))
+            save_tractogram(sft, '{}.trk'
+                            .format(os.path.join(args.out_dir, key)))
 
     hdf5_file.close()
 

--- a/scripts/scil_save_connections_from_hdf5.py
+++ b/scripts/scil_save_connections_from_hdf5.py
@@ -5,6 +5,9 @@
 Save individual connection of an hd5f from scil_decompose_connectivity.py.
 Useful for quality control and visual inspections.
 
+It can either save all connections, individual connections specified with
+edge_keys or connections from specific nodes with node_keys.
+
 The output is a directory containing the thousands of connections:
 out_dir/
     ├── LABEL1_LABEL1.trk

--- a/scripts/scil_save_connections_from_hdf5.py
+++ b/scripts/scil_save_connections_from_hdf5.py
@@ -89,8 +89,8 @@ def main():
                 if dps_key not in ['data', 'offsets', 'lengths']:
                     sft.data_per_streamline[dps_key] = hdf5_file[key][dps_key]
 
-            save_tractogram(sft, '{}.trk'
-                            .format(os.path.join(args.out_dir, key)))
+        save_tractogram(sft, '{}.trk'
+                        .format(os.path.join(args.out_dir, key)))
 
     hdf5_file.close()
 

--- a/scripts/scil_save_connections_from_hdf5.py
+++ b/scripts/scil_save_connections_from_hdf5.py
@@ -39,6 +39,9 @@ def _build_arg_parser():
     p.add_argument('--include_dps', action='store_true',
                    help='Include the data_per_streamline the metadata.')
 
+    p.add_argument('--edge_keys', nargs='+',
+                   help='Keys to identify the sub-network of interest.')
+
     add_overwrite_arg(p)
     return p
 


### PR DESCRIPTION
Add the options to save with specifying edges_keys of interet or with node_keys to the script save_connections_hdf5.py.
Data from the scirpt decompose_connectivity is avalaible here : [(https://drive.google.com/file/d/1cavj1VGavbPJCBbPdAN9dqz845Tza-tN/view?usp=sharing)].