### PR TITLE
Fixing roi_center argparser

### DIFF
--- a/scripts/scil_compute_msmt_frf.py
+++ b/scripts/scil_compute_msmt_frf.py
@@ -124,7 +124,7 @@ def buildArgsParser():
              'either an int (e.g. --roi_radii 10) or an array-like (3,) '
              '(e.g. --roi_radii 20 30 10). [%(default)s]')
     p.add_argument(
-        '--roi_center', metavar='tuple(3)', type=int,
+        '--roi_center', metavar='tuple(3)', nargs=3, type=int,
         help='If supplied, use this center to span the cuboid roi '
              'using roi_radii. [center of the 3D volume] '
              '(e.g. --roi_center 66 79 79)')

--- a/scripts/scil_compute_ssst_frf.py
+++ b/scripts/scil_compute_ssst_frf.py
@@ -73,7 +73,7 @@ def _build_arg_parser():
                         'a cuboid spanning from the middle of the volume in '
                         'each direction with the different radii. The type is '
                         'either an int or an array-like (3,). [%(default)s]')
-    p.add_argument('--roi_center', metavar='tuple(3)', nargs=3, type=int
+    p.add_argument('--roi_center', metavar='tuple(3)', nargs=3, type=int,
                    help='If supplied, use this center to span the roi of size '
                         'roi_radius. [center of the 3D volume]')
 

--- a/scripts/scil_compute_ssst_frf.py
+++ b/scripts/scil_compute_ssst_frf.py
@@ -73,7 +73,7 @@ def _build_arg_parser():
                         'a cuboid spanning from the middle of the volume in '
                         'each direction with the different radii. The type is '
                         'either an int or an array-like (3,). [%(default)s]')
-    p.add_argument('--roi_center', metavar='tuple(3)',
+    p.add_argument('--roi_center', metavar='tuple(3)', nargs=3, type=int
                    help='If supplied, use this center to span the roi of size '
                         'roi_radius. [center of the 3D volume]')
 

--- a/scripts/tests/test_compute_msmt_frf.py
+++ b/scripts/tests/test_compute_msmt_frf.py
@@ -14,6 +14,7 @@ def test_help_option(script_runner):
     ret = script_runner.run('scil_compute_msmt_frf.py', '--help')
     assert ret.success
 
+
 def test_roi_radii_shape_parameter(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi = os.path.join(get_home(), 'commit_amico',

--- a/scripts/tests/test_compute_msmt_frf.py
+++ b/scripts/tests/test_compute_msmt_frf.py
@@ -14,6 +14,28 @@ def test_help_option(script_runner):
     ret = script_runner.run('scil_compute_msmt_frf.py', '--help')
     assert ret.success
 
+def test_roi_radii_shape_parameter(script_runner):
+    os.chdir(os.path.expanduser(tmp_dir.name))
+    in_dwi = os.path.join(get_home(), 'commit_amico',
+                          'dwi.nii.gz')
+    in_bval = os.path.join(get_home(), 'commit_amico',
+                           'dwi.bval')
+    in_bvec = os.path.join(get_home(), 'commit_amico',
+                           'dwi.bvec')
+    mask = os.path.join(get_home(), 'commit_amico',
+                           'mask.nii.gz')
+    ret = script_runner.run('scil_compute_msmt_frf.py', in_dwi,
+                            in_bval, in_bvec, 'wm_frf.txt', 'gm_frf.txt',
+                            'csf_frf.txt', '--mask', mask, '--roi_center',
+                            '15', '15', '15', '-f')
+    assert ret.success
+
+    ret = script_runner.run('scil_compute_msmt_frf.py', in_dwi,
+                            in_bval, in_bvec, 'wm_frf.txt', 'gm_frf.txt',
+                            'csf_frf.txt', '--mask', mask, '--roi_center',
+                            '15', '-f')
+
+    assert (not ret.success)
 
 def test_roi_radii_shape_parameter(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
@@ -28,7 +50,7 @@ def test_roi_radii_shape_parameter(script_runner):
     ret = script_runner.run('scil_compute_msmt_frf.py', in_dwi,
                             in_bval, in_bvec, 'wm_frf.txt', 'gm_frf.txt',
                             'csf_frf.txt', '--mask', mask, '--roi_radii',
-                            '37', '--roi_center', '15', '15', '15', '-f')
+                            '37', '-f')
     assert ret.success
 
     ret = script_runner.run('scil_compute_msmt_frf.py', in_dwi,

--- a/scripts/tests/test_compute_msmt_frf.py
+++ b/scripts/tests/test_compute_msmt_frf.py
@@ -28,7 +28,7 @@ def test_roi_radii_shape_parameter(script_runner):
     ret = script_runner.run('scil_compute_msmt_frf.py', in_dwi,
                             in_bval, in_bvec, 'wm_frf.txt', 'gm_frf.txt',
                             'csf_frf.txt', '--mask', mask, '--roi_radii',
-                            '37', '-f')
+                            '37', '--roi_center', '15', '15', '15', '-f')
     assert ret.success
 
     ret = script_runner.run('scil_compute_msmt_frf.py', in_dwi,

--- a/scripts/tests/test_compute_ssst_frf.py
+++ b/scripts/tests/test_compute_ssst_frf.py
@@ -15,6 +15,24 @@ def test_help_option(script_runner):
     ret = script_runner.run('scil_compute_ssst_frf.py', '--help')
     assert ret.success
 
+def test_roi_center_parameter(script_runner):
+    os.chdir(os.path.expanduser(tmp_dir.name))
+    in_dwi = os.path.join(get_home(), 'processing',
+                          'dwi_crop.nii.gz')
+    in_bval = os.path.join(get_home(), 'processing',
+                           'dwi.bval')
+    in_bvec = os.path.join(get_home(), 'processing',
+                           'dwi.bvec')
+    ret = script_runner.run('scil_compute_ssst_frf.py', in_dwi,
+                            in_bval, in_bvec, 'frf.txt', '--roi_center',
+                            '15', '15', '15', '-f')
+    assert ret.success
+
+    ret = script_runner.run('scil_compute_ssst_frf.py', in_dwi,
+                            in_bval, in_bvec, 'frf.txt', '--roi_center',
+                            '15', '-f')
+
+    assert (not ret.success)
 
 def test_roi_radii_shape_parameter(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))

--- a/scripts/tests/test_compute_ssst_frf.py
+++ b/scripts/tests/test_compute_ssst_frf.py
@@ -15,6 +15,7 @@ def test_help_option(script_runner):
     ret = script_runner.run('scil_compute_ssst_frf.py', '--help')
     assert ret.success
 
+
 def test_roi_center_parameter(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi = os.path.join(get_home(), 'processing',


### PR DESCRIPTION
Quick fix of the `--roi_center` argument for `scil_compute_ssst_frf.py` and `scil_compute_msmt_frf.py`. It was missing `nargs=3` so it could not actually be used. I added `--roi_center` to the tests of these scripts so a quick pytest should do it.