### PR TITLE
ENH: Add local orientation and uniform coloring to `scil_visualize_bundles`

### DIFF
--- a/scripts/scil_visualize_bundles.py
+++ b/scripts/scil_visualize_bundles.py
@@ -44,10 +44,11 @@ def _build_arg_parser():
         description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
     p.add_argument('in_bundles', nargs='+',
                    help='List of tractography files supported by nibabel.')
-    coloring_group = p.add_mutually_exclusive_group()
+    p2 = p.add_argument_group(title='Colouring options')
+    coloring_group = p2.add_mutually_exclusive_group()
     coloring_group.add_argument('--random_coloring', metavar='SEED', type=int,
                                 help='Assign a random color to bundles.')
-    coloring_group.add_argument('--uniform_coloring', metavar='R G B',
+    coloring_group.add_argument('--uniform_coloring', metavar=('R', 'G', 'B'),
                                 nargs=3,
                                 help='Assign a uniform color to streamlines.')
     coloring_group.add_argument('--local_coloring', action='store_true',
@@ -80,7 +81,7 @@ def _build_arg_parser():
     p.add_argument('--downsample', type=int, default=None,
                    help='Downsample streamlines to N points.'
                    '\n[Default: %(default)s]')
-    p.add_argument('--background', metavar='R G B', nargs=3,
+    p.add_argument('--background', metavar=('R', 'G', 'B'), nargs=3,
                    default=[0, 0, 0], type=parser_color_type,
                    help='RBG values [0, 255] of the color of the background.'
                    '\n[Default: %(default)s]')

--- a/scripts/scil_visualize_bundles.py
+++ b/scripts/scil_visualize_bundles.py
@@ -48,7 +48,7 @@ def _build_arg_parser():
     coloring_group.add_argument('--random_coloring', metavar='SEED', type=int,
                                 help='Assign a random color to bundles.')
     coloring_group.add_argument('--uniform_coloring', metavar='R G B',
-                                nargs='+',
+                                nargs=3,
                                 help='Assign a uniform color to streamlines.')
     coloring_group.add_argument('--local_coloring', action='store_true',
                                 help='Assign coloring to streamlines '
@@ -80,7 +80,7 @@ def _build_arg_parser():
     p.add_argument('--downsample', type=int, default=None,
                    help='Downsample streamlines to N points.'
                    '\n[Default: %(default)s]')
-    p.add_argument('--background', metavar='R G B', nargs='+',
+    p.add_argument('--background', metavar='R G B', nargs=3,
                    default=[0, 0, 0], type=parser_color_type,
                    help='RBG values [0, 255] of the color of the background.'
                    '\n[Default: %(default)s]')


### PR DESCRIPTION
As title says. Default coloring (by fury-gl) remains to compute a single color for each streamlines based on its endpoints

If you have the rbx atlas downloaded, you can test with:

Local coloring:
`$ ./scripts/scil_visualize_bundles.py atlas/**/* --local_coloring --width=0.35 --subsample 5`
![image](https://user-images.githubusercontent.com/10272382/108938935-e9e30d80-761e-11eb-8075-1e622b4a4f34.png)

Uniform coloring:
`$ ./scripts/scil_visualize_bundles.py atlas/**/* --width=0.35 --subsample 5 --uniform_coloring 50 100 85`
![image](https://user-images.githubusercontent.com/10272382/108939284-77bef880-761f-11eb-889b-f4d50d8ca5c5.png)

Default coloring:
`$ ./scripts/scil_visualize_bundles.py atlas/**/* --width=0.35 --subsample 5`
![image](https://user-images.githubusercontent.com/10272382/108939379-9ae9a800-761f-11eb-9602-e63410878119.png)

@arnaudbore @frheault @GuillaumeTh 