### PR TITLE
Resample bvals

### DIFF
--- a/scripts/scil_resample_bvals.py
+++ b/scripts/scil_resample_bvals.py
@@ -33,6 +33,9 @@ def _build_arg_parser():
     parser.add_argument('bvals',
                         help='The b-values in FSL format.')
 
+    parser.add_argument('bvecs',
+                        help='The b-vectors in FSL format.')
+
     parser.add_argument('bvals_to_extract', nargs='+',
                         metavar='bvals-to-extract', type=int,
                         help='The list of b-values to extract. For example '
@@ -62,20 +65,31 @@ def main():
     assert_inputs_exist(parser, [args.bvals])
     assert_outputs_exist(parser, args, [args.output_bvals])
 
-    bvals,  = read_bvals_bvecs(args.bvals)
+    bvals, bvecs = read_bvals_bvecs(args.bvals, args.bvecs)
 
     # Find the volume indices that correspond to the shells to extract.
     tol = args.tolerance
 
-    centroids,shell_indices = identify_shells(bvals, tol, True)
+    centroids,shell_indices = identify_shells(bvals, tol, False)
 
-    print(centroids)
-    print(shell_indices)
+    bvals_to_extract = args.bvals_to_extract
+    n_shells = np.shape(bvals_to_extract)[0]
 
-    logging.info("Selected indices: {}".format(shell_indices))
+    logging.info("number of shells: {}".format(n_shells))
+    logging.info("bvals to extract: {}".format(bvals_to_extract))
+    logging.info("estimated centroids: {}".format(centroids))
+    logging.info("original bvals: {}".format(bvals))
+    logging.info("selected indices: {}".format(shell_indices))
+
+    new_bvals = np.zeros(np.shape(bvals))
+    for i in range(n_shells):
+        new_bvals[np.where(shell_indices == i)] = bvals_to_extract[i]
+
+    logging.info("new bvals: {}".format(new_bvals))
 
     np.savetxt(args.output_bvals, new_bvals, '%d')
 
+    
 
 if __name__ == "__main__":
     main()

--- a/scripts/scil_resample_bvals.py
+++ b/scripts/scil_resample_bvals.py
@@ -3,7 +3,7 @@
 
 """
 Resample b-values on specific b-value shells for sampling schemes where
-b-values of a shell are not all identicall. The --tolerance
+b-values of a shell are not all identical. The --tolerance
 argument needs to be adjusted to vary the accepted interval around the
 targetted b-value.
 

--- a/scripts/scil_resample_bvals.py
+++ b/scripts/scil_resample_bvals.py
@@ -10,7 +10,7 @@ targetted b-value.
 For example, a b-value of 2000 and a tolerance of 20 will resample all 
 volumes with a b-values from 1980 to 2020 to the value of 2000.
 
-scil_resample_bvals.py grad.bval 0 1000 2000 new_grad.bval --tolerance 20
+scil_resample_bvals.py bvals bvecs 0 1000 2000 newbvals --tolerance 20
 """
 
 import argparse
@@ -66,7 +66,6 @@ def main():
     assert_outputs_exist(parser, args, [args.output_bvals])
 
     bvals, bvecs = read_bvals_bvecs(args.bvals, args.bvecs)
-
     # Find the volume indices that correspond to the shells to extract.
     tol = args.tolerance
 
@@ -86,10 +85,8 @@ def main():
         new_bvals[np.where(shell_indices == i)] = bvals_to_extract[i]
 
     logging.info("new bvals: {}".format(new_bvals))
-
     np.savetxt(args.output_bvals, new_bvals, '%d')
 
-    
 
 if __name__ == "__main__":
     main()

--- a/scripts/scil_resample_bvals.py
+++ b/scripts/scil_resample_bvals.py
@@ -4,10 +4,10 @@
 """
 Resample b-values on specific b-value shells for sampling schemes where
 b-values of a shell are not all identicall. The --tolerance
-argument needs to be adjusted to vary the accepted interval around the 
-targetted b-value. 
+argument needs to be adjusted to vary the accepted interval around the
+targetted b-value.
 
-For example, a b-value of 2000 and a tolerance of 20 will resample all 
+For example, a b-value of 2000 and a tolerance of 20 will resample all
 volumes with a b-values from 1980 to 2020 to the value of 2000.
 
 scil_resample_bvals.py bvals bvecs 0 1000 2000 newbvals --tolerance 20
@@ -69,7 +69,7 @@ def main():
     # Find the volume indices that correspond to the shells to extract.
     tol = args.tolerance
 
-    centroids,shell_indices = identify_shells(bvals, tol, False)
+    centroids, shell_indices = identify_shells(bvals, tol)
 
     bvals_to_extract = args.bvals_to_extract
     n_shells = np.shape(bvals_to_extract)[0]

--- a/scripts/scil_resample_bvals.py
+++ b/scripts/scil_resample_bvals.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Resample b-values on specific b-value shells for sampling schemes where
+b-values of a shell are not all identicall. The --tolerance
+argument needs to be adjusted to vary the accepted interval around the 
+targetted b-value. 
+
+For example, a b-value of 2000 and a tolerance of 20 will resample all 
+volumes with a b-values from 1980 to 2020 to the value of 2000.
+
+scil_resample_bvals.py grad.bval 0 1000 2000 new_grad.bval --tolerance 20
+"""
+
+import argparse
+import logging
+
+from dipy.io import read_bvals_bvecs
+import nibabel as nib
+import numpy as np
+
+from scilpy.io.utils import (add_overwrite_arg, add_verbose_arg,
+                             assert_inputs_exist, assert_outputs_exist)
+from scilpy.utils.bvec_bval_tools import identify_shells
+
+
+def _build_arg_parser():
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawTextHelpFormatter)
+
+    parser.add_argument('bvals',
+                        help='The b-values in FSL format.')
+
+    parser.add_argument('bvals_to_extract', nargs='+',
+                        metavar='bvals-to-extract', type=int,
+                        help='The list of b-values to extract. For example '
+                             '0 1000 2000.')
+
+    parser.add_argument('output_bvals',
+                        help='The name of the output b-values.')
+
+    parser.add_argument('--tolerance', '-t',
+                        metavar='INT', type=int, default=20,
+                        help='The tolerated gap between the b-values to '
+                             'extract\nand the actual b-values.')
+
+    add_verbose_arg(parser)
+    add_overwrite_arg(parser)
+
+    return parser
+
+
+def main():
+    parser = _build_arg_parser()
+    args = parser.parse_args()
+
+    if args.verbose:
+        logging.basicConfig(level=logging.INFO)
+
+    assert_inputs_exist(parser, [args.bvals])
+    assert_outputs_exist(parser, args, [args.output_bvals])
+
+    bvals,  = read_bvals_bvecs(args.bvals)
+
+    # Find the volume indices that correspond to the shells to extract.
+    tol = args.tolerance
+
+    centroids,shell_indices = identify_shells(bvals, tol, True)
+
+    print(centroids)
+    print(shell_indices)
+
+    logging.info("Selected indices: {}".format(shell_indices))
+
+    np.savetxt(args.output_bvals, new_bvals, '%d')
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Small script to create a new bval text file with rounded values according to the tolerance factor. 
Developed specifically for hcp_7T data but could be useful for other datasets. 