### PR TITLE
Empty h5 compute connectivity

### DIFF
--- a/scripts/scil_compute_connectivity.py
+++ b/scripts/scil_compute_connectivity.py
@@ -79,12 +79,10 @@ def _processing_wrapper(args):
     hdf5_file = h5py.File(hdf5_filename, 'r')
     key = '{}_{}'.format(in_label, out_label)
     if key not in hdf5_file:
-        return {(in_label, out_label): dict(zip(measures_to_compute,
-                                                itertools.repeat(0)))}
+        return
     streamlines = reconstruct_streamlines_from_hdf5(hdf5_file, key)
     if len(streamlines) == 0:
-        return {(in_label, out_label): dict(zip(measures_to_compute,
-                                                itertools.repeat(0)))}
+        return
 
     affine, dimensions, voxel_sizes, _ = get_reference_info(labels_img)
     measures_to_return = {}
@@ -324,12 +322,11 @@ def main():
     # Removing None entries (combinaisons that do not exist)
     # Fusing the multiprocessing output into a single dictionary
     measures_dict_list = [it for it in measures_dict_list if it is not None]
-    if measures_dict_list:
-        measures_dict = measures_dict_list[0]
-        for dix in measures_dict_list[1:]:
-            measures_dict.update(dix)
-    else:
-        measures_dict = {}
+    if not measures_dict_list:
+        raise ValueError('Empty matrix, no entries to save.')
+    measures_dict = measures_dict_list[0]
+    for dix in measures_dict_list[1:]:
+        measures_dict.update(dix)
 
     if args.no_self_connection:
         total_elem = len(labels_list)**2 - len(labels_list)

--- a/scripts/scil_compute_connectivity.py
+++ b/scripts/scil_compute_connectivity.py
@@ -79,10 +79,12 @@ def _processing_wrapper(args):
     hdf5_file = h5py.File(hdf5_filename, 'r')
     key = '{}_{}'.format(in_label, out_label)
     if key not in hdf5_file:
-        return
+        return {(in_label, out_label): dict(zip(measures_to_compute,
+                                                itertools.repeat(0)))}
     streamlines = reconstruct_streamlines_from_hdf5(hdf5_file, key)
     if len(streamlines) == 0:
-        return
+        return {(in_label, out_label): dict(zip(measures_to_compute,
+                                                itertools.repeat(0)))}
 
     affine, dimensions, voxel_sizes, _ = get_reference_info(labels_img)
     measures_to_return = {}
@@ -322,9 +324,12 @@ def main():
     # Removing None entries (combinaisons that do not exist)
     # Fusing the multiprocessing output into a single dictionary
     measures_dict_list = [it for it in measures_dict_list if it is not None]
-    measures_dict = measures_dict_list[0]
-    for dix in measures_dict_list[1:]:
-        measures_dict.update(dix)
+    if measures_dict_list:
+        measures_dict = measures_dict_list[0]
+        for dix in measures_dict_list[1:]:
+            measures_dict.update(dix)
+    else:
+        measures_dict = {}
 
     if args.no_self_connection:
         total_elem = len(labels_list)**2 - len(labels_list)

--- a/scripts/scil_merge_json.py
+++ b/scripts/scil_merge_json.py
@@ -32,7 +32,7 @@ def _merge_dict(dict_1, dict_2, no_list=False, recursive=False):
                 new_dict[key] = [new_dict[key]]
 
             if not isinstance(dict_2[key], list) and not no_list:
-                new_dict[key].extend(dict_2[key])
+                new_dict[key].extend([dict_2[key]])
             else:
                 if isinstance(dict_2[key], dict):
                     new_dict.update(dict_2)


### PR DESCRIPTION
Slightly clearer error when an empty matrices is produces. This should never happen, which is why it crash.
An empty matrices means there is no single streamlines in the input decomposed. If you reach compute connectivity with this it is worthy of an error.