### PR TITLE
Update to save RAM and parameters optims

### DIFF
--- a/scilpy/io/image.py
+++ b/scilpy/io/image.py
@@ -61,6 +61,8 @@ def get_data_as_mask(in_img, dtype=np.uint8):
                 logging.warning('The two unique values in mask were not 0 and'
                                 ' 1. Tha mask has been binarised.')
                 data[data != 0] = 1
+        elif len(unique_vals) == 1:
+            data[data != 0] = 1
         else:
             raise IOError('The image {} contains more than 2 values. '
                           'It can\'t be loaded as mask.'.format(basename))

--- a/scilpy/segment/recobundlesx.py
+++ b/scilpy/segment/recobundlesx.py
@@ -92,7 +92,6 @@ class RecobundlesX(object):
         """
         self._cluster_model_bundle(model_bundle, model_clust_thr,
                                    identifier=identifier)
-
         if not self._reduce_search_space():
             if identifier:
                 logging.error('{0} did not find any neighbors in '
@@ -197,7 +196,7 @@ class RecobundlesX(object):
         slr_transform_type_id = possible_slr_transform_type[slr_transform_type]
         if slr_transform_type_id >= 0:
             init_transfo_dof = np.zeros(3)
-            slr = StreamlineLinearRegistration(metric=metric, method="Powell",
+            slr = StreamlineLinearRegistration(metric=metric, method="L-BFGS-B",
                                                x0=init_transfo_dof,
                                                bounds=bounds_dof[:3],
                                                num_threads=slr_num_thread)
@@ -248,7 +247,7 @@ class RecobundlesX(object):
         :param neighbors_cluster_thr, float, distance in mm for clustering.
         """
         # Neighbors can be refined since the search space is smaller
-        thresholds = [32, 16, neighbors_cluster_thr]
+        thresholds = [32, 16, 24, neighbors_cluster_thr]
 
         neighb_cluster_map = qbx_and_merge(self.neighb_streamlines, thresholds,
                                            nb_pts=self.nb_points,

--- a/scilpy/segment/voting_scheme.py
+++ b/scilpy/segment/voting_scheme.py
@@ -11,6 +11,7 @@ from time import time
 from dipy.segment.clustering import qbx_and_merge
 from dipy.tracking.streamline import transform_streamlines
 import nibabel as nib
+from nibabel.streamlines.array_sequence import ArraySequence
 import numpy as np
 from scipy.sparse import lil_matrix
 
@@ -125,7 +126,6 @@ class VotingScheme(object):
             if len(bundle) > 5000:
                 logging.warning(
                     '{0} has above 5000 streamlines'.format(filename))
-
         return model_bundles_dict
 
     def _find_max_in_sparse_matrix(self, bundle_id, min_vote, bundles_wise_vote):
@@ -226,10 +226,10 @@ class VotingScheme(object):
         load_timer = time()
         tractogram = nib.streamlines.load(input_tractogram_path)
         wb_streamlines = tractogram.streamlines
-
+        len_wb_streamlines = len(wb_streamlines)
         logging.debug('Tractogram {0} with {1} streamlines '
                       'is loaded in {2} seconds'.format(input_tractogram_path,
-                                                        len(wb_streamlines),
+                                                        len_wb_streamlines,
                                                         round(time() -
                                                               load_timer, 2)))
 
@@ -240,7 +240,13 @@ class VotingScheme(object):
         rbx_params_list = []
 
         # Each type of bundle is processed separately
+        model_bundles_dict = {}
         for bundle_id in range(len(bundle_names)):
+            # Using the tag previously generated, load the appropriate
+            # model bundles
+            model_bundles_dict.update(self._load_bundles_dictionary(
+                bundles_filepath[bundle_id]))
+
             # Using multiple seeds will result in a multiplicative factor
             # of the number of executions
             for seed in seeds:
@@ -270,28 +276,24 @@ class VotingScheme(object):
                                   self.multi_parameters,
                                   picked_parameters))
 
-                # Using the tag previously generated, load the appropriate
-                # model bundles
-                model_bundles_dict = self._load_bundles_dictionary(
-                    bundles_filepath[bundle_id])
-
                 # Each run (can) have their unique set of parameters
                 for parameters in picked_parameters:
                     tct, mct, bpt = parameters
 
                     # Each bundle (can) have multiple models
                     for tag in bundles_filepath[bundle_id]:
-                        model_bundle = model_bundles_dict[tag]
-                        rbx_params_list.append([bundle_id, tag, model_bundle,
+                        rbx_params_list.append([bundle_id, tag,
                                                 tct, mct, bpt,
                                                 slr_transform_type, seed])
 
-        # Clustring is now parallelize
-        pool = multiprocessing.Pool(nbr_processes)
         tmp_dir, tmp_memmap_filenames = streamlines_to_memmap(wb_streamlines)
         comb_param_cluster = product(self.tractogram_clustering_thr, seeds)
+
+        # Clustring is now parallelize
+        pool = multiprocessing.Pool(nbr_processes)
         all_rbx_dict = pool.map(single_clusterize_and_rbx_init,
-                                zip(repeat(tmp_memmap_filenames),
+                                zip(repeat(wb_streamlines),
+                                    repeat(tmp_memmap_filenames),
                                     comb_param_cluster,
                                     repeat(self.nb_points)))
         pool.close()
@@ -306,6 +308,7 @@ class VotingScheme(object):
         pool = multiprocessing.Pool(nbr_processes)
         all_recognized_dict = pool.map(single_recognize,
                                        zip(repeat(rbx_dict),
+                                           repeat(model_bundles_dict),
                                            rbx_params_list))
         pool.close()
         pool.join()
@@ -326,7 +329,7 @@ class VotingScheme(object):
 
         save_timer = time()
         bundles_wise_vote = lil_matrix((len(bundle_names),
-                                        len(wb_streamlines)),
+                                        len_wb_streamlines),
                                        dtype=np.int16)
 
         for bundle_id, recognized_indices in all_recognized_dict:
@@ -345,6 +348,7 @@ class VotingScheme(object):
         self._save_recognized_bundles(tractogram, bundle_names,
                                       bundles_wise_vote,
                                       minimum_vote, extension)
+
         logging.info('Saving of {0} files in {1} took {2} sec.'.format(
             len(bundle_names),
             self.output_directory,
@@ -376,16 +380,16 @@ def single_clusterize_and_rbx_init(args):
     rbx : dict
         Initialisation of the recobundles class using specific parameters.
     """
-    tmp_memmap_filename = args[0]
-    clustering_thr = args[1][0]
-    seed = args[1][1]
-    nb_points = args[2]
+    wb_streamlines = args[0]
+    tmp_memmap_filename = args[1]
+    clustering_thr = args[2][0]
+    seed = args[2][1]
+    nb_points = args[3]
 
     rbx = {}
     base_thresholds = [45, 35, 25]
     rng = np.random.RandomState(seed)
     cluster_timer = time()
-    wb_streamlines = reconstruct_streamlines_from_memmap(tmp_memmap_filename)
     # If necessary, add an extra layer (more optimal)
     if clustering_thr < 15:
         current_thr_list = base_thresholds + [15, clustering_thr]
@@ -399,7 +403,9 @@ def single_clusterize_and_rbx_init(args):
     clusters_indices = []
     for cluster in cluster_map.clusters:
         clusters_indices.append(cluster.indices)
-    centroids = list(cluster_map.centroids)
+    centroids = ArraySequence(cluster_map.centroids)
+    clusters_indices = ArraySequence(clusters_indices)
+    clusters_indices._data = clusters_indices._data.astype(np.int32)
 
     rbx[(seed, clustering_thr)] = RecobundlesX(tmp_memmap_filename,
                                                clusters_indices, centroids,
@@ -420,14 +426,13 @@ def single_recognize(args):
     ----------
     rbx_dict : dict
         Dictionary with int as key and QBx ClusterMap as values
-
+    model_dict : dict
+        Dictionary with model tag as key and model streamlines as values
     parameters_list : tuple (8)
         bundle_id : int
             Unique value to each bundle to identify them
         tag : str
             Model bundle filepath for logging
-        model_bundle : list or Array Sequence
-            Model bundle as loaded by the nibabel API
         tct : int
             Tractogram clustering threshold, distance in mm (for QBx)
         mct : int
@@ -449,17 +454,19 @@ def single_recognize(args):
             Streamlines indices from the original tractogram.
     """
     rbx_dict = args[0]
-    bundle_id = args[1][0]
-    tag = args[1][1]
-    model_bundle = args[1][2]
-    tct = args[1][3]
-    mct = args[1][4]
-    bpt = args[1][5]
-    slr_transform_type = args[1][6]
-    seed = args[1][7]
+    model_dict = args[1]
+    bundle_id = args[2][0]
+    tag = args[2][1]
+    tct = args[2][2]
+    mct = args[2][3]
+    bpt = args[2][4]
+    slr_transform_type = args[2][5]
+    seed = args[2][6]
+    model_bundle = model_dict[tag]
 
     # Use the appropriate initialisation of RBx from the provided parameters
     rbx = rbx_dict[(seed, tct)]
+    del rbx_dict
 
     tmp_split = str(tag).split('/')
     shorter_tag = os.path.join(*tmp_split[-3:])

--- a/scilpy/segment/voting_scheme.py
+++ b/scilpy/segment/voting_scheme.py
@@ -100,12 +100,13 @@ class VotingScheme(object):
 
         # Only keep the group of models where all files exist
         bundle_names_exist = [bundle_names[i] for i in to_keep]
-
         bundles_filepath_exist = [bundles_filepath[i] for i in to_keep]
         logging.info('{0} sub-model directory were found each '
                      'with {1} model bundles'.format(
                          len(self.atlas_dir),
                          len(bundle_names_exist)))
+        if len(bundle_names_exist) == 0:
+            raise IOError("No model bundles found, check input directory.")
 
         return bundle_names_exist, bundles_filepath_exist
 

--- a/scripts/scil_recognize_multi_bundles.py
+++ b/scripts/scil_recognize_multi_bundles.py
@@ -91,7 +91,7 @@ def _build_arg_parser():
                    type=int, default=[12], nargs='+',
                    help='Input tractogram clustering thresholds %(default)smm.')
 
-    p.add_argument('--seeds', type=int, default=[None], nargs='+',
+    p.add_argument('--seeds', type=int, default=[0], nargs='+',
                    help='Random number generator seed %(default)s\n'
                         'Will multiply the number of times Recobundles is ran.')
     p.add_argument('--inverse', action='store_true',


### PR DESCRIPTION
I realized I was generating all of thousands of parameters combinations AND including the models bundle in it. Meaning that if you run 18 parameters * 5 models * 2 seeds you are copying the model bundles that many times in memory before launching sub-processes. Oversight on my part, also I realized that copies (as many as # thread) of QBX indices was kept during the sub-processes despite not being needed for the whole time, so now it is deleted.

These two additions save quite a lot of RAM, enough that now I am fairly sure RBx can be run on the 192Gb node at 40 CPU !

Other tiny fixes on the side, I can explain if needed.