### PR TITLE
[FIX] MultiVoxelFit is badly constructed after a multiprocess fit

### DIFF
--- a/scilpy/reconst/multi_processes.py
+++ b/scilpy/reconst/multi_processes.py
@@ -81,7 +81,13 @@ def fit_from_model(model, data, mask=None, nbr_processes=None):
     for i, fit in results:
         tmp_fit_array[chunk_len[i]:chunk_len[i+1]] = fit
 
-    fit_array[mask] = tmp_fit_array
+    fit_results_mask = np.array(
+        [not isinstance(it, int) for it in tmp_fit_array]
+    )
+
+    mask[mask] = fit_results_mask
+
+    fit_array[mask] = tmp_fit_array[fit_results_mask]
     fit_array = MultiVoxelFit(model, fit_array, mask)
 
     return fit_array


### PR DESCRIPTION
When fitting using multiple processes with `fit_from_model`, if some data points included in the mask are empty, the `fit_from_model_parallel` will return a 0 instead of a Fit object. Subsequent calls to attributes of the MultiVoxelFit object constructed with those fits will fail, since those zeros are not excluded from the mask fed to it.

Added a masking routine to exclude those voxels from the MultiVoxelFit mask.