### PR TITLE
Fix scil_prepare_* so empty options does not crash

### DIFF
--- a/scripts/scil_prepare_eddy_command.py
+++ b/scripts/scil_prepare_eddy_command.py
@@ -78,7 +78,7 @@ def _build_arg_parser():
                    help='if set, will use the fixed seed strategy for eddy.\n'
                         'Enhances reproducibility.')
 
-    p.add_argument('--eddy_options',  default=None,
+    p.add_argument('--eddy_options',  default='',
                    help='Additional options you want to use to run eddy.\n'
                         'Add these options using quotes (i.e. "--ol_nstd=6'
                         ' --mb=4").')

--- a/scripts/scil_prepare_topup_command.py
+++ b/scripts/scil_prepare_topup_command.py
@@ -67,7 +67,7 @@ def _build_arg_parser():
                         'else, will output the lines to the ' +
                         'terminal [%(default)s].')
 
-    p.add_argument('--topup_options',  default=None,
+    p.add_argument('--topup_options',  default='',
                    help='Additional options you want to use to run topup.\n'
                         'Add these options using quotes (i.e. "--fwhm=6'
                         ' --miter=4").')
@@ -90,7 +90,7 @@ def main():
 
     assert_inputs_exist(parser, required_args)
     assert_outputs_exist(parser, args, [], args.out_b0s)
-    assert_fsl_options_exist(parser, args.topup_options)
+    assert_fsl_options_exist(parser, args.topup_options, 'topup')
 
     if os.path.splitext(args.out_prefix)[1] != '':
         parser.error('The prefix must not contain any extension.')


### PR DESCRIPTION
Added cmd, switch default to empty string instead of none