### PR TITLE
Clarification to condition for greater or lesser than

### DIFF
--- a/scilpy/image/operations.py
+++ b/scilpy/image/operations.py
@@ -127,7 +127,7 @@ def lower_threshold_eq(input_list, ref_img):
     """
     lower_threshold_eq: IMG THRESHOLD
         All values below the threshold will be set to zero.
-        All values above (or equal) the threshold will be set to one.
+        All values above or equal the threshold will be set to one.
     """
     _validate_length(input_list, 2)
     _validate_type(input_list[0], nib.Nifti1Image)
@@ -144,7 +144,7 @@ def lower_threshold_eq(input_list, ref_img):
 def upper_threshold_eq(input_list, ref_img):
     """
     upper_threshold_eq: IMG THRESHOLD
-        All values below (or equal) the threshold will be set to one.
+        All values below or equal the threshold will be set to one.
         All values above the threshold will be set to zero.
         Equivalent to lower_threshold followed by an inversion.
     """
@@ -172,7 +172,7 @@ def lower_threshold(input_list, ref_img):
 
     output_data = np.zeros(ref_img.header.get_data_shape(), dtype=np.float64)
     data = input_list[0].get_fdata(dtype=np.float64)
-    output_data[data < input_list[1]] = 0
+    output_data[data <= input_list[1]] = 0
     output_data[data > input_list[1]] = 1
 
     return output_data
@@ -192,7 +192,7 @@ def upper_threshold(input_list, ref_img):
     output_data = np.zeros(ref_img.header.get_data_shape(), dtype=np.float64)
     data = input_list[0].get_fdata(dtype=np.float64)
     output_data[data < input_list[1]] = 1
-    output_data[data > input_list[1]] = 0
+    output_data[data >= input_list[1]] = 0
 
     return output_data
 

--- a/scilpy/image/operations.py
+++ b/scilpy/image/operations.py
@@ -27,6 +27,8 @@ def get_array_ops():
     return OrderedDict([
         ('lower_threshold', lower_threshold),
         ('upper_threshold', upper_threshold),
+        ('lower_threshold_eq', lower_threshold_eq),
+        ('upper_threshold_eq', upper_threshold_eq),
         ('lower_clip', lower_clip),
         ('upper_clip', upper_clip),
         ('absolute_value', absolute_value),
@@ -121,6 +123,43 @@ def _validate_float(x):
         raise ValueError
 
 
+def lower_threshold_eq(input_list, ref_img):
+    """
+    lower_threshold_eq: IMG THRESHOLD
+        All values below the threshold will be set to zero.
+        All values above (or equal) the threshold will be set to one.
+    """
+    _validate_length(input_list, 2)
+    _validate_type(input_list[0], nib.Nifti1Image)
+    _validate_float(input_list[1])
+
+    output_data = np.zeros(ref_img.header.get_data_shape(), dtype=np.float64)
+    data = input_list[0].get_fdata(dtype=np.float64)
+    output_data[data < input_list[1]] = 0
+    output_data[data >= input_list[1]] = 1
+
+    return output_data
+
+
+def upper_threshold_eq(input_list, ref_img):
+    """
+    upper_threshold_eq: IMG THRESHOLD
+        All values below (or equal) the threshold will be set to one.
+        All values above the threshold will be set to zero.
+        Equivalent to lower_threshold followed by an inversion.
+    """
+    _validate_length(input_list, 2)
+    _validate_type(input_list[0], nib.Nifti1Image)
+    _validate_float(input_list[1])
+
+    output_data = np.zeros(ref_img.header.get_data_shape(), dtype=np.float64)
+    data = input_list[0].get_fdata(dtype=np.float64)
+    output_data[data <= input_list[1]] = 1
+    output_data[data > input_list[1]] = 0
+
+    return output_data
+
+
 def lower_threshold(input_list, ref_img):
     """
     lower_threshold: IMG THRESHOLD
@@ -134,7 +173,7 @@ def lower_threshold(input_list, ref_img):
     output_data = np.zeros(ref_img.header.get_data_shape(), dtype=np.float64)
     data = input_list[0].get_fdata(dtype=np.float64)
     output_data[data < input_list[1]] = 0
-    output_data[data >= input_list[1]] = 1
+    output_data[data > input_list[1]] = 1
 
     return output_data
 
@@ -152,7 +191,7 @@ def upper_threshold(input_list, ref_img):
 
     output_data = np.zeros(ref_img.header.get_data_shape(), dtype=np.float64)
     data = input_list[0].get_fdata(dtype=np.float64)
-    output_data[data <= input_list[1]] = 1
+    output_data[data < input_list[1]] = 1
     output_data[data > input_list[1]] = 0
 
     return output_data

--- a/scripts/scil_filter_connectivity.py
+++ b/scripts/scil_filter_connectivity.py
@@ -18,6 +18,8 @@ a node with at least 90% of the population having at least 1 streamline,
 90% of the population is similar to the average (2mm) and 90% of the
 population having at least 40mm of average streamlines length.
 
+All operation are stricly > or <, there is no >= or <=.
+
 --greater_than or --lower_than expect the same convention:
     MATRICES_LIST VALUE_THR POPULATION_PERC
 It is strongly recommended (but not enforced) that the same number of
@@ -110,7 +112,7 @@ def main():
         if condition == 'lower':
             empty_matrices[matrices < value_threshold] = 1
         else:
-            empty_matrices[matrices >= value_threshold] = 1
+            empty_matrices[matrices > value_threshold] = 1
 
         population_score = np.sum(empty_matrices, axis=2)
 
@@ -122,7 +124,7 @@ def main():
                                        population_threshold)[0]),
                           np.prod(shape)))
 
-        output_mask[population_score >= population_threshold] += 1
+        output_mask[population_score > population_threshold] += 1
 
     if not args.keep_condition_count:
         output_mask[output_mask < condition_counter] = 0


### PR DESCRIPTION
In relation to #385 . This add new condition to image_math and connectivity math
- lower_threshold -> lower_threshold_eq
- upper_threshold -> upper_threshold_eq
The >= and <= are not clearly distinct.

The script scil_filter_connectivity was unclear. The greater_than and lesser_than option were actually greater_or_equal and lesser_or_equal. To make it clearer, while keeping the script easy to read (and simple) the equals were removed and now the script does what the paramters are saying. Strictly greater or lesser than.

@mdesco This should be slightly clearer