### PR TITLE
BF (bug fix) reorder visualize connectivty 

### DIFF
--- a/scripts/scil_visualize_connectivity.py
+++ b/scripts/scil_visualize_connectivity.py
@@ -135,8 +135,8 @@ def main():
         fig.colorbar(im, ax=ax)
 
     if args.name_axis:
-        x_ticks = np.arange(matrix.shape[0])
-        y_ticks = np.arange(matrix.shape[1])
+        y_ticks = np.arange(matrix.shape[0])
+        x_ticks = np.arange(matrix.shape[1])
 
         if args.labels_list:
             labels_list = np.loadtxt(args.labels_list, dtype=np.int16).tolist()
@@ -146,17 +146,17 @@ def main():
                     or len(labels_list) != matrix.shape[1]:
                 logging.warning('The provided matrix not the same size as '
                                 'the labels list.')
-            x_legend = labels_list[0:matrix.shape[0]]
-            y_legend = labels_list[0:matrix.shape[1]]
+            y_legend = labels_list[0:matrix.shape[0]]
+            x_legend = labels_list[0:matrix.shape[1]]
         else:
-            x_legend = x_ticks
             y_legend = y_ticks
+            x_legend = x_ticks
 
         if args.reorder_txt:
             with open(args.reorder_txt, 'r') as my_file:
                 lines = my_file.readlines()
-                x_legend = [int(val) for val in lines[0].split()]
-                y_legend = [int(val) for val in lines[1].split()]
+                y_legend = [int(val) for val in lines[0].split()]
+                x_legend = [int(val) for val in lines[1].split()]
 
         if args.lookup_table:
             if args.reorder_txt:
@@ -166,31 +166,31 @@ def main():
             with open(args.lookup_table) as json_data:
                 lut = json.load(json_data)
 
-            x_legend = []
             y_legend = []
+            x_legend = []
             if args.reorder_txt:
                 with open(args.reorder_txt, 'r') as my_file:
                     lines = my_file.readlines()
-                    x_list = [int(val) for val in lines[0].split()]
-                    y_list = [int(val) for val in lines[1].split()]
+                    y_list = [int(val) for val in lines[0].split()]
+                    x_list = [int(val) for val in lines[1].split()]
             else:
-                x_list = labels_list[0:matrix.shape[0]]
-                y_list = labels_list[0:matrix.shape[1]]
+                y_list = labels_list[0:matrix.shape[0]]
+                x_list = labels_list[0:matrix.shape[1]]
 
-            x_legend = [lut[str(x)] if str(x) in lut else str(x)
-                        for x in x_list]
             y_legend = [lut[str(x)] if str(x) in lut else str(x)
                         for x in y_list]
+            x_legend = [lut[str(x)] if str(x) in lut else str(x)
+                        for x in x_list]
 
-        if len(x_ticks) != len(x_legend) \
-                or len(y_ticks) != len(y_legend):
+        if len(y_ticks) != len(y_legend) \
+                or len(x_ticks) != len(x_legend):
             logging.warning('Legend is not the same size as the data.'
                             'Make sure you are using the same reordering '
                             'json.')
-        plt.xticks(y_ticks, y_legend,
+        plt.xticks(x_ticks, x_legend,
                    rotation=args.axis_text_angle[0],
                    fontsize=args.axis_text_size[0])
-        plt.yticks(x_ticks, x_legend,
+        plt.yticks(y_ticks, y_legend,
                    rotation=args.axis_text_angle[1],
                    fontsize=args.axis_text_size[1])
 

--- a/scripts/scil_visualize_connectivity.py
+++ b/scripts/scil_visualize_connectivity.py
@@ -42,7 +42,8 @@ def _build_arg_parser():
                     help='List saved by the decomposition script,\n'
                          'must contain labels rather than coordinates (.txt).')
     g1.add_argument('--reorder_txt',
-                    help='File with two rows (x/y) listing the ordering (.txt).')
+                    help='File with two rows (x/y) listing the ordering '
+                         '(.txt).')
     g1.add_argument('--lookup_table',
                     help='Lookup table with the label number as keys and the '
                          'name as values.')
@@ -53,14 +54,17 @@ def _build_arg_parser():
     g2.add_argument('--axis_text_size', nargs=2, metavar=('X_SIZE', 'Y_SIZE'),
                     default=(10, 10),
                     help='Font size of the X and Y axis labels. [%(default)s]')
-    g2.add_argument('--axis_text_angle', nargs=2, metavar=('X_ANGLE', 'Y_ANGLE'),
+    g2.add_argument('--axis_text_angle', nargs=2,
+                    metavar=('X_ANGLE', 'Y_ANGLE'),
                     default=(90, 0),
-                    help='Text angle of the X and Y axis labels. [%(default)s]')
+                    help='Text angle of the X and Y axis labels. '
+                         '[%(default)s]')
     g2.add_argument('--colormap', default='viridis',
                     help='Colormap to use for the matrix. [%(default)s]')
     g2.add_argument('--display_legend', action='store_true',
                     help='Display the colorbar next to the matrix.')
-    g2.add_argument('--write_values', nargs=2, metavar=('FONT_SIZE', 'DECIMAL'),
+    g2.add_argument('--write_values', nargs=2,
+                    metavar=('FONT_SIZE', 'DECIMAL'),
                     default=None, type=int,
                     help='Write the values at the center of each node.\n'
                          'The font size and the rouding parameters can be '
@@ -156,8 +160,9 @@ def main():
 
         if args.lookup_table:
             if args.reorder_txt:
-                logging.warning('Using a lookup table, make sure the reordering '
-                                'json contain labels, not coordinates')
+                logging.warning('Using a lookup table, make sure the '
+                                'reordering json contain labels, not '
+                                'coordinates')
             with open(args.lookup_table) as json_data:
                 lut = json.load(json_data)
 
@@ -180,11 +185,12 @@ def main():
         if len(x_ticks) != len(x_legend) \
                 or len(y_ticks) != len(y_legend):
             logging.warning('Legend is not the same size as the data.'
-                            'Make sure you are using the same reordering json.')
-        plt.xticks(x_ticks, x_legend,
+                            'Make sure you are using the same reordering '
+                            'json.')
+        plt.xticks(y_ticks, y_legend,
                    rotation=args.axis_text_angle[0],
                    fontsize=args.axis_text_size[0])
-        plt.yticks(y_ticks, y_legend,
+        plt.yticks(x_ticks, x_legend,
                    rotation=args.axis_text_angle[1],
                    fontsize=args.axis_text_size[1])
 


### PR DESCRIPTION
(duplicate from old PR344 but with clean history)
Bug detected by Sami with non-square connectivity matrices.
To test this:
https://www.dropbox.com/s/ge4qpxi8934sbt5/PR_BF_reorder.zip?dl=0

Try these 2 commands:
scil_reorder_connectivity.py sc.npy test_short.txt --labels_list atlas_brainnetome_v2_labels_list_final.txt --out_suffix _reordered -f
scil_visualize_connectivity.py sc_reordered.npy sc_reordered.png --labels_list atlas_brainnetome_v2_labels_list_final.txt --reorder_txt test_short.txt --name_axis --axis_text_size 4 4 --display_legend -f