### PR TITLE
Perform majority vote refactor (faster/clearer)

### DIFF
--- a/scripts/scil_evaluate_bundles_binary_classification_measures.py
+++ b/scripts/scil_evaluate_bundles_binary_classification_measures.py
@@ -216,6 +216,7 @@ def main():
             voxels_dict.append(compute_voxel_measures(
                 [i, tracking_mask_data, gs_binary_3d]))
     else:
+        pool = multiprocessing.Pool(nbr_cpu)
         voxels_dict = pool.map(compute_voxel_measures,
                                zip(bundles_references_tuple_extended,
                                    itertools.repeat(tracking_mask_data),

--- a/scripts/scil_perform_majority_vote.py
+++ b/scripts/scil_perform_majority_vote.py
@@ -14,7 +14,7 @@ Input tractograms must have identical header.
 
 import argparse
 
-from dipy.io.stateful_tractogram import Space, StatefulTractogram
+from dipy.io.stateful_tractogram import Origin, Space, StatefulTractogram
 from dipy.io.streamline import save_tractogram
 from dipy.io.utils import is_header_compatible, get_reference_info
 import nibabel as nib
@@ -72,50 +72,46 @@ def main():
     if not 0 <= args.ratio_voxels <= 1 or not 0 <= args.ratio_streamlines <= 1:
         parser.error('Ratios must be between 0 and 1.')
 
-    fusion_streamlines = ArraySequence([])
+    fusion_streamlines = []
     if args.reference:
         reference_file = args.reference
     else:
         reference_file = args.in_bundles[0]
+    sft_list = []
     for name in args.in_bundles:
         tmp_sft = load_tractogram_with_reference(parser, args, name)
+        tmp_sft.to_vox()
+        tmp_sft.to_corner()
+
         if not is_header_compatible(reference_file, tmp_sft):
             raise ValueError('Headers are not compatible.')
-        fusion_streamlines.extend(tmp_sft.streamlines)
+        sft_list.append(tmp_sft)
+        fusion_streamlines.append(tmp_sft.streamlines)
 
-    fusion_streamlines, _ = union_robust([fusion_streamlines])
+    fusion_streamlines, _ = union_robust(fusion_streamlines)
 
     transformation, dimensions, _, _ = get_reference_info(reference_file)
     volume = np.zeros(dimensions)
     streamlines_vote = dok_matrix((len(fusion_streamlines),
                                    len(args.in_bundles)))
 
-    for i, name in enumerate(args.in_bundles):
-        sft = load_tractogram_with_reference(parser, args, name)
-
-        # Needed for streamline-wise representation
-        bundle = sft.get_streamlines_copy()
-        sft.to_vox()
-        sft.to_corner()
-
+    for i in range(len(args.in_bundles)):
+        sft = sft_list[i]
         binary = compute_tract_counts_map(sft.streamlines, dimensions)
         volume[binary > 0] += 1
 
         if args.same_tractogram:
-            _, indices = intersection_robust([fusion_streamlines, bundle])
+            _, indices = intersection_robust([fusion_streamlines,
+                                              sft.streamlines])
             streamlines_vote[list(indices), [i]] += 1
 
     if args.same_tractogram:
         real_indices = []
-        for i in range(len(fusion_streamlines)):
-            ratio_value = int(args.ratio_streamlines*len(args.in_bundles))
-            if np.sum(streamlines_vote[i]) >= ratio_value:
-                real_indices.append(i)
-
-        new_streamlines = fusion_streamlines[real_indices]
-
-        new_sft = StatefulTractogram(list(new_streamlines), reference_file,
-                                     Space.RASMM)
+        ratio_value = int(args.ratio_streamlines*len(args.in_bundles))
+        real_indices = np.where(np.sum(streamlines_vote,
+                                       axis=1) >= ratio_value)[0]
+        new_sft = StatefulTractogram.from_sft(fusion_streamlines[real_indices],
+                                              sft_list[0])
         save_tractogram(new_sft, output_streamlines_filename)
 
     volume[volume < int(args.ratio_voxels*len(args.in_bundles))] = 0


### PR DESCRIPTION
This simply avoid double loading and iteration over all streamlines (using array and numpy for vote instead)