### PR TITLE
BF: Fix scil_reshape_to_reference crashes with TypeError

### DIFF
--- a/scilpy/utils/image.py
+++ b/scilpy/utils/image.py
@@ -64,7 +64,7 @@ def transform_anatomy(transfo, reference, moving, filename_to_save,
         raise ValueError('Does not support this dataset (shape, type, etc)')
 
 
-def transform_dwi(reg_obj, static, dwi, interp='linear'):
+def transform_dwi(reg_obj, static, dwi, interpolation='linear'):
     """
     Iteratively apply transformation to 4D image using Dipy's tool
 
@@ -76,7 +76,7 @@ def transform_dwi(reg_obj, static, dwi, interp='linear'):
         Target image data
     dwi: numpy.ndarray
         4D numpy array containing a scalar in each voxel (moving image data)
-    interp : string, either 'linear' or 'nearest'
+    interpolation : string, either 'linear' or 'nearest'
         the type of interpolation to be used, either 'linear'
         (for k-linear interpolation) or 'nearest' for nearest neighbor
     """

--- a/scilpy/utils/image.py
+++ b/scilpy/utils/image.py
@@ -83,7 +83,7 @@ def transform_dwi(reg_obj, static, dwi, interpolation='linear'):
     trans_dwi = np.zeros(static.shape + (dwi.shape[3],), dtype=dwi.dtype)
     for i in range(dwi.shape[3]):
         trans_dwi[..., i] = reg_obj.transform(dwi[..., i],
-                                              interpolation=interp)
+                                              interpolation=interpolation)
 
     return trans_dwi
 

--- a/scripts/tests/test_reshape_to_reference.py
+++ b/scripts/tests/test_reshape_to_reference.py
@@ -8,7 +8,7 @@ from scilpy.io.fetcher import get_testing_files_dict, fetch_data, get_home
 
 
 # If they already exist, this only takes 5 seconds (check md5sum)
-fetch_data(get_testing_files_dict(), keys=['others.zip'])
+fetch_data(get_testing_files_dict(), keys=['others.zip', 'commit_amico.zip'])
 tmp_dir = tempfile.TemporaryDirectory()
 
 
@@ -19,11 +19,19 @@ def test_help_option(script_runner):
 
 def test_execution_others(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
-    in_img = os.path.join(get_home(), 'others',
-                          't1_crop.nii.gz')
-    in_ref = os.path.join(get_home(), 'others',
-                          't1.nii.gz')
+    in_img = os.path.join(get_home(), 'others', 't1_crop.nii.gz')
+    in_ref = os.path.join(get_home(), 'others', 't1.nii.gz')
     ret = script_runner.run('scil_reshape_to_reference.py', in_img,
                             in_ref, 't1_reshape.nii.gz',
+                            '--interpolation', 'nearest')
+    assert ret.success
+
+
+def test_execution_4D(script_runner):
+    os.chdir(os.path.expanduser(tmp_dir.name))
+    in_img = os.path.join(get_home(), 'commit_amico', 'dwi.nii.gz')
+    in_ref = os.path.join(get_home(), 'others', 't1.nii.gz')
+    ret = script_runner.run('scil_reshape_to_reference.py', in_img,
+                            in_ref, 'dwi_reshape.nii.gz',
                             '--interpolation', 'nearest')
     assert ret.success


### PR DESCRIPTION
Hi,
When reshaping a 4D volume, `scil_reshape_to_reference` crashes because an unknown keyword argument is passed to `utils.image.transform_dwi`. I fixed it and added a test case to validate.

Thanks!