### PR TITLE
FIX: Add warning to reference and .trk

### DIFF
--- a/scilpy/io/streamlines.py
+++ b/scilpy/io/streamlines.py
@@ -85,7 +85,10 @@ def load_tractogram_with_reference(parser, args, filepath,
 
     _, ext = os.path.splitext(filepath)
     if ext == '.trk':
-        if args.reference:
+        if (
+            args.reference or
+            arg_name and args.__getattribute__(arg_name + '_ref')
+           ):
             logging.warning('--reference is discarded for this file format '
                             '{}.'.format(filepath))
         sft = load_tractogram(filepath, 'same',

--- a/scilpy/io/streamlines.py
+++ b/scilpy/io/streamlines.py
@@ -85,11 +85,9 @@ def load_tractogram_with_reference(parser, args, filepath,
 
     _, ext = os.path.splitext(filepath)
     if ext == '.trk':
-        if (
-            args.reference or
-            arg_name and args.__getattribute__(arg_name + '_ref')
-           ):
-            logging.warning('--reference is discarded for this file format '
+        if (getattr(args, 'reference', None) or
+                arg_name and args.__getattribute__(arg_name + '_ref')):
+            logging.warning('Reference is discarded for this file format '
                             '{}.'.format(filepath))
         sft = load_tractogram(filepath, 'same',
                               bbox_valid_check=bbox_check)

--- a/scilpy/io/streamlines.py
+++ b/scilpy/io/streamlines.py
@@ -85,8 +85,8 @@ def load_tractogram_with_reference(parser, args, filepath,
 
     _, ext = os.path.splitext(filepath)
     if ext == '.trk':
-        logging.warn('--reference is discarded for this file format '
-                     '{}.'.format(filepath))
+        logging.warning('--reference is discarded for this file format '
+                        '{}.'.format(filepath))
         sft = load_tractogram(filepath, 'same',
                               bbox_valid_check=bbox_check)
     elif ext in ['.tck', '.fib', '.vtk', '.dpy']:

--- a/scilpy/io/streamlines.py
+++ b/scilpy/io/streamlines.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from itertools import islice
+import logging
 import os
 import tempfile
 
@@ -84,6 +85,8 @@ def load_tractogram_with_reference(parser, args, filepath,
 
     _, ext = os.path.splitext(filepath)
     if ext == '.trk':
+        logging.warn('--reference is discarded for this file format '
+                     '{}.'.format(filepath))
         sft = load_tractogram(filepath, 'same',
                               bbox_valid_check=bbox_check)
     elif ext in ['.tck', '.fib', '.vtk', '.dpy']:

--- a/scilpy/io/streamlines.py
+++ b/scilpy/io/streamlines.py
@@ -85,8 +85,9 @@ def load_tractogram_with_reference(parser, args, filepath,
 
     _, ext = os.path.splitext(filepath)
     if ext == '.trk':
-        logging.warning('--reference is discarded for this file format '
-                        '{}.'.format(filepath))
+        if args.reference:
+            logging.warning('--reference is discarded for this file format '
+                            '{}.'.format(filepath))
         sft = load_tractogram(filepath, 'same',
                               bbox_valid_check=bbox_check)
     elif ext in ['.tck', '.fib', '.vtk', '.dpy']:


### PR DESCRIPTION
Add a warning when loading a .trk with a reference that the reference will be discarded. `scilpy.io.streamlines.load_tractogram_with_reference` was pulling a sneaky and discarding the reference without telling the user if the tractogram was a .trk. Atleast the user should be told that the reference is discarded.

@frheault @GuillaumeTh @arnaudbore 