### PR TITLE
BF: fixed Matplotlib backend in dockerfile

### DIFF
--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -15,3 +15,5 @@ RUN mv scilpy-${SCILPY_VERSION} scilpy
 
 WORKDIR /scilpy
 RUN pip install -e .
+
+RUN sed -i '41s/.*/backend : Agg/' /usr/local/lib/python3.7/site-packages/matplotlib/mpl-data/matplotlibrc


### PR DESCRIPTION
Fixed the mpl backend setup for the Docker container, to avoid issues such as crashing when plotting the residuals figures in scil_compute_dti_metrics.py