### PR TITLE
FIX - Robustness in decompose due to invalid streamlines

### DIFF
--- a/scripts/scil_decompose_connectivity.py
+++ b/scripts/scil_decompose_connectivity.py
@@ -109,9 +109,20 @@ def _save_if_needed(sft, hdf5_file, args,
                     save_type, step_type,
                     in_label, out_label):
     if step_type == 'final':
+        # Due to the cutting, streamlines can become invalid
+        indices = []
+        for i in range(len(sft)):
+            norm = np.linalg.norm(np.gradient(sft.streamlines[i],
+                                                axis=0), axis=1)
+            if (norm < 0.001).any():# or len(sft.streamlines[i]) <= 1:
+                indices.append(i)
+
+        indices = np.setdiff1d(range(len(sft)), indices).astype(np.uint32)
+        sft = sft[indices]
+
         group = hdf5_file.create_group('{}_{}'.format(in_label, out_label))
         group.create_dataset('data', data=sft.streamlines._data,
-                             dtype=np.float16)
+                             dtype=np.float32)
         group.create_dataset('offsets', data=sft.streamlines._offsets,
                              dtype=np.int64)
         group.create_dataset('lengths', data=sft.streamlines._lengths,
@@ -125,20 +136,10 @@ def _save_if_needed(sft, hdf5_file, args,
         out_paths = _get_output_paths(args)
 
         if saving_options[save_type] and len(sft):
-            indices = []
-            indices = [i for i in range(len(sft)) if len(
-                sft.streamlines[i]) <= 1]
-
-            for i in np.setdiff1d(range(len(sft)), indices):
-                norm = np.linalg.norm(np.gradient(sft.streamlines[i],
-                                                  axis=0), axis=1)
-                if (norm < 0.001).any():
-                    indices.append(i)
             out_name = os.path.join(out_paths[step_type],
                                     '{}_{}.trk'.format(in_label,
                                                        out_label))
-            save_tractogram(sft[np.setdiff1d(range(len(sft)), indices)],
-                            out_name)
+            save_tractogram(sft, out_name)
 
 
 def _prune_segments(segments, min_length, max_length, vox_size):

--- a/scripts/scil_decompose_connectivity.py
+++ b/scripts/scil_decompose_connectivity.py
@@ -113,8 +113,8 @@ def _save_if_needed(sft, hdf5_file, args,
         indices = []
         for i in range(len(sft)):
             norm = np.linalg.norm(np.gradient(sft.streamlines[i],
-                                                axis=0), axis=1)
-            if (norm < 0.001).any():# or len(sft.streamlines[i]) <= 1:
+                                              axis=0), axis=1)
+            if (norm < 0.001).any():  # or len(sft.streamlines[i]) <= 1:
                 indices.append(i)
 
         indices = np.setdiff1d(range(len(sft)), indices).astype(np.uint32)

--- a/scripts/scil_decompose_connectivity.py
+++ b/scripts/scil_decompose_connectivity.py
@@ -125,10 +125,20 @@ def _save_if_needed(sft, hdf5_file, args,
         out_paths = _get_output_paths(args)
 
         if saving_options[save_type] and len(sft):
+            indices = []
+            indices = [i for i in range(len(sft)) if len(
+                sft.streamlines[i]) <= 1]
+
+            for i in np.setdiff1d(range(len(sft)), indices):
+                norm = np.linalg.norm(np.gradient(sft.streamlines[i],
+                                                  axis=0), axis=1)
+                if (norm < 0.001).any():
+                    indices.append(i)
             out_name = os.path.join(out_paths[step_type],
                                     '{}_{}.trk'.format(in_label,
                                                        out_label))
-            save_tractogram(sft, out_name)
+            save_tractogram(sft[np.setdiff1d(range(len(sft)), indices)],
+                            out_name)
 
 
 def _prune_segments(segments, min_length, max_length, vox_size):

--- a/scripts/scil_remove_invalid_streamlines.py
+++ b/scripts/scil_remove_invalid_streamlines.py
@@ -13,7 +13,6 @@ within the bounding box
 import argparse
 import logging
 
-from dipy.io.stateful_tractogram import StatefulTractogram
 from dipy.io.streamline import save_tractogram
 import numpy as np
 
@@ -68,10 +67,9 @@ def main():
     if args.remove_single_point:
         # Will try to do a PR in Dipy
         indices = [i for i in range(len(sft)) if len(sft.streamlines[i]) <= 1]
-        remaining_indices = np.setdiff1d(range(len(sft)), indices)
 
     if args.remove_overlapping_points:
-        for i in remaining_indices:
+        for i in np.setdiff1d(range(len(sft)), indices):
             norm = np.linalg.norm(np.gradient(sft.streamlines[i],
                                               axis=0), axis=1)
             if (norm < 0.001).any():
@@ -79,10 +77,7 @@ def main():
 
     indices = np.setdiff1d(range(len(sft)), indices)
     if len(indices):
-        new_sft = StatefulTractogram.from_sft(
-            sft.streamlines[indices], sft,
-            data_per_point=sft.data_per_point[indices],
-            data_per_streamline=sft.data_per_streamline[indices])
+        new_sft = sft[indices]
     else:
         new_sft = sft
     logging.warning('Removed {} invalid streamlines.'.format(

--- a/scripts/scil_remove_invalid_streamlines.py
+++ b/scripts/scil_remove_invalid_streamlines.py
@@ -75,7 +75,7 @@ def main():
             if (norm < 0.001).any():
                 indices.append(i)
 
-    indices = np.setdiff1d(range(len(sft)), indices)
+    indices = np.setdiff1d(range(len(sft)), indices).astype(np.uint32)
     if len(indices):
         new_sft = sft[indices]
     else:


### PR DESCRIPTION
While processing a lot of data, I realized that sometime the decompose would produce an invalid streamline during the cutting portion. An infinitely small step for example, combine with the cast to float16 this produced overlapping point and then crash in cython code such as  grid_intersection.

This happened with like 10 streamlines over 100 HCP subject, so super rare. Yet I observed it. So here is a small fix to remove invalid right before saving, and reverted to float32 in case.