### PR TITLE
Change version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ Cython==0.29.*
 dipy==1.2.*
 fury==0.2.*
 future==0.17.*
-h5py==2.9.*
+h5py==2.10.*
 kiwisolver==1.0.*
 matplotlib==2.2.*
 nibabel==3.0.*
@@ -20,7 +20,7 @@ scikit-learn==0.22.*
 scipy==1.4.*
 setuptools==46.1.*
 six==1.15.*
-vtk==9.0.1
+vtk>=8.0.0,<10.0.0
 trimeshpy==0.0.*
 coloredlogs==10.0.*
 nilearn==0.6.*

--- a/scilpy/version.py
+++ b/scilpy/version.py
@@ -3,10 +3,10 @@
 import glob
 
 # Format expected by setup.py and doc/source/conf.py: string of form "X.Y.Z"
-_version_major = 0
-_version_minor = 2
+_version_major = 1
+_version_minor = 0
 _version_micro = ''
-_version_extra = 'dev'
+_version_extra = ''
 
 # Construct full version string from these.
 _ver = [_version_major, _version_minor]

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@ import os
 from setuptools import setup, find_packages, Extension
 from setuptools.command.build_ext import build_ext
 
-
 with open('requirements.txt') as f:
     required_dependencies = f.read().splitlines()
     external_dependencies = []


### PR DESCRIPTION
Change the version number, adapted requirements for centOS (clusters or Linux Kernel in Bordeaux)
The change to VTK will always take the highest available version (which is currently 8.1.* on centOS and 9.0.* on Ubuntu)