### PR TITLE
BF: Fix scil_compute_sh_from_signal uses full SH basis by default

### DIFF
--- a/scilpy/reconst/raw_signal.py
+++ b/scilpy/reconst/raw_signal.py
@@ -81,7 +81,7 @@ def compute_sh_coefficients(dwi, gradient_table, sh_order=4,
         sphere = Sphere(xyz=bvecs)
 
     # Fit SH
-    sh = sf_to_sh(weights, sphere, sh_order, basis_type, smooth)
+    sh = sf_to_sh(weights, sphere, sh_order, basis_type, smooth=smooth)
 
     # Apply mask
     if mask is not None:


### PR DESCRIPTION
Hi,
I changed the call to `sf_to_sh` in `scilpy/reconst/raw_signal.py` to respect the new DIPY 1.3 method signature, which is:
```
sf_to_sh(sf, sphere, sh_order=4, basis_type=None, full_basis=False, legacy=True, smooth=0.0)
```
Otherwise, the value of variable `smooth` is used for `full_basis` argument, and since it is not 0 by default, `sf_to_sh` returns coefficients for a full SH basis.

@arnaudbore