### PR TITLE
Memory friendly scil_image_math.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ bz2file==0.98.*
 coloredlogs==10.0.*
 cycler==0.10.*
 Cython==0.29.*
-dipy>=1.1.0
+dipy==1.1.*
 fury==0.2.*
 future==0.17.*
 h5py==2.9.*

--- a/scilpy/image/operations.py
+++ b/scilpy/image/operations.py
@@ -417,16 +417,17 @@ def std(input_list, ref_img):
                 'This operation with 4D data only support one operand.')
     else:
         if len(input_list) == 1:
-            raise ValueError('This operation with only one operand requires 4D data.')
+            raise ValueError(
+                'This operation with only one operand requires 4D data.')
 
     if len(input_list[0].header.get_data_shape()) > 3:
         return np.std(input_list[0].get_fdata(dtype=np.float64), axis=-1)
     else:
-        mean_data=mean(input_list, ref_img)
-        output_data=np.zeros(input_list[0].header.get_data_shape())
+        mean_data = mean(input_list, ref_img)
+        output_data = np.zeros(input_list[0].header.get_data_shape())
         for img in input_list:
             if isinstance(img, nib.Nifti1Image):
-                data=img.get_fdata(dtype=np.float64)
+                data = img.get_fdata(dtype=np.float64)
                 output_data += (data - mean_data) ** 2
                 img.uncache()
             else:
@@ -440,8 +441,8 @@ def union(input_list, ref_img):
         Operation on binary image to keep voxels, that are non-zero, in at
         least one file.
     """
-    output_data=addition(input_list, ref_img)
-    output_data[output_data != 0]=1
+    output_data = addition(input_list, ref_img)
+    output_data[output_data != 0] = 1
 
     return output_data
 
@@ -452,8 +453,8 @@ def intersection(input_list, ref_img):
         Operation on binary image to keep the voxels, that are non-zero,
         are present in all files.
     """
-    output_data=multiplication(input_list, ref_img)
-    output_data[output_data != 0]=1
+    output_data = multiplication(input_list, ref_img)
+    output_data[output_data != 0] = 1
 
     return output_data
 
@@ -467,18 +468,18 @@ def difference(input_list, ref_img):
     _validate_length(input_list, 2)
     _validate_imgs(*input_list, ref_img)
 
-    output_data=np.zeros(ref_img.header.get_data_shape(), dtype=np.float64)
+    output_data = np.zeros(ref_img.header.get_data_shape(), dtype=np.float64)
     if isinstance(input_list[0], nib.Nifti1Image):
-        data_1=input_list[0].get_fdata(dtype=np.float64)
+        data_1 = input_list[0].get_fdata(dtype=np.float64)
     else:
-        data_1=input_list[0]
+        data_1 = input_list[0]
     if isinstance(input_list[1], nib.Nifti1Image):
-        data_2=input_list[1].get_fdata(dtype=np.float64)
+        data_2 = input_list[1].get_fdata(dtype=np.float64)
     else:
-        data_2=input_list[1]
+        data_2 = input_list[1]
 
-    output_data[data_1 != 0]=1
-    output_data[data_2 != 0]=0
+    output_data[data_1 != 0] = 1
+    output_data[data_2 != 0] = 0
     return output_data
 
 
@@ -490,10 +491,10 @@ def invert(input_list, ref_img):
     _validate_length(input_list, 1)
     _validate_type(input_list[0], nib.Nifti1Image)
 
-    data=input_list[0].get_fdata(dtype=np.float64)
-    output_data=np.zeros(data.shape, dtype=np.float64)
-    output_data[data != 0]=0
-    output_data[data == 0]=1
+    data = input_list[0].get_fdata(dtype=np.float64)
+    output_data = np.zeros(data.shape, dtype=np.float64)
+    output_data[data != 0] = 0
+    output_data[data == 0] = 1
 
     return output_data
 
@@ -507,9 +508,9 @@ def concat(input_list, ref_img):
     if len(input_list[0].header.get_data_shape()) != 3:
         raise ValueError('Concatenate require 3D arrays.')
 
-    input_data=[]
+    input_data = []
     for img in input_list:
-        data=img.get_fdata(dtype=np.float64)
+        data = img.get_fdata(dtype=np.float64)
         input_data.append(data)
         img.uncache()
     return np.rollaxis(np.stack(input_data), axis=0, start=4)

--- a/scilpy/image/operations.py
+++ b/scilpy/image/operations.py
@@ -423,7 +423,7 @@ def std(input_list, ref_img):
                 img.uncache()
             else:
                 output_data += (img - mean_data) ** 2
-        return np.sqrt(output_data / (len(input_list) - 1))
+        return np.sqrt(output_data / len(input_list))
 
 
 def union(input_list, ref_img):

--- a/scilpy/image/operations.py
+++ b/scilpy/image/operations.py
@@ -7,7 +7,6 @@ to apply simple operations on nibabel images or numpy arrays.
 """
 
 from collections import OrderedDict
-from copy import copy
 import logging
 
 import nibabel as nib
@@ -230,7 +229,7 @@ def normalize_sum(input_list, ref_img):
     _validate_type(input_list[0], nib.Nifti1Image)
 
     data = input_list[0].get_fdata(dtype=np.float64)
-    return copy(data) / np.sum(data)
+    return data / np.sum(data)
 
 
 def normalize_max(input_list, ref_img):
@@ -242,7 +241,7 @@ def normalize_max(input_list, ref_img):
     _validate_type(input_list[0], nib.Nifti1Image)
 
     data = input_list[0].get_fdata(dtype=np.float64)
-    return copy(data) / np.max(data)
+    return data / np.max(data)
 
 
 def base_10_log(input_list, ref_img):
@@ -285,7 +284,7 @@ def convert(input_list, ref_img):
     _validate_length(input_list, 1)
     _validate_type(input_list[0], nib.Nifti1Image)
 
-    return copy(input_list[0].get_fdata(dtype=np.float64))
+    return input_list[0].get_fdata(dtype=np.float64)
 
 
 def addition(input_list, ref_img):

--- a/scilpy/image/operations.py
+++ b/scilpy/image/operations.py
@@ -412,7 +412,7 @@ def std(input_list, ref_img):
         raise ValueError
 
     if len(input_list[0].header.get_data_shape()) > 3:
-        return np.average(input_list[0].get_fdata(dtype=np.float64), axis=-1)
+        return np.std(input_list[0].get_fdata(dtype=np.float64), axis=-1)
     else:
         mean_data = mean(input_list, ref_img)
         output_data = np.zeros(input_list[0].header.get_data_shape())

--- a/scilpy/image/operations.py
+++ b/scilpy/image/operations.py
@@ -386,10 +386,14 @@ def mean(input_list, ref_img):
     _validate_length(input_list, 1, at_least=True)
     _validate_imgs(*input_list, ref_img)
 
-    if len(input_list) == 1 \
-            and not len(input_list[0].header.get_data_shape()) > 3:
-        logging.error('This operation with only one operand requires 4D data.')
-        raise ValueError
+    if len(input_list[0].header.get_data_shape()) > 3:
+        if not len(input_list) == 1:
+            raise ValueError(
+                'This operation with 4D data only support one operand.')
+    else:
+        if len(input_list) == 1:
+            raise ValueError(
+                'This operation with only one operand requires 4D data.')
 
     if len(input_list[0].header.get_data_shape()) > 3:
         return np.average(input_list[0].get_fdata(dtype=np.float64), axis=-1)
@@ -407,19 +411,22 @@ def std(input_list, ref_img):
     _validate_length(input_list, 1, at_least=True)
     _validate_imgs(*input_list, ref_img)
 
-    if len(input_list) == 1 \
-            and not len(input_list[0].header.get_data_shape()) > 3:
-        logging.error('This operation with only one operand requires 4D data.')
-        raise ValueError
+    if len(input_list[0].header.get_data_shape()) > 3:
+        if not len(input_list) == 1:
+            raise ValueError(
+                'This operation with 4D data only support one operand.')
+    else:
+        if len(input_list) == 1:
+            raise ValueError('This operation with only one operand requires 4D data.')
 
     if len(input_list[0].header.get_data_shape()) > 3:
         return np.std(input_list[0].get_fdata(dtype=np.float64), axis=-1)
     else:
-        mean_data = mean(input_list, ref_img)
-        output_data = np.zeros(input_list[0].header.get_data_shape())
+        mean_data=mean(input_list, ref_img)
+        output_data=np.zeros(input_list[0].header.get_data_shape())
         for img in input_list:
             if isinstance(img, nib.Nifti1Image):
-                data = img.get_fdata(dtype=np.float64)
+                data=img.get_fdata(dtype=np.float64)
                 output_data += (data - mean_data) ** 2
                 img.uncache()
             else:
@@ -433,8 +440,8 @@ def union(input_list, ref_img):
         Operation on binary image to keep voxels, that are non-zero, in at
         least one file.
     """
-    output_data = addition(input_list, ref_img)
-    output_data[output_data != 0] = 1
+    output_data=addition(input_list, ref_img)
+    output_data[output_data != 0]=1
 
     return output_data
 
@@ -445,8 +452,8 @@ def intersection(input_list, ref_img):
         Operation on binary image to keep the voxels, that are non-zero,
         are present in all files.
     """
-    output_data = multiplication(input_list, ref_img)
-    output_data[output_data != 0] = 1
+    output_data=multiplication(input_list, ref_img)
+    output_data[output_data != 0]=1
 
     return output_data
 
@@ -460,18 +467,18 @@ def difference(input_list, ref_img):
     _validate_length(input_list, 2)
     _validate_imgs(*input_list, ref_img)
 
-    output_data = np.zeros(ref_img.header.get_data_shape(), dtype=np.float64)
+    output_data=np.zeros(ref_img.header.get_data_shape(), dtype=np.float64)
     if isinstance(input_list[0], nib.Nifti1Image):
-        data_1 = input_list[0].get_fdata(dtype=np.float64)
+        data_1=input_list[0].get_fdata(dtype=np.float64)
     else:
-        data_1 = input_list[0]
+        data_1=input_list[0]
     if isinstance(input_list[1], nib.Nifti1Image):
-        data_2 = input_list[1].get_fdata(dtype=np.float64)
+        data_2=input_list[1].get_fdata(dtype=np.float64)
     else:
-        data_2 = input_list[1]
+        data_2=input_list[1]
 
-    output_data[data_1 != 0] = 1
-    output_data[data_2 != 0] = 0
+    output_data[data_1 != 0]=1
+    output_data[data_2 != 0]=0
     return output_data
 
 
@@ -483,10 +490,10 @@ def invert(input_list, ref_img):
     _validate_length(input_list, 1)
     _validate_type(input_list[0], nib.Nifti1Image)
 
-    data = input_list[0].get_fdata(dtype=np.float64)
-    output_data = np.zeros(data.shape, dtype=np.float64)
-    output_data[data != 0] = 0
-    output_data[data == 0] = 1
+    data=input_list[0].get_fdata(dtype=np.float64)
+    output_data=np.zeros(data.shape, dtype=np.float64)
+    output_data[data != 0]=0
+    output_data[data == 0]=1
 
     return output_data
 
@@ -500,9 +507,9 @@ def concat(input_list, ref_img):
     if len(input_list[0].header.get_data_shape()) != 3:
         raise ValueError('Concatenate require 3D arrays.')
 
-    input_data = []
+    input_data=[]
     for img in input_list:
-        data = img.get_fdata(dtype=np.float64)
+        data=img.get_fdata(dtype=np.float64)
         input_data.append(data)
         img.uncache()
     return np.rollaxis(np.stack(input_data), axis=0, start=4)

--- a/scilpy/image/operations.py
+++ b/scilpy/image/operations.py
@@ -387,7 +387,8 @@ def mean(input_list, ref_img):
     _validate_length(input_list, 1, at_least=True)
     _validate_imgs(*input_list, ref_img)
 
-    if len(input_list) == 1 and not len(input_list[0].header.get_data_shape()) > 3:
+    if len(input_list) == 1 \
+            and not len(input_list[0].header.get_data_shape()) > 3:
         logging.error('This operation with only one operand requires 4D data.')
         raise ValueError
 
@@ -407,7 +408,8 @@ def std(input_list, ref_img):
     _validate_length(input_list, 1, at_least=True)
     _validate_imgs(*input_list, ref_img)
 
-    if len(input_list) == 1 and not len(input_list[0].header.get_data_shape()) > 3:
+    if len(input_list) == 1 \
+            and not len(input_list[0].header.get_data_shape()) > 3:
         logging.error('This operation with only one operand requires 4D data.')
         raise ValueError
 

--- a/scilpy/image/operations.py
+++ b/scilpy/image/operations.py
@@ -10,6 +10,7 @@ from collections import OrderedDict
 from copy import copy
 import logging
 
+import nibabel as nib
 import numpy as np
 from scipy.ndimage.filters import gaussian_filter
 from scipy.ndimage.morphology import (binary_closing, binary_dilation,
@@ -54,7 +55,7 @@ def get_image_ops():
     """Get a dictionary of all functions relating to image operations"""
     image_ops = get_array_ops()
     image_ops.update(OrderedDict([
-        ('concat', concat),
+        ('concatenate', concat),
         ('dilation', dilation),
         ('erosion', erosion),
         ('closing', closing),
@@ -73,12 +74,13 @@ def get_operations_doc(ops: dict):
     return "".join(full_doc)
 
 
-def _validate_arrays(*arrays):
-    """Make sure that all inputs are arrays, and that their shapes match."""
-    ref_array = arrays[0]
-    for array in arrays:
-        if isinstance(array, np.ndarray) and \
-                not np.all(ref_array.shape == array.shape):
+def _validate_imgs(*imgs):
+    """Make sure that all inputs are images, and that their shapes match."""
+    ref_img = imgs[-1]
+    for img in imgs:
+        if isinstance(img, nib.Nifti1Image) and \
+                not np.all(ref_img.header.get_data_shape() ==
+                           img.header.get_data_shape()):
             raise ValueError('Not all inputs have the same shape!')
 
 
@@ -97,8 +99,8 @@ def _validate_length(input_list, length, at_least=False):
             raise ValueError
 
 
-def _validate_dtype(x, dtype):
-    """Make sure that the input has the right datatype."""
+def _validate_type(x, dtype):
+    """Make sure that the input has the right type."""
     if not isinstance(x, dtype):
         logging.error(
             'The input must be of type {} for this operation.'.format(dtype))
@@ -112,24 +114,25 @@ def _validate_float(x):
         raise ValueError
 
 
-def lower_threshold(input_list):
+def lower_threshold(input_list, ref_img):
     """
     lower_threshold: IMG THRESHOLD
         All values below the threshold will be set to zero.
         All values above the threshold will be set to one.
     """
     _validate_length(input_list, 2)
-    _validate_dtype(input_list[0], np.ndarray)
+    _validate_type(input_list[0], nib.Nifti1Image)
     _validate_float(input_list[1])
 
-    output_data = copy(input_list[0])
-    output_data[input_list[0] < input_list[1]] = 0
-    output_data[input_list[0] >= input_list[1]] = 1
+    output_data = np.zeros(ref_img.header.get_data_shape(), dtype=np.float64)
+    data = input_list[0].get_fdata(dtype=np.float64)
+    output_data[data < input_list[1]] = 0
+    output_data[data >= input_list[1]] = 1
 
     return output_data
 
 
-def upper_threshold(input_list):
+def upper_threshold(input_list, ref_img):
     """
     upper_threshold: IMG THRESHOLD
         All values below the threshold will be set to one.
@@ -137,228 +140,264 @@ def upper_threshold(input_list):
         Equivalent to lower_threshold followed by an inversion.
     """
     _validate_length(input_list, 2)
-    _validate_dtype(input_list[0], np.ndarray)
+    _validate_type(input_list[0], nib.Nifti1Image)
     _validate_float(input_list[1])
 
-    output_data = copy(input_list[0])
-    output_data[input_list[0] <= input_list[1]] = 1
-    output_data[input_list[0] > input_list[1]] = 0
+    output_data = np.zeros(ref_img.header.get_data_shape(), dtype=np.float64)
+    data = input_list[0].get_fdata(dtype=np.float64)
+    output_data[data <= input_list[1]] = 1
+    output_data[data > input_list[1]] = 0
 
     return output_data
 
 
-def lower_clip(input_list):
+def lower_clip(input_list, ref_img):
     """
     lower_clip: IMG THRESHOLD
         All values below the threshold will be set to threshold.
     """
     _validate_length(input_list, 2)
-    _validate_dtype(input_list[0], np.ndarray)
+    _validate_type(input_list[0], nib.Nifti1Image)
     _validate_float(input_list[1])
 
-    return np.clip(input_list[0], input_list[1], None)
+    return np.clip(input_list[0].get_fdata(dtype=np.float64),
+                   input_list[1], None)
 
 
-def upper_clip(input_list):
+def upper_clip(input_list, ref_img):
     """
     upper_clip: IMG THRESHOLD
         All values above the threshold will be set to threshold.
     """
     _validate_length(input_list, 2)
-    _validate_dtype(input_list[0], np.ndarray)
+    _validate_type(input_list[0], nib.Nifti1Image)
     _validate_float(input_list[1])
 
-    return np.clip(input_list[0], None, input_list[1])
+    return np.clip(input_list[0].get_fdata(dtype=np.float64),
+                   None, input_list[1])
 
 
-def absolute_value(input_list):
+def absolute_value(input_list, ref_img):
     """
     absolute_value: IMG
         All negative values will become positive.
     """
     _validate_length(input_list, 1)
-    _validate_dtype(input_list[0], np.ndarray)
+    _validate_type(input_list[0], nib.Nifti1Image)
 
-    return np.abs(input_list[0])
+    return np.abs(input_list[0].get_fdata(dtype=np.float64))
 
 
-def around(input_list):
+def around(input_list, ref_img):
     """
     round: IMG
         Round all decimal values to the closest integer.
     """
     _validate_length(input_list, 1)
-    _validate_dtype(input_list[0], np.ndarray)
+    _validate_type(input_list[0], nib.Nifti1Image)
 
-    return np.round(input_list[0])
+    return np.round(input_list[0].get_fdata(dtype=np.float64))
 
 
-def ceil(input_list):
+def ceil(input_list, ref_img):
     """
     ceil: IMG
         Ceil all decimal values to the next integer.
     """
     _validate_length(input_list, 1)
-    _validate_dtype(input_list[0], np.ndarray)
+    _validate_type(input_list[0], nib.Nifti1Image)
 
-    return np.ceil(input_list[0])
+    return np.ceil(input_list[0].get_fdata(dtype=np.float64))
 
 
-def floor(input_list):
+def floor(input_list, ref_img):
     """
     floor: IMG
         Floor all decimal values to the previous integer.
     """
     _validate_length(input_list, 1)
-    _validate_dtype(input_list[0], np.ndarray)
+    _validate_type(input_list[0], nib.Nifti1Image)
 
-    return np.floor(input_list[0])
+    return np.floor(input_list[0].get_fdata(dtype=np.float64))
 
 
-def normalize_sum(input_list):
+def normalize_sum(input_list, ref_img):
     """
     normalize_sum: IMG
         Normalize the image so the sum of all values is one.
     """
     _validate_length(input_list, 1)
-    _validate_dtype(input_list[0], np.ndarray)
+    _validate_type(input_list[0], nib.Nifti1Image)
 
-    return copy(input_list[0]) / np.sum(input_list[0])
+    data = input_list[0].get_fdata(dtype=np.float64)
+    return copy(data) / np.sum(data)
 
 
-def normalize_max(input_list):
+def normalize_max(input_list, ref_img):
     """
     normalize_max: IMG
         Normalize the image so the maximum value is one.
     """
     _validate_length(input_list, 1)
-    _validate_dtype(input_list[0], np.ndarray)
+    _validate_type(input_list[0], nib.Nifti1Image)
 
-    return copy(input_list[0]) / np.max(input_list[0])
+    data = input_list[0].get_fdata(dtype=np.float64)
+    return copy(data) / np.max(data)
 
 
-def base_10_log(input_list):
+def base_10_log(input_list, ref_img):
     """
     log_10: IMG
         Apply a log (base 10) to all non zeros values of an image.
     """
     _validate_length(input_list, 1)
-    _validate_dtype(input_list[0], np.ndarray)
+    _validate_type(input_list[0], nib.Nifti1Image)
 
-    output_data = np.zeros(input_list[0].shape)
-    output_data[input_list[0] > EPSILON] = np.log10(
-        input_list[0][input_list[0] > EPSILON])
+    data = input_list[0].get_fdata(dtype=np.float64)
+    output_data = np.zeros(data.shape, dtype=np.float64)
+    output_data[data > EPSILON] = np.log10(data[data > EPSILON])
     output_data[np.abs(output_data) < EPSILON] = -65536
 
     return output_data
 
 
-def natural_log(input_list):
+def natural_log(input_list, ref_img):
     """
     log_e: IMG
         Apply a natural log to all non zeros values of an image.
     """
     _validate_length(input_list, 1)
-    _validate_dtype(input_list[0], np.ndarray)
+    _validate_type(input_list[0], nib.Nifti1Image)
 
-    output_data = np.zeros(input_list[0].shape)
-    output_data[input_list[0] > EPSILON] = np.log(
-        input_list[0][input_list[0] > EPSILON])
+    data = input_list[0].get_fdata(dtype=np.float64)
+    output_data = np.zeros(data.shape, dtype=np.float64)
+    output_data[data > EPSILON] = np.log(data[data > EPSILON])
     output_data[np.abs(output_data) < EPSILON] = -65536
 
     return output_data
 
 
-def convert(input_list):
+def convert(input_list, ref_img):
     """
     convert: IMG
         Perform no operation, but simply change the data type.
     """
     _validate_length(input_list, 1)
-    _validate_dtype(input_list[0], np.ndarray)
+    _validate_type(input_list[0], nib.Nifti1Image)
 
-    return copy(input_list[0])
+    return copy(input_list[0].get_fdata(dtype=np.float64))
 
 
-def addition(input_list):
+def addition(input_list, ref_img):
     """
     addition: IMGs
         Add multiple images together.
     """
     _validate_length(input_list, 2, at_least=True)
-    _validate_arrays(*input_list)
-    ref_array = input_list[0]
+    _validate_imgs(*input_list, ref_img)
 
-    output_data = np.zeros(ref_array.shape)
-    for data in input_list:
-        output_data += data
+    output_data = np.zeros(ref_img.header.get_data_shape(), dtype=np.float64)
+    for img in input_list:
+        if isinstance(img, nib.Nifti1Image):
+            data = img.get_fdata(dtype=np.float64)
+            output_data += data
+            img.uncache()
+        else:
+            output_data += img
 
     return output_data
 
 
-def subtraction(input_list):
+def subtraction(input_list, ref_img):
     """
     subtraction: IMG_1 IMG_2
         Subtract first image by the second (IMG_1 - IMG_2).
     """
     _validate_length(input_list, 2)
-    _validate_arrays(*input_list)
+    _validate_imgs(*input_list, ref_img)
 
-    return input_list[0] - input_list[1]
+    output_data = np.zeros(ref_img.header.get_data_shape(), dtype=np.float64)
+    if isinstance(input_list[0], nib.Nifti1Image):
+        data_1 = input_list[0].get_fdata(dtype=np.float64)
+    else:
+        data_1 = input_list[0]
+    if isinstance(input_list[1], nib.Nifti1Image):
+        data_2 = input_list[1].get_fdata(dtype=np.float64)
+    else:
+        data_2 = input_list[1]
+
+    output_data += data_1
+    return output_data - data_2
 
 
-def multiplication(input_list):
+def multiplication(input_list, ref_img):
     """
     multiplication: IMGs
         Multiply multiple images together (danger of underflow and overflow)
     """
     _validate_length(input_list, 2, at_least=True)
-    _validate_arrays(*input_list)
+    _validate_imgs(*input_list, ref_img)
 
-    output_data = input_list[0]
-    for data in input_list[1:]:
-        output_data *= data
+    output_data = np.ones(ref_img.header.get_data_shape())
+    if isinstance(input_list[0], nib.Nifti1Image):
+        output_data *= input_list[0].get_fdata(dtype=np.float64)
+    else:
+        output_data *= input_list[0]
+    for img in input_list[1:]:
+        if isinstance(img, nib.Nifti1Image):
+            data = img.get_fdata(dtype=np.float64)
+            output_data *= data
+            img.uncache()
+        else:
+            output_data *= img
 
     return output_data
 
 
-def division(input_list):
+def division(input_list, ref_img):
     """
     division: IMG_1 IMG_2
         Divide first image by the second (danger of underflow and overflow)
         Ignore zeros values, excluded from the operation.
     """
     _validate_length(input_list, 2)
-    _validate_arrays(*input_list)
-    ref_array = input_list[0]
+    _validate_imgs(*input_list, ref_img)
 
-    output_data = np.zeros(ref_array.shape)
-    output_data[input_list[1] != 0] = input_list[0][input_list[1] != 0] \
-        / input_list[1][input_list[1] > 0]
+    output_data = np.zeros(ref_img.header.get_data_shape(), dtype=np.float64)
+    if isinstance(input_list[0], nib.Nifti1Image):
+        data_1 = input_list[0].get_fdata(dtype=np.float64)
+    else:
+        data_1 = input_list[0]
+    if isinstance(input_list[1], nib.Nifti1Image):
+        data_2 = input_list[1].get_fdata(dtype=np.float64)
+    else:
+        data_2 = input_list[1]
+
+    output_data += data_1
+    output_data[data_2 != 0] /= data_2[data_2 != 0]
     return output_data
 
 
-def mean(input_list):
+def mean(input_list, ref_img):
     """
     mean: IMGs
         Compute the mean of images.
         If a single 4D image is provided, average along the last dimension.
     """
     _validate_length(input_list, 1, at_least=True)
-    _validate_arrays(*input_list)
-    ref_array = input_list[0]
+    _validate_imgs(*input_list, ref_img)
 
-    if len(input_list) == 1 and not ref_array.ndim > 3:
+    if len(input_list) == 1 and not len(input_list[0].header.get_data_shape()) > 3:
         logging.error('This operation with only one operand requires 4D data.')
         raise ValueError
 
-    in_data = np.squeeze(np.rollaxis(np.array(input_list), 0,
-                                     input_list[0].ndim+1))
+    if len(input_list[0].header.get_data_shape()) > 3:
+        return np.average(input_list[0].get_fdata(dtype=np.float64), axis=-1)
+    else:
+        return addition(input_list, ref_img) / len(input_list)
 
-    return np.average(in_data, axis=-1)
 
-
-def std(input_list):
+def std(input_list, ref_img):
     """
     std: IMGs
         Compute the standard deviation average of multiple images.
@@ -366,142 +405,170 @@ def std(input_list):
         dimension.
     """
     _validate_length(input_list, 1, at_least=True)
-    _validate_arrays(*input_list)
-    ref_array = input_list[0]
+    _validate_imgs(*input_list, ref_img)
 
-    if len(input_list) == 1 and not ref_array.ndim > 3:
+    if len(input_list) == 1 and not len(input_list[0].header.get_data_shape()) > 3:
         logging.error('This operation with only one operand requires 4D data.')
         raise ValueError
 
-    in_data = np.squeeze(np.rollaxis(np.array(input_list), 0,
-                                     input_list[0].ndim+1))
+    if len(input_list[0].header.get_data_shape()) > 3:
+        return np.average(input_list[0].get_fdata(dtype=np.float64), axis=-1)
+    else:
+        mean_data = mean(input_list, ref_img)
+        output_data = np.zeros(input_list[0].header.get_data_shape())
+        for img in input_list:
+            if isinstance(img, nib.Nifti1Image):
+                data = img.get_fdata(dtype=np.float64)
+                output_data += (data - mean_data) ** 2
+                img.uncache()
+            else:
+                output_data += (img - mean_data) ** 2
+        return np.sqrt(output_data / (len(input_list) - 1))
 
-    return np.std(in_data, axis=-1)
 
-
-def union(input_list):
+def union(input_list, ref_img):
     """
     union: IMGs
         Operation on binary image to keep voxels, that are non-zero, in at
         least one file.
     """
-    output_data = addition(input_list)
+    output_data = addition(input_list, ref_img)
     output_data[output_data != 0] = 1
 
     return output_data
 
 
-def intersection(input_list):
+def intersection(input_list, ref_img):
     """
     intersection: IMGs
         Operation on binary image to keep the voxels, that are non-zero,
         are present in all files.
     """
-    output_data = multiplication(input_list)
+    output_data = multiplication(input_list, ref_img)
     output_data[output_data != 0] = 1
 
     return output_data
 
 
-def difference(input_list):
+def difference(input_list, ref_img):
     """
     difference: IMG_1 IMG_2
         Operation on binary image to keep voxels from the first file that are
         not in the second file (non-zeros).
     """
     _validate_length(input_list, 2)
-    _validate_arrays(*input_list)
+    _validate_imgs(*input_list, ref_img)
 
-    output_data = copy(input_list[0]).astype(np.bool)
-    output_data[input_list[1] != 0] = 0
+    output_data = np.zeros(ref_img.header.get_data_shape(), dtype=np.float64)
+    if isinstance(input_list[0], nib.Nifti1Image):
+        data_1 = input_list[0].get_fdata(dtype=np.float64)
+    else:
+        data_1 = input_list[0]
+    if isinstance(input_list[1], nib.Nifti1Image):
+        data_2 = input_list[1].get_fdata(dtype=np.float64)
+    else:
+        data_2 = input_list[1]
 
+    output_data[data_1 != 0] = 1
+    output_data[data_2 != 0] = 0
     return output_data
 
 
-def invert(input_list):
+def invert(input_list, ref_img):
     """
     invert: IMG
         Operation on binary image to interchange 0s and 1s in a binary mask.
     """
     _validate_length(input_list, 1)
-    _validate_arrays(*input_list)
+    _validate_type(input_list[0], nib.Nifti1Image)
 
-    output_data = np.zeros(input_list[0].shape)
-    output_data[input_list[0] != 0] = 0
-    output_data[input_list[0] == 0] = 1
+    data = input_list[0].get_fdata(dtype=np.float64)
+    output_data = np.zeros(data.shape, dtype=np.float64)
+    output_data[data != 0] = 0
+    output_data[data == 0] = 1
 
     return output_data
 
 
-def concat(input_list):
+def concat(input_list, ref_img):
     """
     concat: IMGs
         Concatenate a list of 3D images into a single 4D image.
     """
-    _validate_arrays(*input_list)
-    if input_list[0].ndim != 3:
+    _validate_imgs(*input_list, ref_img)
+    if len(input_list[0].header.get_data_shape()) != 3:
         raise ValueError('Concatenate require 3D arrays.')
 
-    return np.rollaxis(np.stack(input_list), axis=0, start=4)
+    input_data = []
+    for img in input_list:
+        data = img.get_fdata(dtype=np.float64)
+        input_data.append(data)
+        img.uncache()
+    return np.rollaxis(np.stack(input_data), axis=0, start=4)
 
 
-def dilation(input_list):
+def dilation(input_list, ref_img):
     """
     dilation: IMG, VALUE
         Binary morphological operation to spatially extend the values of an
         image to their neighbors.
     """
     _validate_length(input_list, 2)
-    _validate_arrays(input_list[0])
+    _validate_type(input_list[0], nib.Nifti1Image)
     _validate_float(input_list[1])
 
-    return binary_dilation(input_list[0], iterations=int(input_list[1]))
+    return binary_dilation(input_list[0].get_fdata(dtype=np.float64),
+                           iterations=int(input_list[1]))
 
 
-def erosion(input_list):
+def erosion(input_list, ref_img):
     """
     erosion: IMG, VALUE
         Binary morphological operation to spatially shrink the volume contained
         in a binary image.
     """
     _validate_length(input_list, 2)
-    _validate_arrays(input_list[0])
+    _validate_type(input_list[0], nib.Nifti1Image)
     _validate_float(input_list[1])
 
-    return binary_erosion(input_list[0], iterations=int(input_list[1]))
+    return binary_erosion(input_list[0].get_fdata(dtype=np.float64),
+                          iterations=int(input_list[1]))
 
 
-def closing(input_list):
+def closing(input_list, ref_img):
     """
     closing: IMG, VALUE
         Binary morphological operation, dilation followed by an erosion.
     """
     _validate_length(input_list, 2)
-    _validate_arrays(input_list[0])
+    _validate_type(input_list[0], nib.Nifti1Image)
     _validate_float(input_list[1])
 
-    return binary_closing(input_list[0], iterations=int(input_list[1]))
+    return binary_closing(input_list[0].get_fdata(dtype=np.float64),
+                          iterations=int(input_list[1]))
 
 
-def opening(input_list):
+def opening(input_list, ref_img):
     """
     opening: IMG, VALUE
         Binary morphological operation, erosion followed by a dilation.
     """
     _validate_length(input_list, 2)
-    _validate_arrays(input_list[0])
+    _validate_type(input_list[0], nib.Nifti1Image)
     _validate_float(input_list[1])
 
-    return binary_opening(input_list[0], iterations=int(input_list[1]))
+    return binary_opening(input_list[0].get_fdata(dtype=np.float64),
+                          iterations=int(input_list[1]))
 
 
-def gaussian_blur(input_list):
+def gaussian_blur(input_list, ref_img):
     """
     blur: IMG, VALUE
         Apply a gaussian blur to a single image.
     """
     _validate_length(input_list, 2)
-    _validate_arrays(input_list[0])
+    _validate_type(input_list[0], nib.Nifti1Image)
     _validate_float(input_list[1])
 
-    return gaussian_filter(input_list[0], sigma=input_list[1])
+    return gaussian_filter(input_list[0].get_fdata(dtype=np.float64),
+                           sigma=input_list[1])

--- a/scripts/scil_connectivity_math.py
+++ b/scripts/scil_connectivity_math.py
@@ -14,6 +14,7 @@ import argparse
 import logging
 import os
 
+import nibabel as nib
 import numpy as np
 
 from scilpy.image.operations import (get_array_ops, get_operations_doc)
@@ -41,7 +42,7 @@ def _build_arg_parser():
                    choices=OPERATIONS.keys(),
                    help='The type of operation to be performed on the '
                         'matrices.')
-    p.add_argument('inputs', nargs='+',
+    p.add_argument('in_matrices', nargs='+',
                    help='The list of matrices files or parameters.')
     p.add_argument('out_matrix',
                    help='Output matrix path.')
@@ -49,6 +50,9 @@ def _build_arg_parser():
     p.add_argument('--data_type',
                    help='Data type of the output image. Use the format: '
                         'uint8, float16, int32.')
+    p.add_argument('--exclude_background', action='store_true',
+                   help='Does not affect the background of the original '
+                        'matrices.')
 
     add_overwrite_arg(p)
     add_verbose_arg(p)
@@ -56,14 +60,15 @@ def _build_arg_parser():
     return p
 
 
-def load_data(arg):
+def load_matrix(arg):
     if is_float(arg):
-        data = float(arg)
+        matrix = float(arg)
     else:
         if not os.path.isfile(arg):
             raise ValueError('Input file {} does not exist.'.format(arg))
 
-        data = load_matrix_in_any_format(arg)
+        data = load_matrix_in_any_format(arg).astype(np.float64)
+        matrix = nib.Nifti1Image(data, np.eye(4))
         logging.info('Loaded {} of shape {} and data_type {}.'.format(
             arg, data.shape, data.dtype))
 
@@ -74,7 +79,7 @@ def load_data(arg):
             raise ValueError('{} has {} dimensions, not valid.'.format(
                 arg, data.ndim))
 
-    return data
+    return matrix
 
 
 def main():
@@ -92,12 +97,26 @@ def main():
     if args.operation not in OPERATIONS.keys():
         parser.error('Operation {} not implemented.'.format(args.operation))
 
-    # Load all input masks.
-    input_data = []
-    for input_arg in args.inputs:
-        data = load_data(input_arg)
+    # Find at least one matrix for reference
+    for input_arg in args.in_matrices:
+        found_ref = False
+        if not is_float(input_arg):
+            ref_data = load_matrix_in_any_format(input_arg)
+            ref_matrix = nib.Nifti1Image(ref_data, np.eye(4))
+            mask = np.zeros(ref_data.shape)
+            found_ref = True
+            break
 
-        if args.operation in binary_op and isinstance(data, np.ndarray):
+    if not found_ref:
+        raise ValueError('Requires at least one matrix.')
+
+    # Load all input matrices
+    input_matrices = []
+    for input_arg in args.in_matrices:
+        matrix = load_matrix(input_arg)
+
+        if args.operation in binary_op and isinstance(matrix, nib.Nifti1Image):
+            data = matrix.get_fdata(dtype=np.float64)
             unique = np.unique(data)
             if not len(unique) <= 2:
                 parser.error('Binary operations can only be performed with '
@@ -109,16 +128,17 @@ def main():
                                 'Non-zeros will be set to ones.')
                 data[data != 0] = 1
 
-        if isinstance(data, np.ndarray):
-            data = data.astype(np.float64)
-        input_data.append(data)
+        if isinstance(matrix, nib.Nifti1Image):
+            data = matrix.get_fdata(dtype=np.float64)
+            mask[data > 0] = 1
+        input_matrices.append(matrix)
 
     if args.operation == 'convert' and not args.data_type:
         parser.error('Convert operation must be used with --data_type.')
 
     # Perform the request operation
     try:
-        output_data = OPERATIONS[args.operation](input_data)
+        output_data = OPERATIONS[args.operation](input_matrices, ref_matrix)
     except ValueError:
         logging.error('{} operation failed.'.format(
             args.operation.capitalize()))
@@ -129,6 +149,9 @@ def main():
         output_data = output_data.astype(args.data_type)
     else:
         output_data = output_data.astype(np.float64)
+
+    if args.exclude_background:
+        output_data[mask == 0] = 0
 
     # Saving in the right format
     save_matrix_in_any_format(args.out_matrix, output_data)

--- a/scripts/scil_image_math.py
+++ b/scripts/scil_image_math.py
@@ -59,7 +59,7 @@ def _build_arg_parser():
     return p
 
 
-def load_img(arg, ref):
+def load_img(arg):
     if is_float(arg):
         img = float(arg)
         dtype = np.float64
@@ -116,7 +116,7 @@ def main():
         if not is_float(input_arg) and \
                 not is_header_compatible(ref_img, input_arg):
             parser.error('Inputs do not have a compatible header.')
-        img, dtype = load_img(input_arg, ref_img)
+        img, dtype = load_img(input_arg)
 
         if isinstance(img, nib.Nifti1Image) and \
             dtype != ref_img.get_data_dtype() and \

--- a/scripts/scil_image_math.py
+++ b/scripts/scil_image_math.py
@@ -58,24 +58,27 @@ def _build_arg_parser():
     return p
 
 
-def load_data(arg):
+def load_data(arg, ref):
     if is_float(arg):
-        data = float(arg)
+        img = float(arg)
+        dtype = np.float64
     else:
         if not os.path.isfile(arg):
             raise ValueError('Input file {} does not exist.'.format(arg))
-        data = np.asanyarray(nib.load(arg).dataobj)
+        img = nib.load(arg)
+        shape = img.header.get_data_shape()
+        dtype = img.header.get_data_dtype()
         logging.info('Loaded {} of shape {} and data_type {}.'.format(
-                     arg, data.shape, data.dtype))
+                     arg, shape, dtype))
 
-        if data.ndim > 3:
+        if len(shape) > 3:
             logging.warning('{} has {} dimensions, be careful.'.format(
-                arg, data.ndim))
-        elif data.ndim < 3:
+                arg, len(shape)))
+        elif len(shape) < 3:
             raise ValueError('{} has {} dimensions, not valid.'.format(
-                arg, data.ndim))
+                arg, len(shape)))
 
-    return data
+    return img, dtype
 
 
 def main():
@@ -96,25 +99,31 @@ def main():
 
     # Find at least one image for reference
     for input_arg in args.in_images:
+        found_ref = False
         if not is_float(input_arg):
             ref_img = nib.load(input_arg)
             mask = np.zeros(ref_img.shape)
+            found_ref = True
             break
 
+    if not found_ref:
+        raise ValueError('Requires at least one nifti image.')
+
     # Load all input masks.
-    input_data = []
+    input_img = []
     for input_arg in args.in_images:
         if not is_float(input_arg) and \
                 not is_header_compatible(ref_img, input_arg):
             parser.error('Inputs do not have a compatible header.')
-        data = load_data(input_arg)
+        img, dtype = load_data(input_arg, ref_img)
 
-        if isinstance(data, np.ndarray) and \
-            data.dtype != ref_img.get_data_dtype() and \
+        if isinstance(img, nib.Nifti1Image) and \
+            dtype != ref_img.get_data_dtype() and \
                 not args.data_type:
             parser.error('Inputs do not have a compatible data type.\n'
                          'Use --data_type to specify output datatype.')
-        if args.operation in binary_op and isinstance(data, np.ndarray):
+        if args.operation in binary_op and isinstance(img, nib.Nifti1Image):
+            data = img.get_fdata(dtype=np.float64)
             unique = np.unique(data)
             if not len(unique) <= 2:
                 parser.error('Binary operations can only be performed with '
@@ -124,18 +133,18 @@ def main():
                 logging.warning('Input data for binary operation are not '
                                 'binary arrays, will be converted.\n'
                                 'Non-zeros will be set to ones.')
-                data[data != 0] = 1
 
-        if isinstance(data, np.ndarray):
-            data = data.astype(np.float64)
+        if isinstance(img, nib.Nifti1Image):
+            data = img.get_fdata(dtype=np.float64)
             mask[data > 0] = 1
-        input_data.append(data)
+            img.uncache()
+        input_img.append(img)
 
     if args.operation == 'convert' and not args.data_type:
         parser.error('Convert operation must be used with --data_type.')
 
     try:
-        output_data = OPERATIONS[args.operation](input_data)
+        output_data = OPERATIONS[args.operation](input_img, ref_img)
     except ValueError as msg:
         logging.error('{} operation failed.'.format(
             args.operation.capitalize()))
@@ -150,7 +159,7 @@ def main():
 
     if args.exclude_background:
         output_data[mask == 0] = 0
-
+    
     new_img = nib.Nifti1Image(output_data, ref_img.affine,
                               header=ref_img.header)
     nib.save(new_img, args.out_image)

--- a/scripts/scil_image_math.py
+++ b/scripts/scil_image_math.py
@@ -50,7 +50,8 @@ def _build_arg_parser():
                    help='Data type of the output image. Use the format: '
                         'uint8, int16, int/float32, int/float64.')
     p.add_argument('--exclude_background', action='store_true',
-                   help='Does not affect the background of the original image.')
+                   help='Does not affect the background of the original '
+                        'images.')
 
     add_overwrite_arg(p)
     add_verbose_arg(p)
@@ -58,7 +59,7 @@ def _build_arg_parser():
     return p
 
 
-def load_data(arg, ref):
+def load_img(arg, ref):
     if is_float(arg):
         img = float(arg)
         dtype = np.float64
@@ -115,7 +116,7 @@ def main():
         if not is_float(input_arg) and \
                 not is_header_compatible(ref_img, input_arg):
             parser.error('Inputs do not have a compatible header.')
-        img, dtype = load_data(input_arg, ref_img)
+        img, dtype = load_img(input_arg, ref_img)
 
         if isinstance(img, nib.Nifti1Image) and \
             dtype != ref_img.get_data_dtype() and \
@@ -159,7 +160,7 @@ def main():
 
     if args.exclude_background:
         output_data[mask == 0] = 0
-    
+
     new_img = nib.Nifti1Image(output_data, ref_img.affine,
                               header=ref_img.header)
     nib.save(new_img, args.out_image)

--- a/scripts/scil_split_volume_by_ids.py
+++ b/scripts/scil_split_volume_by_ids.py
@@ -16,8 +16,9 @@ import nibabel as nib
 import numpy as np
 
 from scilpy.io.image import get_data_as_label
-from scilpy.io.utils import (add_overwrite_arg, assert_inputs_exist,
-                             assert_outputs_exist)
+from scilpy.io.utils import (add_overwrite_arg,
+                             assert_inputs_exist, assert_outputs_exist,
+                             assert_output_dirs_exist_and_empty)
 
 
 # Taken from http://stackoverflow.com/a/6512463
@@ -69,7 +70,6 @@ def _build_arg_parser():
 
 
 def main():
-
     parser = _build_arg_parser()
     args = parser.parse_args()
 
@@ -96,12 +96,10 @@ def main():
             else:
                 output_filenames.append(os.path.join(args.out_dir,
                                                      '{0}.nii.gz'.format(
-                                                        name)))
+                                                         name)))
 
+    assert_output_dirs_exist_and_empty(parser, args, [], optional=args.out_dir)
     assert_outputs_exist(parser, args, output_filenames)
-
-    if args.out_dir and not os.path.isdir(args.out_dir):
-        os.mkdir(args.out_dir)
 
     # Extract the voxels that match the label and save them to a file.
     cnt_filename = 0

--- a/scripts/scil_split_volume_by_labels.py
+++ b/scripts/scil_split_volume_by_labels.py
@@ -20,8 +20,9 @@ import numpy as np
 
 import scilpy
 from scilpy.io.image import get_data_as_label
-from scilpy.io.utils import (add_overwrite_arg, assert_inputs_exist,
-                             assert_outputs_exist)
+from scilpy.io.utils import (add_overwrite_arg,
+                             assert_inputs_exist, assert_outputs_exist,
+                             assert_output_dirs_exist_and_empty)
 
 
 def _build_arg_parser():
@@ -40,14 +41,12 @@ def _build_arg_parser():
                    help='Prefix to be used for each output image.')
 
     mutual_group = p.add_mutually_exclusive_group(required=True)
-    mutual_group.add_argument(
-        '--scilpy_lut', choices=luts,
-        help='Lookup table, in the file scilpy/data/LUT, '
-             'used to name the output files.')
-    mutual_group.add_argument(
-        '--custom_lut',
-        help='Path of the lookup table file, '
-             'used to name the output files.')
+    mutual_group.add_argument('--scilpy_lut', choices=luts,
+                              help='Lookup table, in the file scilpy/data/LUT, '
+                              'used to name the output files.')
+    mutual_group.add_argument('--custom_lut',
+                              help='Path of the lookup table file, '
+                              'used to name the output files.')
 
     add_overwrite_arg(p)
 
@@ -102,12 +101,10 @@ def main():
             else:
                 output_filenames.append(os.path.join(args.out_dir,
                                                      '{0}.nii.gz'.format(
-                                                        name)))
+                                                         name)))
 
+    assert_output_dirs_exist_and_empty(parser, args, [], optional=args.out_dir)
     assert_outputs_exist(parser, args, output_filenames)
-
-    if args.out_dir and not os.path.isdir(args.out_dir):
-        os.mkdir(args.out_dir)
 
     # Extract the voxels that match the label and save them to a file.
     cnt_filename = 0

--- a/scripts/tests/test_image_math.py
+++ b/scripts/tests/test_image_math.py
@@ -53,7 +53,7 @@ def test_execution_concat(script_runner):
     in_img_4 = os.path.join(get_home(), 'atlas', 'ids', '13.nii.gz')
     in_img_5 = os.path.join(get_home(), 'atlas', 'ids', '17.nii.gz')
     in_img_6 = os.path.join(get_home(), 'atlas', 'ids', '18.nii.gz')
-    ret = script_runner.run('scil_image_math.py', 'concat',
+    ret = script_runner.run('scil_image_math.py', 'concatenate',
                             in_img_1, in_img_2, in_img_3, in_img_4, in_img_5,
                             in_img_6, 'concat_ids.nii.gz')
     assert ret.success


### PR DESCRIPTION
Resolving issue #235 

I thought that a heuristic was not a robust/useful approach to common operations I know are possible (e.g adding 100+ labels in in16) so I modified all operations so they could be performed on the fly one image at the time.
This does not affect the speed in an observable way below 10 images, slightly slower than before above 25-50. To my surprise, since `AverageImages` is multiprocessed (1 main CPU and multiple readers) `scil_image_math.py ` is actually faster in CPU-times! So I think it's fine just like that.

Before all operations were capped at around 100 3D images in float32, now I can call any operation with hundreds of images!
Operations such as concatenate (of 3D images still rely on 4D image routine so this one have the same limitation as before

Operations having only one/two inputs (threshold, clip, difference, subtraction, division, convert) are now slightly slower than before due to the robustness increased (Not really observable, like 10% of 0.8sec).

Since all operations are performed using `nibabel` caching system and that operations were also used with `scil_connectivity_math.py` I had to switch to Nifti1Image for connectivity matrices before sending them to the operations.
This has no consequences on speed for `scil_connectivity_math.py` (None observable).

While testing everything I had to fix a few bugs & update the `scil_split_volume_by_*` scripts.
Since half of that code is also @ppoulin91 I think you could review/test it.