### PR TITLE
scil connectivity Normalization fix by zero labels

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,5 +30,5 @@ googledrivedownloader==0.*
 requests==2.23.*
 bctpy==0.5.*
 statsmodels==0.11.*
-dmri-commit==1.3.*
+#dmri-commit==1.3.*
 openpyxl==2.6.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,5 +30,5 @@ googledrivedownloader==0.*
 requests==2.23.*
 bctpy==0.5.*
 statsmodels==0.11.*
-#dmri-commit==1.3.*
+dmri-commit==1.3.*
 openpyxl==2.6.*

--- a/scripts/scil_normalize_connectivity.py
+++ b/scripts/scil_normalize_connectivity.py
@@ -139,7 +139,7 @@ def main():
 
         voxels_vol = np.prod(atlas_img.header.get_zooms()[:3])
         voxels_sur = np.prod(atlas_img.header.get_zooms()[:2])
-
+        
         # Excluding background (0)
         labels_list = np.loadtxt(labels_filepath)
         if len(labels_list) != in_matrix.shape[0] \
@@ -174,8 +174,12 @@ def main():
                 factor_list.append(np.count_nonzero(
                     atlas_data == label) * voxels_vol)
             else:
-                factor_list.append(approximate_surface_node(
-                    atlas_data, label) * voxels_sur)
+                if np.count_nonzero(atlas_data == label): 
+                    factor_list.append(approximate_surface_node(
+                        atlas_data, label) * voxels_sur)
+                else:
+                    factor_list.append(0)
+                    
 
         for pos_1, pos_2 in all_comb:
             factor = factor_list[pos_1] + factor_list[pos_2]

--- a/scripts/scil_normalize_connectivity.py
+++ b/scripts/scil_normalize_connectivity.py
@@ -30,8 +30,8 @@ Normalize a connectivity matrix coming from scil_decompose_connectivity.py.
  - sum_to_one: Ensure the sum of all edges weight is one
  - log_10: Apply a base 10 logarithm to all edges weight
 
-The volume and length matrix should come from the scil_decompose_connectivity.py
-script.
+The volume and length matrix should come from the
+scil_decompose_connectivity.py script.
 
 A review of the type of normalization is available in:
 Colon-Perez, Luis M., et al. "Dimensionless, scale-invariant, edge weight
@@ -72,7 +72,8 @@ def _build_arg_parser():
     edge_p = p.add_argument_group('Edge-wise options')
     length = edge_p.add_mutually_exclusive_group()
     length.add_argument('--length', metavar='LENGTH_MATRIX',
-                        help='Length matrix used for edge-wise multiplication.')
+                        help='Length matrix used for '
+                        'edge-wise multiplication.')
     length.add_argument('--inverse_length', metavar='LENGTH_MATRIX',
                         help='Length matrix used for edge-wise division.')
     edge_p.add_argument('--bundle_volume', metavar='VOLUME_MATRIX',
@@ -134,12 +135,13 @@ def main():
         atlas_data = get_data_as_label(atlas_img)
 
         voxels_size = atlas_img.header.get_zooms()[:3]
-        if voxels_size[0] != voxels_size[1] or voxels_size[0] != voxels_size[2]:
+        if voxels_size[0] != voxels_size[1] \
+           or voxels_size[0] != voxels_size[2]:
             parser.error('Atlas must have an isotropic resolution.')
 
         voxels_vol = np.prod(atlas_img.header.get_zooms()[:3])
         voxels_sur = np.prod(atlas_img.header.get_zooms()[:2])
-        
+
         # Excluding background (0)
         labels_list = np.loadtxt(labels_filepath)
         if len(labels_list) != in_matrix.shape[0] \
@@ -174,12 +176,11 @@ def main():
                 factor_list.append(np.count_nonzero(
                     atlas_data == label) * voxels_vol)
             else:
-                if np.count_nonzero(atlas_data == label): 
+                if np.count_nonzero(atlas_data == label):
                     factor_list.append(approximate_surface_node(
                         atlas_data, label) * voxels_sur)
                 else:
                     factor_list.append(0)
-                    
 
         for pos_1, pos_2 in all_comb:
             factor = factor_list[pos_1] + factor_list[pos_2]


### PR DESCRIPTION
Sami had 4 subjects with label 90 with 0 voxels in them after warping to MNI.
Maybe sign of an issue but regardless, we should deal with the case label is empty. The volume normalization was doing this check but not the surface normalization.

This should fix it.

Data to test: https://www.dropbox.com/s/kuwb5lhs8339x5v/normalization_fix.zip?dl=0
Command ran:
scil_normalize_connectivity.py sc.npy sc_surface_normalized.npy --parcel_surface atlas_brainnetome_v2_mni.nii.gz brainnetome_mni.txt