### PR TITLE
[ENH] Extend extract_b0 capabilities

### DIFF
--- a/scilpy/image/utils.py
+++ b/scilpy/image/utils.py
@@ -43,6 +43,11 @@ def volume_iterator(img, blocksize=1, start=0, end=0):
         Image of a 4D volume with shape X,Y,Z,N
     blocksize : int, optional
         Number of volumes to return in a single batch
+    start : int, optional
+        Starting iteration index in the 4D volume
+    end : int, optional
+        Stopping iteration index in the 4D volume
+        (the volume at this index is excluded)
 
     Yields
     -------

--- a/scilpy/image/utils.py
+++ b/scilpy/image/utils.py
@@ -34,7 +34,7 @@ def count_non_zero_voxels(image):
     return nb_voxels
 
 
-def volume_iterator(img, blocksize=1):
+def volume_iterator(img, blocksize=1, start=0, end=0):
     """Generator that iterates on volumes of data.
 
     Parameters
@@ -49,18 +49,23 @@ def volume_iterator(img, blocksize=1):
     tuple of (list of int, ndarray)
         The ids of the selected volumes, and the selected data as a 4D array
     """
+    assert end <= img.shape[-1], "End limit provided is greater than the " \
+                                 "total number of volumes in image"
+
     nb_volumes = img.shape[-1]
+    end = end if end else img.shape[-1]
 
     if blocksize == nb_volumes:
-        yield list(range(nb_volumes)), img.get_fdata(dtype=np.float32)
+        yield list(range(start, end)), \
+              img.get_fdata(dtype=np.float32)[..., start:end]
     else:
-        start, end = 0, 0
-        for i in range(0, nb_volumes - blocksize, blocksize):
-            start, end = i, i + blocksize
-            logging.info("Loading volumes {} to {}.".format(start, end - 1))
-            yield list(range(start, end)), img.dataobj[..., start:end]
+        stop = start
+        for i in range(start, end - blocksize, blocksize):
+            start, stop = i, i + blocksize
+            logging.info("Loading volumes {} to {}.".format(start, stop - 1))
+            yield list(range(start, stop)), img.dataobj[..., start:stop]
 
-        if end < nb_volumes:
+        if stop < end:
             logging.info(
-                "Loading volumes {} to {}.".format(end, nb_volumes - 1))
-            yield list(range(end, nb_volumes)), img.dataobj[..., end:]
+                "Loading volumes {} to {}.".format(stop, end - 1))
+            yield list(range(stop, end)), img.dataobj[..., stop:end]

--- a/scilpy/utils/bvec_bval_tools.py
+++ b/scilpy/utils/bvec_bval_tools.py
@@ -292,7 +292,7 @@ def extract_dwi_shell(dwi, bvals, bvecs, bvals_to_extract, tol=20,
         The tolerated gap between the b-values to extract and the actual
         b-values.
     block_size : int
-        Loads the data using this block size. Useful when the data is too
+        Load the data using this block size. Useful when the data is too
         large to be loaded in memory.
 
     Returns
@@ -362,7 +362,7 @@ def extract_b0(dwi, b0_mask, extract_in_cluster=False,
         parameter set to True, the strategy is applied individually on each
         continuous set found.
     block_size : int
-        Loads the data using this block size. Useful when the data is too
+        Load the data using this block size. Useful when the data is too
         large to be loaded in memory.
 
     Returns

--- a/scilpy/utils/bvec_bval_tools.py
+++ b/scilpy/utils/bvec_bval_tools.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import logging
+from enum import Enum
 
 import numpy as np
 
@@ -9,6 +10,12 @@ from scilpy.gradientsampling.save_gradient_sampling import (save_gradient_sampli
                                                             save_gradient_sampling_mrtrix)
 
 DEFAULT_B0_THRESHOLD = 20
+
+
+class B0ExtractionStrategy(Enum):
+    FIRST = "first"
+    MEAN = "mean"
+    ALL = "all"
 
 
 def is_normalized_bvecs(bvecs):
@@ -282,11 +289,11 @@ def extract_dwi_shell(dwi, bvals, bvecs, bvals_to_extract, tol=20,
     bvals_to_extract : list of int
         The list of b-values to extract.
     tol : int
-        Loads the data using this block size. Useful when the data is too
-        large to be loaded in memory.
-    block_size : int
         The tolerated gap between the b-values to extract and the actual
         b-values.
+    block_size : int
+        Loads the data using this block size. Useful when the data is too
+        large to be loaded in memory.
 
     Returns
     -------
@@ -333,6 +340,89 @@ def extract_dwi_shell(dwi, bvals, bvecs, bvals_to_extract, tol=20,
     output_bvecs = bvecs[indices, :]
 
     return indices, shell_data, output_bvals, output_bvecs
+
+
+def extract_b0(dwi, b0_mask, extract_in_cluster=False,
+               strategy=B0ExtractionStrategy.MEAN, block_size=None):
+    """
+    Extract a set of b0 volumes from a dwi dataset
+
+    Parameters
+    ----------
+    dwi : nib.Nifti1Image
+        Original multi-shell volume.
+    b0_mask: array of bool
+        Mask over the time dimension (4th) identifying b0 volumes.
+    extract_in_cluster: bool
+        Specify to extract b0's in each continuous sets of b0 volumes
+        appearing in the input data.
+    strategy: Enum
+        The extraction strategy, of either select the first b0 found, select
+        them all or average them. When used in conjunction with the batch
+        parameter set to True, the strategy is applied individually on each
+        continuous set found.
+    block_size : int
+        Loads the data using this block size. Useful when the data is too
+        large to be loaded in memory.
+
+    Returns
+    -------
+    b0_data : ndarray
+        Extracted b0 volumes.
+    """
+
+    indices = np.where(b0_mask)[0]
+
+    if block_size is None:
+        block_size = dwi.shape[-1]
+
+    if not extract_in_cluster and strategy == B0ExtractionStrategy.FIRST:
+        idx = np.min(indices)
+        output_b0 = dwi.dataobj[..., idx:idx + 1].squeeze()
+    else:
+        # Generate list of clustered b0 in the data
+        mask = np.ma.masked_array(b0_mask)
+        mask[~b0_mask] = np.ma.masked
+        b0_clusters = np.ma.notmasked_contiguous(mask, axis=0)
+
+        if extract_in_cluster or strategy == B0ExtractionStrategy.ALL:
+            if strategy == B0ExtractionStrategy.ALL:
+                time_d = len(indices)
+            else:
+                time_d = len(b0_clusters)
+
+            output_b0 = np.zeros(dwi.shape[:-1] + (time_d,))
+
+            for idx, cluster in enumerate(b0_clusters):
+                if strategy == B0ExtractionStrategy.FIRST:
+                    data = dwi.dataobj[..., cluster.start:cluster.start + 1]
+                    output_b0[..., idx] = data.squeeze()
+                else:
+                    vol_it = volume_iterator(dwi, block_size,
+                                             cluster.start, cluster.stop)
+
+                    for vi, data in vol_it:
+                        if strategy == B0ExtractionStrategy.ALL:
+                            in_volume = np.array([i in vi for i in indices])
+                            output_b0[..., in_volume] = data
+                        elif strategy == B0ExtractionStrategy.MEAN:
+                            output_b0[..., idx] += np.sum(data, -1)
+
+                    if strategy == B0ExtractionStrategy.MEAN:
+                        output_b0[..., idx] /= cluster.stop - cluster.start
+
+        else:
+            output_b0 = np.zeros(dwi.shape[:-1])
+            for cluster in b0_clusters:
+                vol_it = volume_iterator(dwi, block_size,
+                                         cluster.start, cluster.stop)
+
+                for _, data in vol_it:
+                    output_b0 += np.sum(data, -1)
+
+            output_b0 /= len(indices)
+
+    return output_b0
 
 
 def flip_mrtrix_gradient_sampling(gradient_sampling_filename,

--- a/scripts/scil_extract_b0.py
+++ b/scripts/scil_extract_b0.py
@@ -19,7 +19,8 @@ import numpy as np
 
 from scilpy.io.utils import (add_verbose_arg, assert_inputs_exist,
                              add_force_b0_arg)
-from scilpy.utils.bvec_bval_tools import check_b0_threshold
+from scilpy.utils.bvec_bval_tools import (check_b0_threshold, extract_b0,
+                                          B0ExtractionStrategy)
 from scilpy.utils.filenames import split_name_with_nii
 
 logger = logging.getLogger(__file__)
@@ -47,38 +48,36 @@ def _build_arg_parser():
                             'the output file.')
     group.add_argument('--mean', action='store_true', help='Extract mean b0.')
 
+    p.add_argument('--cluster', action='store_true',
+                   help='Apply the extraction strategy to clusters of '
+                        'continuous b0 volumes in the data')
+
+    p.add_argument('--block-size', '-s',
+                   metavar='INT', type=int,
+                   help='Loads the data using this block size. '
+                        'Useful\nwhen the data is too large to be '
+                        'loaded in memory.')
+
+    p.add_argument('--single-image', action='store_true',
+                   help='If output b0 volume has multiple time points, only '
+                        'outputs a single image instead of a numbered series '
+                        'of images.')
+
     add_force_b0_arg(p)
     add_verbose_arg(p)
 
     return p
 
 
-def _keep_time_step(dwi, time, output):
-    image = nib.load(dwi)
-    data = image.get_fdata(dtype=np.float32)
-
+def _split_time_steps(b0, affine, header, output):
     fname, fext = split_name_with_nii(os.path.basename(output))
 
-    multi_b0 = len(time) > 1
-    for t in time:
-        t_data = data[..., t]
-
+    multiple_b0 = b0.shape[-1] > 1
+    for t in range(b0.shape[-1]):
         out_name = os.path.join(
             os.path.dirname(os.path.abspath(output)),
-            '{}_{}{}'.format(fname, t, fext)) if multi_b0 else output
-        nib.save(nib.Nifti1Image(t_data, image.affine, image.header),
-                 out_name)
-
-
-def _mean_in_time(dwi, time, output):
-    image = nib.load(dwi)
-
-    data = image.get_fdata(dtype=np.float32)
-    data = data[..., time]
-    data = np.mean(data, axis=3, dtype=data.dtype)
-
-    nib.save(nib.Nifti1Image(data, image.affine, image.header),
-             output)
+            '{}_{}{}'.format(fname, t, fext)) if multiple_b0 else output
+        nib.save(nib.Nifti1Image(b0[..., t], affine, header), out_name)
 
 
 def main():
@@ -103,14 +102,22 @@ def main():
 
     logger.info('Number of b0 images in the data: {}'.format(len(b0_idx)))
 
+    strategy = B0ExtractionStrategy.FIRST
     if args.mean:
-        logger.info('Using mean of indices {} for b0'.format(b0_idx))
-        _mean_in_time(args.in_dwi, b0_idx, args.out_b0)
+        strategy = B0ExtractionStrategy.MEAN
+    elif args.all:
+        strategy = B0ExtractionStrategy.ALL
+
+    image = nib.load(args.in_dwi)
+
+    b0_volumes = extract_b0(
+        image, gtab.b0s_mask, args.cluster, strategy, args.block_size)
+
+    if len(b0_volumes.shape) > 3 and not args.single_image:
+        _split_time_steps(b0_volumes, image.affine, image.header, args.out_b0)
     else:
-        if not args.all:
-            b0_idx = [b0_idx[0]]
-        logger.info("Keeping {} for b0".format(b0_idx))
-        _keep_time_step(args.in_dwi, b0_idx, args.out_b0)
+        nib.save(nib.Nifti1Image(b0_volumes, image.affine, image.header),
+                 args.out_b0)
 
 
 if __name__ == '__main__':

--- a/scripts/scil_extract_b0.py
+++ b/scripts/scil_extract_b0.py
@@ -48,14 +48,14 @@ def _build_arg_parser():
                             'the output file.')
     group.add_argument('--mean', action='store_true', help='Extract mean b0.')
     group.add_argument('--cluster-mean', action='store_true',
-                       help='Extracts mean of each continuous cluster of b0s')
+                       help='Extract mean of each continuous cluster of b0s.')
     group.add_argument('--cluster-first', action='store_true',
-                       help='Extracts first b0 of each '
-                            'continuous cluster of b0s')
+                       help='Extract first b0 of each '
+                            'continuous cluster of b0s.')
 
     p.add_argument('--block-size', '-s',
                    metavar='INT', type=int,
-                   help='Loads the data using this block size. '
+                   help='Load the data using this block size. '
                         'Useful\nwhen the data is too large to be '
                         'loaded in memory.')
 

--- a/scripts/scil_extract_b0.py
+++ b/scripts/scil_extract_b0.py
@@ -40,7 +40,7 @@ def _build_arg_parser():
     p.add_argument('--b0_thr', type=float, default=0.0,
                    help='All b-values with values less than or equal '
                         'to b0_thr are considered as b0s i.e. without '
-                        'diffusion weighting.')
+                        'diffusion weighting. [%(default)s]')
 
     group = p.add_mutually_exclusive_group()
     group.add_argument('--all', action='store_true',


### PR DESCRIPTION
This PR contains modifications to :

- Extract b0 : added more extraction options, such as extracting b0s from clusters of b0s in the data (mean or first b0 of each cluster). Also reformatted the code to enable lazyloading. (Does not modify previous behavior of the script, fully back-compatible cli)
- Prepare Topup : TBD
- Prepare Eddy : TBD