### PR TITLE
FIX: Add reference to mosaic and check reference

### DIFF
--- a/scilpy/io/streamlines.py
+++ b/scilpy/io/streamlines.py
@@ -80,12 +80,17 @@ def ichunk(sequence, n):
         chunk = list(islice(sequence, n))
 
 
+def is_argument_set(args, arg_name):
+    # Check that attribute is not None
+    return not getattr(args, 'reference', None) is None
+
+
 def load_tractogram_with_reference(parser, args, filepath,
                                    bbox_check=True, arg_name=None):
 
     _, ext = os.path.splitext(filepath)
     if ext == '.trk':
-        if (getattr(args, 'reference', None) or
+        if (is_argument_set(args, 'reference') or
                 arg_name and args.__getattribute__(arg_name + '_ref')):
             logging.warning('Reference is discarded for this file format '
                             '{}.'.format(filepath))
@@ -101,7 +106,7 @@ def load_tractogram_with_reference(parser, args, filepath,
             else:
                 parser.error('--{} is required for this file format '
                              '{}.'.format(arg_ref, filepath))
-        elif (getattr(args, 'reference', None)) or args.reference is None:
+        elif (not is_argument_set(args, 'reference')) or args.reference is None:
             parser.error('--reference is required for this file format '
                          '{}.'.format(filepath))
         else:

--- a/scilpy/io/streamlines.py
+++ b/scilpy/io/streamlines.py
@@ -101,10 +101,9 @@ def load_tractogram_with_reference(parser, args, filepath,
             else:
                 parser.error('--{} is required for this file format '
                              '{}.'.format(arg_ref, filepath))
-        elif args.reference is None:
+        elif (getattr(args, 'reference', None)) or args.reference is None:
             parser.error('--reference is required for this file format '
                          '{}.'.format(filepath))
-
         else:
             sft = load_tractogram(filepath, args.reference,
                                   bbox_valid_check=bbox_check)

--- a/scripts/scil_visualize_bundles_mosaic.py
+++ b/scripts/scil_visualize_bundles_mosaic.py
@@ -24,6 +24,7 @@ from PIL import ImageDraw
 from scilpy.io.image import get_data_as_mask
 from scilpy.io.streamlines import load_tractogram_with_reference
 from scilpy.io.utils import (add_overwrite_arg,
+                             add_reference_arg,
                              assert_inputs_exist,
                              assert_outputs_exist,
                              assert_output_dirs_exist_and_empty)
@@ -64,6 +65,7 @@ def _build_arg_parser():
                    help='Resolution of thumbnails used in mosaic '
                         '[%(default)s].')
 
+    add_reference_arg(p)
     add_overwrite_arg(p)
     return p
 


### PR DESCRIPTION
- Add reference to `scil_visualize_bundles_mosaic.py`
- Add check that `--reference` is in args

Fixes #386 

@arnaudbore @frheault @GuillaumeTh 

Tests are running, will update once they're done