### PR TITLE
ENH: Add ratio to pairwise_agreement

### DIFF
--- a/scripts/scil_evaluate_bundles_pairwise_agreement_measures.py
+++ b/scripts/scil_evaluate_bundles_pairwise_agreement_measures.py
@@ -70,6 +70,11 @@ def _build_arg_parser():
                    help='Compare inputs to this single file.')
     p.add_argument('--keep_tmp', action='store_true',
                    help='Will not delete the tmp folder at the end.')
+    p.add_argument('--ratio', action='store_true',
+                   help='Return overlap and overreach as a ratio over the '
+                        'reference tractogram in a Tractometer-style way. Can '
+                        'only be used if also using the `single_compare` '
+                        'option.')
 
     add_processes_arg(p)
     add_reference_arg(p)
@@ -149,6 +154,7 @@ def compute_all_measures(args):
     filename_2, reference_2 = tuple_2
     streamline_dice = args[1]
     disable_streamline_distance = args[2]
+    ratio = args[3]
 
     if not is_header_compatible(reference_1, reference_2):
         raise ValueError('{} and {} have incompatible headers'.format(
@@ -186,6 +192,13 @@ def compute_all_measures(args):
     volume_overreach_endpoints = np.abs(np.count_nonzero(
         endpoints_density_1 + endpoints_density_2) - volume_overlap_endpoints)
 
+    if ratio:
+        count = np.count_nonzero(binary_1)
+        volume_overlap /= count
+        volume_overlap_endpoints /= count
+        volume_overreach /= count
+        volume_overreach_endpoints /= count
+
     # These measures are in mm
     bundle_adjacency_voxel = compute_bundle_adjacency_voxel(density_1,
                                                             density_2,
@@ -222,6 +235,10 @@ def compute_all_measures(args):
                      'volume_overreach_endpoints',
                      'density_correlation',
                      'density_correlation_endpoints']
+
+    # If computing ratio, voxel size does not make sense
+    if ratio:
+        voxel_size = 1.
     measures = [bundle_adjacency_voxel,
                 dice_vox, w_dice_vox,
                 volume_overlap * voxel_size,
@@ -260,6 +277,9 @@ def main():
 
     assert_inputs_exist(parser, args.in_bundles)
     assert_outputs_exist(parser, args, [args.out_json])
+
+    if args.ratio and not args.single_compare:
+        parser.error('Can only compute ratio if also using `single_compare`')
 
     nbr_cpu = validate_nbr_processes(parser, args)
 
@@ -306,14 +326,16 @@ def main():
         all_measures_dict = []
         for i in comb_dict_keys:
             all_measures_dict.append(compute_all_measures([
-                i, args.streamline_dice, args.disable_streamline_distance]))
+                i, args.streamline_dice, args.disable_streamline_distance,
+                args.ratio]))
     else:
         all_measures_dict = pool.map(
             compute_all_measures,
             zip(comb_dict_keys,
                 itertools.repeat(
                     args.streamline_dice),
-                itertools.repeat(args.disable_streamline_distance)))
+                itertools.repeat(args.disable_streamline_distance),
+                itertools.repeat(args.ratio)))
         pool.close()
         pool.join()
 

--- a/scripts/scil_evaluate_bundles_pairwise_agreement_measures.py
+++ b/scripts/scil_evaluate_bundles_pairwise_agreement_measures.py
@@ -59,9 +59,8 @@ def _build_arg_parser():
                    help='Path of the input bundles.')
     p.add_argument('out_json',
                    help='Path of the output json file.')
-
     p.add_argument('--streamline_dice', action='store_true',
-                   help='Streamlines-wise Dice coefficient will be computed \n'
+                   help='Compute streamline-wise dice coefficient.\n'
                         'Tractograms must be identical [%(default)s].')
     p.add_argument('--disable_streamline_distance', action='store_true',
                    help='Will not compute the streamlines distance \n'
@@ -71,9 +70,9 @@ def _build_arg_parser():
     p.add_argument('--keep_tmp', action='store_true',
                    help='Will not delete the tmp folder at the end.')
     p.add_argument('--ratio', action='store_true',
-                   help='Return overlap and overreach as a ratio over the '
-                        'reference tractogram in a Tractometer-style way. Can '
-                        'only be used if also using the `single_compare` '
+                   help='Compute overlap and overreach as a ratio over the\n'
+                        'reference tractogram in a Tractometer-style way.\n'
+                        'Can only be used if also using the `single_compare` '
                         'option.')
 
     add_processes_arg(p)

--- a/scripts/tests/test_evaluate_bundles_pairwise_agreement_measures.py
+++ b/scripts/tests/test_evaluate_bundles_pairwise_agreement_measures.py
@@ -13,8 +13,9 @@ tmp_dir = tempfile.TemporaryDirectory()
 
 
 def test_help_option(script_runner):
-    ret = script_runner.run('scil_evaluate_bundles_pairwise_agreement_measures.py',
-                            '--help')
+    ret = script_runner.run(
+        'scil_evaluate_bundles_pairwise_agreement_measures.py',
+        '--help')
     assert ret.success
 
 
@@ -26,10 +27,11 @@ def test_execution_bundles(script_runner):
                         'bundle_0.trk')
     in_ref = os.path.join(get_home(), 'bundles',
                           'bundle_all_1mm.nii.gz')
-    ret = script_runner.run('scil_evaluate_bundles_pairwise_agreement_measures.py',
-                            in_1, in_2, 'AF_L_similarity.json',
-                            '--streamline_dice', '--reference', in_ref,
-                            '--processes', '1')
+    ret = script_runner.run(
+        'scil_evaluate_bundles_pairwise_agreement_measures.py',
+        in_1, in_2, 'AF_L_similarity.json',
+        '--streamline_dice', '--reference', in_ref,
+        '--processes', '1')
     assert ret.success
 
 
@@ -41,11 +43,12 @@ def test_single(script_runner):
                         'bundle_0.trk')
     in_ref = os.path.join(get_home(), 'bundles',
                           'bundle_all_1mm.nii.gz')
-    ret = script_runner.run('scil_evaluate_bundles_pairwise_agreement_measures.py',
-                            in_2, 'AF_L_similarity_single.json',
-                            '--streamline_dice', '--reference', in_ref,
-                            '--single_compare', in_1,
-                            '--processes', '1')
+    ret = script_runner.run(
+        'scil_evaluate_bundles_pairwise_agreement_measures.py',
+        in_2, 'AF_L_similarity_single.json',
+        '--streamline_dice', '--reference', in_ref,
+        '--single_compare', in_1,
+        '--processes', '1')
     assert ret.success
 
 
@@ -57,12 +60,13 @@ def test_ratio(script_runner):
                         'bundle_0.trk')
     in_ref = os.path.join(get_home(), 'bundles',
                           'bundle_all_1mm.nii.gz')
-    ret = script_runner.run('scil_evaluate_bundles_pairwise_agreement_measures.py',
-                            in_2, 'AF_L_similarity_ratio.json',
-                            '--streamline_dice', '--reference', in_ref,
-                            '--single_compare', in_1,
-                            '--processes', '1',
-                            '--ratio')
+    ret = script_runner.run(
+        'scil_evaluate_bundles_pairwise_agreement_measures.py',
+        in_2, 'AF_L_similarity_ratio.json',
+        '--streamline_dice', '--reference', in_ref,
+        '--single_compare', in_1,
+        '--processes', '1',
+        '--ratio')
     assert ret.success
 
 
@@ -77,9 +81,10 @@ def test_ratio_fail(script_runner):
                         'bundle_0.trk')
     in_ref = os.path.join(get_home(), 'bundles',
                           'bundle_all_1mm.nii.gz')
-    ret = script_runner.run('scil_evaluate_bundles_pairwise_agreement_measures.py',
-                            in_1, in_2, 'AF_L_similarity_fail.json',
-                            '--streamline_dice', '--reference', in_ref,
-                            '--processes', '1',
-                            '--ratio')
+    ret = script_runner.run(
+        'scil_evaluate_bundles_pairwise_agreement_measures.py',
+        in_1, in_2, 'AF_L_similarity_fail.json',
+        '--streamline_dice', '--reference', in_ref,
+        '--processes', '1',
+        '--ratio')
     assert not ret.success

--- a/scripts/tests/test_evaluate_bundles_pairwise_agreement_measures.py
+++ b/scripts/tests/test_evaluate_bundles_pairwise_agreement_measures.py
@@ -31,3 +31,55 @@ def test_execution_bundles(script_runner):
                             '--streamline_dice', '--reference', in_ref,
                             '--processes', '1')
     assert ret.success
+
+
+def test_single(script_runner):
+    os.chdir(os.path.expanduser(tmp_dir.name))
+    in_1 = os.path.join(get_home(), 'bundles',
+                        'bundle_0_reco.tck')
+    in_2 = os.path.join(get_home(), 'bundles', 'voting_results',
+                        'bundle_0.trk')
+    in_ref = os.path.join(get_home(), 'bundles',
+                          'bundle_all_1mm.nii.gz')
+    ret = script_runner.run('scil_evaluate_bundles_pairwise_agreement_measures.py',
+                            in_2, 'AF_L_similarity_single.json',
+                            '--streamline_dice', '--reference', in_ref,
+                            '--single_compare', in_1,
+                            '--processes', '1')
+    assert ret.success
+
+
+def test_ratio(script_runner):
+    os.chdir(os.path.expanduser(tmp_dir.name))
+    in_1 = os.path.join(get_home(), 'bundles',
+                        'bundle_0_reco.tck')
+    in_2 = os.path.join(get_home(), 'bundles', 'voting_results',
+                        'bundle_0.trk')
+    in_ref = os.path.join(get_home(), 'bundles',
+                          'bundle_all_1mm.nii.gz')
+    ret = script_runner.run('scil_evaluate_bundles_pairwise_agreement_measures.py',
+                            in_2, 'AF_L_similarity_ratio.json',
+                            '--streamline_dice', '--reference', in_ref,
+                            '--single_compare', in_1,
+                            '--processes', '1',
+                            '--ratio')
+    assert ret.success
+
+
+def test_ratio_fail(script_runner):
+    """ Test ratio without single_compare argument.
+    The test should fail.
+    """
+    os.chdir(os.path.expanduser(tmp_dir.name))
+    in_1 = os.path.join(get_home(), 'bundles',
+                        'bundle_0_reco.tck')
+    in_2 = os.path.join(get_home(), 'bundles', 'voting_results',
+                        'bundle_0.trk')
+    in_ref = os.path.join(get_home(), 'bundles',
+                          'bundle_all_1mm.nii.gz')
+    ret = script_runner.run('scil_evaluate_bundles_pairwise_agreement_measures.py',
+                            in_1, in_2, 'AF_L_similarity_fail.json',
+                            '--streamline_dice', '--reference', in_ref,
+                            '--processes', '1',
+                            '--ratio')
+    assert not ret.success


### PR DESCRIPTION
Add tractometer-style overlap and overreach output as a ratio over the "gold-standard" instead of absolute values.

@arnaudbore @frheault @GuillaumeTh