### PR TITLE
Add compute_sf_from_sh.py script

### DIFF
--- a/scripts/scil_compute_sf_from_sh.py
+++ b/scripts/scil_compute_sf_from_sh.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Script to sample SF values from a Spherical Harmonics signal.
+"""
+
+import argparse
+
+from dipy.core.gradients import gradient_table
+from dipy.data import get_sphere
+from dipy.io import read_bvals_bvecs
+from dipy.reconst.shm import sh_to_sf
+import nibabel as nib
+import numpy as np
+
+from scilpy.gradientsampling.save_gradient_sampling import \
+    save_gradient_sampling_fsl
+from scilpy.io.image import get_data_as_mask
+from scilpy.io.utils import (add_overwrite_arg,
+                             add_sh_basis_args, assert_inputs_exist,
+                             assert_outputs_exist)
+
+ORDER_FROM_NCOEFFS = {1: 0, 6: 2, 15: 4, 28: 6, 45: 8}
+
+
+def _build_arg_parser():
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+    p.add_argument('in_sh',
+                   help='Path of the SH volume.')
+    p.add_argument('in_dwi',
+                   help='Path of the original DWI volume (to fetch b0 images).')
+    p.add_argument('in_bval',
+                   help='Path of the b-value file, in FSL format.')
+    p.add_argument('in_bvec',
+                   help='Path of the b-vector file, in FSL format.')
+
+    p.add_argument('out_sf',
+                   help='Name of the output SF file to save (bvals/bvecs will '
+                        'be automatically named).')
+
+    p.add_argument('--sphere', choices=['symmetric724', 'repulsion724'],
+                   default='symmetric724',
+                   help='Sphere to use for sampling SF. [%(default)s]')
+    add_sh_basis_args(p)
+    p.add_argument('--mask',
+                   help='Path to a binary mask.\nOnly data inside the mask '
+                        'will be used for computations and reconstruction ')
+    add_overwrite_arg(p)
+
+    return p
+
+
+def main():
+    parser = _build_arg_parser()
+    args = parser.parse_args()
+
+    assert_inputs_exist(parser, [args.in_sh])
+
+    out_bvecs = args.out_sf.replace(".nii.gz", ".bvec")
+    out_bvals = args.out_sf.replace(".nii.gz", ".bval")
+
+    assert_outputs_exist(parser, args, [args.out_sf, out_bvals, out_bvecs])
+
+    # Load SH
+    vol_sh = nib.load(args.in_sh)
+    data_sh = vol_sh.get_fdata(dtype=np.float32)
+
+    # Load DWI + gradients
+    vol_dwi = nib.load(args.in_dwi)
+    data_dwi = vol_dwi.get_fdata(dtype=np.float32)
+    bvals, bvecs = read_bvals_bvecs(args.in_bval, args.in_bvec)
+    gtab = gradient_table(args.in_bval, args.in_bvec, b0_threshold=bvals.min())
+    b0_volume = data_dwi[..., gtab.b0s_mask]
+
+    # Apply mask
+    if args.mask:
+        mask = get_data_as_mask(nib.load(args.mask), dtype=np.bool)
+        data_sh = data_sh * mask
+        b0_volume = b0_volume * mask
+
+    # Figure out SH order
+    n_coeffs = data_sh.shape[-1]
+    sh_order = ORDER_FROM_NCOEFFS[n_coeffs]
+
+    # Sample SF from SH
+    sphere = get_sphere(args.sphere)
+    sf = sh_to_sf(data_sh, sphere, sh_order=sh_order, basis_type=args.sh_basis)
+
+    # Append b0 images
+    sf = np.concatenate((sf, b0_volume), axis=-1)
+
+    # Save SF
+    nib.save(nib.Nifti1Image(sf.astype(np.float32), vol_sh.affine), args.out_sf)
+
+    # Save new bvals/bvecs
+    avg_bval = np.mean(gtab.bvals[np.logical_not(gtab.b0s_mask)])
+    bvals = ([avg_bval] * len(sphere.theta)) + ([0] * b0_volume.shape[-1])
+    bvecs = np.concatenate(
+        (sphere.vertices, np.zeros((b0_volume.shape[-1], 3))), axis=0)
+    save_gradient_sampling_fsl(bvecs, np.arange(len(bvals)), bvals,
+                               out_bvals, out_bvecs)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/scil_compute_sf_from_sh.py
+++ b/scripts/scil_compute_sf_from_sh.py
@@ -2,10 +2,16 @@
 # -*- coding: utf-8 -*-
 
 """
-Script to sample SF values from a Spherical Harmonics signal.
+Script to sample SF values from a Spherical Harmonics signal. Outputs a Nifti
+file with the SF values and an associated .bvec file with the chosen directions.
+
+If converting from SH to a DWI-like SF volume, --in_bval and --in_b0 need
+to be provided to concatenate the b0 image to the SF, and to generate the new
+bvals file. Otherwise, no .bval file will be created.
 """
 
 import argparse
+from operator import xor
 
 from dipy.data import SPHERE_FILES, get_sphere
 from dipy.io import read_bvals_bvecs
@@ -13,8 +19,6 @@ from dipy.reconst.shm import order_from_ncoef, sh_to_sf
 import nibabel as nib
 import numpy as np
 
-from scilpy.gradientsampling.save_gradient_sampling import \
-    save_gradient_sampling_fsl
 from scilpy.io.utils import (add_force_b0_arg, add_overwrite_arg,
                              add_sh_basis_args, assert_inputs_exist,
                              assert_outputs_exist)
@@ -26,21 +30,25 @@ def _build_arg_parser():
         description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
     p.add_argument('in_sh',
                    help='Path of the SH volume.')
-    p.add_argument('in_b0',
-                   help='Path of the original b0 volume (to concatenate to the '
-                        'final SF volume).')
-    p.add_argument('in_bval',
-                   help='Path of the b-value file, in FSL format.')
-
     p.add_argument('out_sf',
                    help='Name of the output SF file to save (bvals/bvecs will '
-                        'be automatically named).')
+                        'be automatically named when necessary).')
 
+    # Optional arguments to generate a DWI-like volume
+    p.add_argument('--in_bval',
+                   help='Optional b-value file, in FSL format, used to '
+                        'generate a DWI-like volume + bvals/bvecs.')
+    p.add_argument('--in_b0',
+                   help='Optional b0 volume, to concatenate to the '
+                        'final SF volume if a DWI representation is needed.')
+
+    # Sphere choice for SF
     p.add_argument('--sphere', default='repulsion724',
                    choices=sorted(SPHERE_FILES.keys()),
                    help='Sphere used for the SH to SF projection. '
                         '[%(default)s]')
     add_sh_basis_args(p)
+
     add_overwrite_arg(p)
     add_force_b0_arg(p)
 
@@ -54,24 +62,20 @@ def main():
     assert_inputs_exist(parser, [args.in_sh])
 
     out_bvecs = args.out_sf.replace(".nii.gz", ".bvec")
-    out_bvals = args.out_sf.replace(".nii.gz", ".bval")
+    assert_outputs_exist(parser, args, [args.out_sf, out_bvecs])
 
-    assert_outputs_exist(parser, args, [args.out_sf, out_bvals, out_bvecs])
+    # Either both --in_bval and --in_b0 are provided, or none
+    if xor(bool(args.in_bval), bool(args.in_b0)):
+        parser.error("If one of --in_bval or --in_b0 is provided, both "
+                     "are required.")
+
+    out_bvals = args.out_sf.replace(".nii.gz", ".bval")
+    if args.in_bval:
+        assert_outputs_exist(parser, args, [out_bvals])
 
     # Load SH
     vol_sh = nib.load(args.in_sh)
     data_sh = vol_sh.get_fdata(dtype=np.float32)
-
-    # Load b0
-    vol_b0 = nib.load(args.in_b0)
-    data_b0 = vol_b0.get_fdata(dtype=np.float32)
-    if data_b0.ndim == 3:
-        data_b0 = data_b0[..., np.newaxis]
-
-    # Load bvals
-    bvals, _ = read_bvals_bvecs(args.in_bval, None)
-    check_b0_threshold(args.force_b0_threshold, bvals.min())
-    b0s_mask = bvals <= bvals.min()
 
     # Figure out SH order
     sh_order = order_from_ncoef(data_sh.shape[-1], full_basis=False)
@@ -79,20 +83,39 @@ def main():
     # Sample SF from SH
     sphere = get_sphere(args.sphere)
     sf = sh_to_sf(data_sh, sphere, sh_order=sh_order, basis_type=args.sh_basis)
+    new_bvecs = sphere.vertices
 
-    # Append b0 images
-    sf = np.concatenate((sf, data_b0), axis=-1)
+    if args.in_bval and args.in_b0:
+        # Load b0
+        vol_b0 = nib.load(args.in_b0)
+        data_b0 = vol_b0.get_fdata(dtype=np.float32)
+        if data_b0.ndim == 3:
+            data_b0 = data_b0[..., np.newaxis]
+
+        # Load bvals
+        bvals, _ = read_bvals_bvecs(args.in_bval, None)
+
+        # Compute average bval
+        check_b0_threshold(args.force_b0_threshold, bvals.min())
+        b0s_mask = bvals <= bvals.min()
+        avg_bval = np.mean(bvals[np.logical_not(b0s_mask)])
+        new_bvals = ([avg_bval] * len(sphere.theta)) + ([0] * data_b0.shape[-1])
+
+        # Save new bvals
+        np.savetxt(out_bvals, np.array(new_bvals)[None, :], fmt='%.3f')
+
+        # Append zeros to bvecs
+        new_bvecs = np.concatenate(
+            (new_bvecs, np.zeros((data_b0.shape[-1], 3))), axis=0)
+
+        # Append b0 images to SF
+        sf = np.concatenate((sf, data_b0), axis=-1)
+
+    # Save new bvecs
+    np.savetxt(out_bvecs, new_bvecs, fmt='%.8f')
 
     # Save SF
     nib.save(nib.Nifti1Image(sf.astype(np.float32), vol_sh.affine), args.out_sf)
-
-    # Save new bvals/bvecs
-    avg_bval = np.mean(bvals[np.logical_not(b0s_mask)])
-    bvals = ([avg_bval] * len(sphere.theta)) + ([0] * data_b0.shape[-1])
-    bvecs = np.concatenate(
-        (sphere.vertices, np.zeros((data_b0.shape[-1], 3))), axis=0)
-    save_gradient_sampling_fsl(bvecs, np.arange(len(bvals)), bvals,
-                               out_bvals, out_bvecs)
 
 
 if __name__ == "__main__":

--- a/scripts/scil_compute_sf_from_sh.py
+++ b/scripts/scil_compute_sf_from_sh.py
@@ -38,7 +38,7 @@ def _build_arg_parser():
                         'be automatically named).')
 
     p.add_argument('--sphere', choices=['symmetric724', 'repulsion724'],
-                   default='symmetric724',
+                   default='repulsion724',
                    help='Sphere to use for sampling SF. [%(default)s]')
     add_sh_basis_args(p)
     add_overwrite_arg(p)

--- a/scripts/scil_compute_sf_from_sh.py
+++ b/scripts/scil_compute_sf_from_sh.py
@@ -123,7 +123,7 @@ def main():
         sf = np.concatenate((sf, data_b0), axis=-1)
 
     # Save new bvecs
-    np.savetxt(out_bvecs, new_bvecs, fmt='%.8f')
+    np.savetxt(out_bvecs, new_bvecs.T, fmt='%.8f')
 
     # Save SF
     nib.save(nib.Nifti1Image(sf.astype(np.float32), vol_sh.affine), args.out_sf)

--- a/scripts/scil_compute_sf_from_sh.py
+++ b/scripts/scil_compute_sf_from_sh.py
@@ -20,8 +20,6 @@ from scilpy.io.utils import (add_force_b0_arg, add_overwrite_arg,
                              assert_outputs_exist)
 from scilpy.utils.bvec_bval_tools import (check_b0_threshold)
 
-ORDER_FROM_NCOEFFS = {1: 0, 6: 2, 15: 4, 28: 6, 45: 8}
-
 
 def _build_arg_parser():
     p = argparse.ArgumentParser(

--- a/scripts/scil_compute_sf_from_sh.py
+++ b/scripts/scil_compute_sf_from_sh.py
@@ -44,9 +44,6 @@ def _build_arg_parser():
                    default='symmetric724',
                    help='Sphere to use for sampling SF. [%(default)s]')
     add_sh_basis_args(p)
-    p.add_argument('--mask',
-                   help='Path to a binary mask.\nOnly data inside the mask '
-                        'will be used for computations and reconstruction ')
     add_overwrite_arg(p)
 
     return p
@@ -73,12 +70,6 @@ def main():
     bvals, bvecs = read_bvals_bvecs(args.in_bval, args.in_bvec)
     gtab = gradient_table(args.in_bval, args.in_bvec, b0_threshold=bvals.min())
     b0_volume = data_dwi[..., gtab.b0s_mask]
-
-    # Apply mask
-    if args.mask:
-        mask = get_data_as_mask(nib.load(args.mask), dtype=np.bool)
-        data_sh = data_sh * mask
-        b0_volume = b0_volume * mask
 
     # Figure out SH order
     n_coeffs = data_sh.shape[-1]

--- a/scripts/scil_compute_sf_from_sh.py
+++ b/scripts/scil_compute_sf_from_sh.py
@@ -68,19 +68,21 @@ def main():
     parser = _build_arg_parser()
     args = parser.parse_args()
 
-    assert_inputs_exist(parser, [args.in_sh])
+    assert_inputs_exist(parser, args.in_sh,
+                        optional=[args.in_bval, args.in_b0])
 
     out_bvecs = args.out_sf.replace(".nii.gz", ".bvec")
-    assert_outputs_exist(parser, args, [args.out_sf, out_bvecs])
+    out_bvals = None
+    if args.in_bval:
+        out_bvals = args.out_sf.replace(".nii.gz", ".bval")
+
+    assert_outputs_exist(parser, args, [args.out_sf, out_bvecs],
+                         optional=out_bvals)
 
     # Either both --in_bval and --in_b0 are provided, or none
     if xor(bool(args.in_bval), bool(args.in_b0)):
         parser.error("If one of --in_bval or --in_b0 is provided, both "
                      "are required.")
-
-    out_bvals = args.out_sf.replace(".nii.gz", ".bval")
-    if args.in_bval:
-        assert_outputs_exist(parser, args, [out_bvals])
 
     # Load SH
     vol_sh = nib.load(args.in_sh)

--- a/scripts/scil_compute_sf_from_sh.py
+++ b/scripts/scil_compute_sf_from_sh.py
@@ -34,19 +34,28 @@ def _build_arg_parser():
                    help='Name of the output SF file to save (bvals/bvecs will '
                         'be automatically named when necessary).')
 
-    # Optional arguments to generate a DWI-like volume
-    p.add_argument('--in_bval',
-                   help='Optional b-value file, in FSL format, used to '
-                        'generate a DWI-like volume + bvals/bvecs.')
-    p.add_argument('--in_b0',
-                   help='Optional b0 volume, to concatenate to the '
-                        'final SF volume if a DWI representation is needed.')
-
     # Sphere choice for SF
     p.add_argument('--sphere', default='repulsion724',
                    choices=sorted(SPHERE_FILES.keys()),
                    help='Sphere used for the SH to SF projection. '
                         '[%(default)s]')
+
+    # Optional subparser for a DWI-like volume
+    sub = p.add_subparsers(help="Optional arguments to generate a "
+                                "DWI-like output")
+    dwi_subparser = sub.add_parser("dwi_like",
+                                   description="Generate a DWI-like output, "
+                                               "including a `.bval` file and "
+                                               "b0 images in the sf file.")
+    dwi_subparser.add_argument('--in_bval',
+                               required=True,
+                               help='b-value file, in FSL format, '
+                                    'used to assign a b-value to the '
+                                    'output SF and generate a `.bval` file.')
+    dwi_subparser.add_argument('--in_b0',
+                               required=True,
+                               help='b0 volume to concatenate to the '
+                                    'final SF volume.')
     add_sh_basis_args(p)
 
     add_overwrite_arg(p)

--- a/scripts/scil_compute_sf_from_sh.py
+++ b/scripts/scil_compute_sf_from_sh.py
@@ -7,9 +7,9 @@ Script to sample SF values from a Spherical Harmonics signal.
 
 import argparse
 
-from dipy.data import get_sphere
+from dipy.data import SPHERE_FILES, get_sphere
 from dipy.io import read_bvals_bvecs
-from dipy.reconst.shm import sh_to_sf
+from dipy.reconst.shm import order_from_ncoef, sh_to_sf
 import nibabel as nib
 import numpy as np
 
@@ -37,9 +37,10 @@ def _build_arg_parser():
                    help='Name of the output SF file to save (bvals/bvecs will '
                         'be automatically named).')
 
-    p.add_argument('--sphere', choices=['symmetric724', 'repulsion724'],
-                   default='repulsion724',
-                   help='Sphere to use for sampling SF. [%(default)s]')
+    p.add_argument('--sphere', default='repulsion724',
+                   choices=sorted(SPHERE_FILES.keys()),
+                   help='Sphere used for the SH to SF projection. '
+                        '[%(default)s]')
     add_sh_basis_args(p)
     add_overwrite_arg(p)
 
@@ -70,8 +71,7 @@ def main():
     b0s_mask = bvals <= 50
 
     # Figure out SH order
-    n_coeffs = data_sh.shape[-1]
-    sh_order = ORDER_FROM_NCOEFFS[n_coeffs]
+    sh_order = order_from_ncoef(data_sh.shape[-1], full_basis=False)
 
     # Sample SF from SH
     sphere = get_sphere(args.sphere)

--- a/scripts/tests/test_compute_sf_from_sh.py
+++ b/scripts/tests/test_compute_sf_from_sh.py
@@ -18,15 +18,10 @@ def test_help_option(script_runner):
 
 def test_execution_processing(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
-    in_sh = os.path.join(get_home(), 'processing',
-                         'sh_1000.nii.gz')
-    in_dwi = os.path.join(get_home(), 'processing',
-                          'dwi_crop_3000.nii.gz')
-    in_bval = os.path.join(get_home(), 'processing',
-                           '3000.bval')
-    in_bvec = os.path.join(get_home(), 'processing',
-                           '3000.bvec')
+    in_sh = os.path.join(get_home(), 'processing', 'sh_1000.nii.gz')
+    in_b0 = os.path.join(get_home(), 'processing', 'fa.nii.gz')
+    in_bval = os.path.join(get_home(), 'processing', '1000.bval')
 
-    ret = script_runner.run('scil_compute_sf_from_sh.py', in_sh, in_dwi, in_bval, in_bvec,
+    ret = script_runner.run('scil_compute_sf_from_sh.py', in_sh, in_b0, in_bval,
                             'sf_724.nii.gz')
     assert ret.success

--- a/scripts/tests/test_compute_sf_from_sh.py
+++ b/scripts/tests/test_compute_sf_from_sh.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import os
+import tempfile
+
+from scilpy.io.fetcher import fetch_data, get_home, get_testing_files_dict
+
+# If they already exist, this only takes 5 seconds (check md5sum)
+fetch_data(get_testing_files_dict(), keys=['processing.zip'])
+tmp_dir = tempfile.TemporaryDirectory()
+
+
+def test_help_option(script_runner):
+    ret = script_runner.run('scil_compute_sf_from_sh.py', '--help')
+    assert ret.success
+
+
+def test_execution_processing(script_runner):
+    os.chdir(os.path.expanduser(tmp_dir.name))
+    in_sh = os.path.join(get_home(), 'processing',
+                         'sh_1000.nii.gz')
+    in_dwi = os.path.join(get_home(), 'processing',
+                          'dwi_crop_3000.nii.gz')
+    in_bval = os.path.join(get_home(), 'processing',
+                           '3000.bval')
+    in_bvec = os.path.join(get_home(), 'processing',
+                           '3000.bvec')
+
+    ret = script_runner.run('scil_compute_sf_from_sh.py', in_sh, in_dwi, in_bval, in_bvec,
+                            'sf_724.nii.gz')
+    assert ret.success

--- a/scripts/tests/test_compute_sf_from_sh.py
+++ b/scripts/tests/test_compute_sf_from_sh.py
@@ -22,6 +22,7 @@ def test_execution_processing(script_runner):
     in_b0 = os.path.join(get_home(), 'processing', 'fa.nii.gz')
     in_bval = os.path.join(get_home(), 'processing', '1000.bval')
 
-    ret = script_runner.run('scil_compute_sf_from_sh.py', in_sh, in_b0, in_bval,
-                            'sf_724.nii.gz')
+    ret = script_runner.run('scil_compute_sf_from_sh.py', in_sh,
+                            'sf_724.nii.gz', 'dwi_like', '--in_bval', in_bval,
+                            '--in_b0', in_b0)
     assert ret.success

--- a/scripts/tests/test_compute_sf_from_sh.py
+++ b/scripts/tests/test_compute_sf_from_sh.py
@@ -23,6 +23,6 @@ def test_execution_processing(script_runner):
     in_bval = os.path.join(get_home(), 'processing', '1000.bval')
 
     ret = script_runner.run('scil_compute_sf_from_sh.py', in_sh,
-                            'sf_724.nii.gz', 'dwi_like', '--in_bval', in_bval,
-                            '--in_b0', in_b0)
+                            'sf_724.nii.gz', '--extract_as_dwi', '--bval',
+                            in_bval, '--b0', in_b0)
     assert ret.success


### PR DESCRIPTION
- Compute SF on a sphere from an SH signal (ODF or fODF)
- Can provide the sphere as argument (currently symetric724 or repulsion724)
- Original b0s are concatenated to have a coherent volume for further analysis