### PR TITLE
Chord chart connectivity

### DIFF
--- a/scilpy/viz/chord_chart.py
+++ b/scilpy/viz/chord_chart.py
@@ -1,5 +1,11 @@
 # -*- coding: utf-8 -*-
 
+"""
+Most code here is from https://github.com/fengwangPhysics/matplotlib-chord-diagram.
+It was adapted to our specific needs: size of matrix, order of magnitude of
+max/min values, alpha for visualisation, etc.
+"""
+
 import math
 import matplotlib
 from matplotlib.path import Path
@@ -8,6 +14,20 @@ import numpy as np
 
 
 def polar2xy(r, theta):
+    """
+    Plot each shell
+
+    Parameters
+    ----------
+    r: float
+        The norm/radius
+    theta: float
+        The angle in radian
+    Return
+    ------
+    numpy.ndarray
+        the x/y coordinates
+    """
     return np.array([r*np.cos(theta), r*np.sin(theta)])
 
 

--- a/scilpy/viz/chord_chart.py
+++ b/scilpy/viz/chord_chart.py
@@ -1,0 +1,235 @@
+# -*- coding: utf-8 -*-
+
+import math
+import matplotlib
+from matplotlib.path import Path
+import matplotlib.patches as patches
+import numpy as np
+
+
+def polar2xy(r, theta):
+    return np.array([r*np.cos(theta), r*np.sin(theta)])
+
+
+def alpha_from_angle(angles_1, threshold, alpha, angles_2=None):
+    importance = np.abs(angles_1[0] - angles_1[1])
+    if angles_2 is not None:
+        importance += np.abs(angles_2[0] - angles_2[1])
+
+    importance = math.degrees(importance)
+    if importance > threshold:
+        alpha = 0.90
+    elif threshold > 0:
+        alpha = importance/threshold * alpha
+    else:
+        alpha = 0.90
+    return alpha
+
+
+def IdeogramArc(start=0, end=60, radius=1.0, width=0.2, ax=None,
+                color=(1, 0, 0)):
+    # start, end should be in [0, 360)
+    if start > end:
+        start, end = end, start
+    start *= np.pi/180.
+    end *= np.pi/180.
+    # optimal distance to the control points
+    # https://stackoverflow.com/questions/1734745/how-to-create-circle-with-b%C3%A9zier-curves
+    opt = 4./3. * np.tan((end-start) / 4.) * radius
+    inner = radius*(1-width)
+    verts = [
+        polar2xy(radius, start),
+        polar2xy(radius, start) + polar2xy(opt, start+0.5*np.pi),
+        polar2xy(radius, end) + polar2xy(opt, end-0.5*np.pi),
+        polar2xy(radius, end),
+        polar2xy(inner, end),
+        polar2xy(inner, end) + polar2xy(opt*(1-width), end-0.5*np.pi),
+        polar2xy(inner, start) + polar2xy(opt*(1-width), start+0.5*np.pi),
+        polar2xy(inner, start),
+        polar2xy(radius, start),
+    ]
+
+    codes = [Path.MOVETO,
+             Path.CURVE4,
+             Path.CURVE4,
+             Path.CURVE4,
+             Path.LINETO,
+             Path.CURVE4,
+             Path.CURVE4,
+             Path.CURVE4,
+             Path.CLOSEPOLY,
+             ]
+
+    if ax is None:
+        return verts, codes
+    else:
+        path = Path(verts, codes)
+        patch = patches.PathPatch(path, facecolor=color+(0.5,),
+                                  edgecolor=color+(0.4,), lw=0.3, alpha=1.0)
+        ax.add_patch(patch)
+
+
+def ChordArc(start1=0, end1=60, start2=180, end2=240,
+             radius=1.0, chordwidth=0.7, ax=None, color=(1, 0, 0),
+             angle_threshold=1, alpha=0.1):
+    # start, end should be in [0, 360)
+    if start1 > end1:
+        start1, end1 = end1, start1
+    if start2 > end2:
+        start2, end2 = end2, start2
+    start1 *= np.pi/180.
+    end1 *= np.pi/180.
+    start2 *= np.pi/180.
+    end2 *= np.pi/180.
+    opt1 = 4./3. * np.tan((end1-start1) / 4.) * radius
+    opt2 = 4./3. * np.tan((end2-start2) / 4.) * radius
+    rchord = radius * (1-chordwidth)
+    verts = [polar2xy(radius, start1),
+             polar2xy(radius, start1) + polar2xy(opt1, start1+0.5*np.pi),
+             polar2xy(radius, end1) + polar2xy(opt1, end1-0.5*np.pi),
+             polar2xy(radius, end1),
+             polar2xy(rchord, end1),
+             polar2xy(rchord, start2),
+             polar2xy(radius, start2),
+             polar2xy(radius, start2) + polar2xy(opt2, start2+0.5*np.pi),
+             polar2xy(radius, end2) + polar2xy(opt2, end2-0.5*np.pi),
+             polar2xy(radius, end2),
+             polar2xy(rchord, end2),
+             polar2xy(rchord, start1),
+             polar2xy(radius, start1), ]
+
+    codes = [Path.MOVETO,
+             Path.CURVE4,
+             Path.CURVE4,
+             Path.CURVE4,
+             Path.CURVE4,
+             Path.CURVE4,
+             Path.CURVE4,
+             Path.CURVE4,
+             Path.CURVE4,
+             Path.CURVE4,
+             Path.CURVE4,
+             Path.CURVE4,
+             Path.CURVE4, ]
+
+    if ax is None:
+        return verts, codes
+    else:
+        path = Path(verts, codes)
+
+        alpha_to_set = alpha_from_angle((start1, end1),
+                                        threshold=angle_threshold, alpha=alpha,
+                                        angles_2=(start2, end2))
+        patch = patches.PathPatch(
+            path, facecolor=color+(0.5,), edgecolor=color+(0.4,), lw=0.3,
+            alpha=alpha_to_set)
+        ax.add_patch(patch)
+
+
+def selfChordArc(start=0, end=60, radius=1.0, chordwidth=0.7, ax=None,
+                 color=(1, 0, 0), angle_threshold=1, alpha=0.1):
+    # start, end should be in [0, 360)
+    if start > end:
+        start, end = end, start
+    start *= np.pi/180.
+    end *= np.pi/180.
+    opt = 4./3. * np.tan((end-start) / 4.) * radius
+    rchord = radius * (1-chordwidth)
+    verts = [polar2xy(radius, start),
+             polar2xy(radius, start) + polar2xy(opt, start+0.5*np.pi),
+             polar2xy(radius, end) + polar2xy(opt, end-0.5*np.pi),
+             polar2xy(radius, end),
+             polar2xy(rchord, end),
+             polar2xy(rchord, start),
+             polar2xy(radius, start), ]
+
+    codes = [Path.MOVETO,
+             Path.CURVE4,
+             Path.CURVE4,
+             Path.CURVE4,
+             Path.CURVE4,
+             Path.CURVE4,
+             Path.CURVE4, ]
+
+    if ax is None:
+        return verts, codes
+    else:
+        path = Path(verts, codes)
+        path = Path(verts, codes)
+        alpha_to_set = alpha_from_angle((start, end),
+                                        threshold=angle_threshold, alpha=alpha)
+        patch = patches.PathPatch(
+            path, facecolor=color+(0.5,), edgecolor=color+(0.4,), lw=0.3,
+            alpha=alpha_to_set)
+        ax.add_patch(patch)
+
+
+def chordDiagram(X, ax, colors=None, width=0.1, pad=2, chordwidth=0.7,
+                 angle_threshold=1, alpha=0.1):
+    """Plot a chord diagram
+    Parameters
+    ----------
+    X :
+        flux data, X[i, j] is the flux from i to j
+    ax :
+        matplotlib `axes` to show the plot
+    colors : optional
+        user defined colors in rgb format.
+    width : optional
+        width/thickness of the ideogram arc
+    pad : optional
+        gap pad between two neighboring ideogram arcs, unit: degree,
+        default: 2 degree
+    chordwidth : optional
+        position of the control points for the chords,
+        controlling the shape of the chords
+    """
+    # X[i, j]:  i -> j
+    x = X.sum(axis=1)  # sum over rows
+    ax.set_xlim(-1.1, 1.1)
+    ax.set_ylim(-1.1, 1.1)
+
+    if colors is None:
+        cmap = matplotlib.cm.get_cmap('plasma')
+        colors = [cmap(i)[0:3] for i in np.linspace(0, 1, len(x))]
+
+    # find position for each start and end
+    y = x/np.sum(x).astype(float) * (360 - pad*len(x))
+
+    pos = {}
+    arc = []
+    nodePos = []
+    start = 0
+    for i in range(len(x)):
+        end = start + y[i]
+        arc.append((start, end))
+        angle = 0.5*(start+end)
+
+        if 90 <= angle <= 270:
+            angle += 180
+        nodePos.append(
+            tuple(polar2xy(1.1, 0.5*(start+end)*np.pi/180.)) + (angle,))
+        z = (X[i, :]/x[i].astype(float)) * (end - start)
+        ids = np.argsort(z)
+        z0 = start
+        for j in ids:
+            pos[(i, j)] = (z0, z0+z[j])
+            z0 += z[j]
+        start = end + pad
+
+    for i in range(len(x)):
+        start, end = arc[i]
+        IdeogramArc(start=start, end=end, radius=1.0,
+                    ax=ax, color=colors[i], width=width)
+        start, end = pos[(i, i)]
+        selfChordArc(start, end, radius=1.-width,
+                     color=colors[i], chordwidth=chordwidth*0.7, ax=ax,
+                     alpha=alpha, angle_threshold=angle_threshold)
+        for j in range(i):
+            start1, end1 = pos[(i, j)]
+            start2, end2 = pos[(j, i)]
+            ChordArc(start1, end1, start2, end2,
+                     radius=1.-width, color=colors[i], chordwidth=chordwidth,
+                     ax=ax, alpha=alpha, angle_threshold=angle_threshold)
+
+    return nodePos

--- a/scilpy/viz/chord_chart.py
+++ b/scilpy/viz/chord_chart.py
@@ -165,7 +165,7 @@ def selfChordArc(start=0, end=60, radius=1.0, chordwidth=0.7, ax=None,
 
 
 def chordDiagram(X, ax, colors=None, width=0.1, pad=2, chordwidth=0.7,
-                 angle_threshold=1, alpha=0.1):
+                 angle_threshold=1, alpha=0.1, text_dist=1.1):
     """Plot a chord diagram
     Parameters
     ----------
@@ -186,8 +186,8 @@ def chordDiagram(X, ax, colors=None, width=0.1, pad=2, chordwidth=0.7,
     """
     # X[i, j]:  i -> j
     x = X.sum(axis=1)  # sum over rows
-    ax.set_xlim(-1.1, 1.1)
-    ax.set_ylim(-1.1, 1.1)
+    ax.set_xlim(-text_dist, text_dist)
+    ax.set_ylim(-text_dist, text_dist)
 
     if colors is None:
         cmap = matplotlib.cm.get_cmap('plasma')
@@ -207,8 +207,10 @@ def chordDiagram(X, ax, colors=None, width=0.1, pad=2, chordwidth=0.7,
 
         if 90 <= angle <= 270:
             angle += 180
+        if angle >= 360:
+            angle -= 360
         nodePos.append(
-            tuple(polar2xy(1.1, 0.5*(start+end)*np.pi/180.)) + (angle,))
+            tuple(polar2xy(text_dist, 0.5*(start+end)*np.pi/180.)) + (angle,))
         z = (X[i, :]/x[i].astype(float)) * (end - start)
         ids = np.argsort(z)
         z0 = start

--- a/scilpy/viz/chord_chart.py
+++ b/scilpy/viz/chord_chart.py
@@ -37,17 +37,16 @@ def IdeogramArc(start=0, end=60, radius=1.0, width=0.2, ax=None,
     # https://stackoverflow.com/questions/1734745/how-to-create-circle-with-b%C3%A9zier-curves
     opt = 4./3. * np.tan((end-start) / 4.) * radius
     inner = radius*(1-width)
-    verts = [
-        polar2xy(radius, start),
-        polar2xy(radius, start) + polar2xy(opt, start+0.5*np.pi),
-        polar2xy(radius, end) + polar2xy(opt, end-0.5*np.pi),
-        polar2xy(radius, end),
-        polar2xy(inner, end),
-        polar2xy(inner, end) + polar2xy(opt*(1-width), end-0.5*np.pi),
-        polar2xy(inner, start) + polar2xy(opt*(1-width), start+0.5*np.pi),
-        polar2xy(inner, start),
-        polar2xy(radius, start),
-    ]
+    verts = [polar2xy(radius, start),
+             polar2xy(radius, start) + polar2xy(opt, start+0.5*np.pi),
+             polar2xy(radius, end) + polar2xy(opt, end-0.5*np.pi),
+             polar2xy(radius, end),
+             polar2xy(inner, end),
+             polar2xy(inner, end) + polar2xy(opt*(1-width), end-0.515*np.pi),
+             polar2xy(inner, start) + polar2xy(opt *
+                                               (1-width), start+0.515*np.pi),
+             polar2xy(inner, start),
+             polar2xy(radius, start), ]
 
     codes = [Path.MOVETO,
              Path.CURVE4,
@@ -57,8 +56,7 @@ def IdeogramArc(start=0, end=60, radius=1.0, width=0.2, ax=None,
              Path.CURVE4,
              Path.CURVE4,
              Path.CURVE4,
-             Path.CLOSEPOLY,
-             ]
+             Path.CLOSEPOLY, ]
 
     if ax is None:
         return verts, codes

--- a/scripts/scil_visualize_connectivity.py
+++ b/scripts/scil_visualize_connectivity.py
@@ -13,6 +13,15 @@ This script can either display the axis labels as:
 
 If the matrix was made from a bigger matrix using scil_reorder_connectivity.py,
 provide the text file(s), using --labels_list and/or --reorder_txt.
+
+The chord chart is always displaying parting in the order they are defined
+(clockwise), the color is attributed in that order following a colormap. The
+thickness of the line represent the 'size/intensity', the greater the value is
+the thicker the line will be. In order to hide the low values, two options are
+available:
+- Angle threshold + alpha, any connections with a small angle on the chord chart
+    will be slightly transparent to increase the focus on bigger connections.
+- Percentile, hide any connections with a value below that percentile
 """
 
 import argparse
@@ -72,7 +81,7 @@ def _build_arg_parser():
 
     histo = p.add_argument_group(title='Histogram options')
     histo.add_argument('--histogram', metavar='FILENAME',
-                       help='Compute and display/save an histogram of weigth.')
+                       help='Compute and display/save an histogram of weights.')
     histo.add_argument('--nb_bins', type=int,
                        help='Number of bins to use for the histogram.')
     histo.add_argument('--exclude_zeros', action='store_true',
@@ -92,10 +101,12 @@ def _build_arg_parser():
                        help='Opacity for the smaller angle on the chord (0-1). '
                             '[%(default)s]')
     chord.add_argument('--text_size', default=10, type=float,
-                       help='Size of the font for the parcels name/number.')
+                       help='Size of the font for the parcels name/number '
+                            '[%(default)s].')
     chord.add_argument('--text_distance', type=float, default=1.1,
                        help='Distance from the center so the parcels '
-                            'name/number do not overlap with the diagram')
+                            'name/number do not overlap \nwith the diagram '
+                            '[%(default)s].')
 
     p.add_argument('--log', action='store_true',
                    help='Apply a base 10 logarithm to the matrix.')

--- a/scripts/scil_visualize_connectivity.py
+++ b/scripts/scil_visualize_connectivity.py
@@ -113,7 +113,7 @@ def write_values(ax, matrix, properties):
     font0.set_size(properties[0])
     for x in range(width):
         for y in range(height):
-            value = round(matrix[y][x], properties[1])
+            value = round(matrix[x][y], properties[1])
             ax.annotate(str(value), xy=(x, y), fontproperties=font0,
                         horizontalalignment='center')
     return ax

--- a/scripts/scil_visualize_connectivity.py
+++ b/scripts/scil_visualize_connectivity.py
@@ -73,6 +73,9 @@ def _build_arg_parser():
                     help='Colormap to use for the matrix. [%(default)s]')
     g2.add_argument('--display_legend', action='store_true',
                     help='Display the colorbar next to the matrix.')
+    g2.add_argument('--legend_min_max', nargs=2, metavar=('MIN', 'MAX'),
+                    type=float, default=None,
+                    help='Manually define the min/max of the legend.')
     g2.add_argument('--write_values', nargs=2, metavar=('FONT_SIZE', 'DECIMAL'),
                     default=None, type=int,
                     help='Write the values at the center of each node.\n'
@@ -150,10 +153,16 @@ def main():
     else:
         min_value = np.min(matrix)
 
+    max_value = None
+    if args.legend_min_max is not None:
+        min_value = args.legend_min_max[0]
+        max_value = args.legend_min_max[1]
+
+
     fig, ax = plt.subplots()
     im = ax.imshow(matrix.T,
                    interpolation='nearest',
-                   cmap=args.colormap, vmin=min_value)
+                   cmap=args.colormap, vmin=min_value, vmax=max_value)
 
     if args.write_values:
         if np.prod(matrix.shape) > 1000:

--- a/scripts/tests/test_visualize_connectivity.py
+++ b/scripts/tests/test_visualize_connectivity.py
@@ -27,5 +27,5 @@ def test_execution_connectivity(script_runner):
                             'sc_norm.png', '--log', '--display_legend',
                             '--labels_list', in_labels_list,
                             '--histogram', 'hist.png', '--nb_bins', '50',
-                            '--exclude_zeros')
+                            '--exclude_zeros', '--chord_chart', 'sc_chord.png')
     assert ret.success


### PR DESCRIPTION
Added options for visualization of connectivity, chord chart!
This is very hard to do in matplotlib (or even in fancy library like Plotly), I used some code I found online and modified it to our need.

This option works best with matrix containing around 25-250 connections, more than that and it requires heavy fine-tunning for it to look nice (likely not possible with the scripts).

It also has some difficulties if the biggest connection is 10x higher values than the second or weird extreme distribution.
Otherwise it works pretty well.

Only makes sense for streamlines count and volume matrix, does not make sense with length or FA.

![sc_vol_normalized_chord-min](https://user-images.githubusercontent.com/10820351/95882695-ff2e5e00-0d47-11eb-83fd-bb4dee8becfa.png)

https://drive.google.com/file/d/1Zka8-xmb1xwJGT7QRW4NRO3LaQIkk3W6/view?usp=sharing