### PR TITLE
FIX: Process pool bug in `scil_evaluate_bundles_pairwise_agreement_measures`

### DIFF
--- a/scripts/scil_evaluate_bundles_pairwise_agreement_measures.py
+++ b/scripts/scil_evaluate_bundles_pairwise_agreement_measures.py
@@ -285,6 +285,8 @@ def main():
         parser.error('Can only compute ratio if also using `single_compare`')
 
     nbr_cpu = validate_nbr_processes(parser, args)
+    if nbr_cpu > 1:
+        pool = multiprocessing.Pool(nbr_cpu)
 
     if not os.path.isdir('tmp_measures/'):
         os.mkdir('tmp_measures/')
@@ -315,7 +317,6 @@ def main():
                                       bundles_references_tuple[i][1],
                                       True, args.disable_streamline_distance])
         else:
-            pool = multiprocessing.Pool(nbr_cpu)
             pool.map(load_data_tmp_saving,
                      zip([tup[0] for tup in bundles_references_tuple],
                          [tup[1] for tup in bundles_references_tuple],


### PR DESCRIPTION
Process pool may have not been initialized if `single_compare` was used.

@frheault @arnaudbore @GuillaumeTh 