### PR TITLE
Generalized scil_compute_metrics_stats_in_ROI.py for multiple masks

### DIFF
--- a/scripts/scil_compute_metrics_stats_in_ROI.py
+++ b/scripts/scil_compute_metrics_stats_in_ROI.py
@@ -3,10 +3,10 @@
 
 """
 Compute the statistics (mean, std) of scalar maps, which can represent
-diffusion metrics, in a ROI.
+diffusion metrics, in a ROI (or multiples ROIs).
 
-The mask can either be a binary mask, or a weighting mask. If the mask is
-a weighting mask it should either contain floats between 0 and 1 or should be
+ROIs mask can either be binary, or a weighted map. If the ROI is
+a weighting map it should either contain floats between 0 and 1 or should be
 normalized with --normalize_weights.
 
 IMPORTANT: if the mask contains weights (and not 0 and 1 exclusively), the
@@ -24,7 +24,8 @@ import numpy as np
 
 from scilpy.io.utils import (add_overwrite_arg,
                              add_json_args,
-                             assert_inputs_exist)
+                             assert_inputs_exist,
+                             assert_outputs_exist)
 from scilpy.utils.filenames import split_name_with_nii
 from scilpy.utils.metrics_tools import get_roi_metrics_mean_std
 
@@ -33,9 +34,9 @@ def _build_arg_parser():
     p = argparse.ArgumentParser(description=__doc__,
                                 formatter_class=argparse.RawTextHelpFormatter)
 
-    p.add_argument('in_mask',
-                   help='Mask volume filename.\nCan be a binary mask or a '
-                        'weighted mask.')
+    p.add_argument('in_mask', nargs='+',
+                   help='Mask volume filename (ROI).\nCan be a binary mask '
+                        'or a weighted mask.')
 
     p_metric = p.add_argument_group('Metrics input options')
     g_metric = p_metric.add_mutually_exclusive_group(required=True)
@@ -55,6 +56,13 @@ def _build_arg_parser():
                    help='If set, the weights will be normalized to the [0,1] '
                         'range.')
 
+    p.add_argument('--compute_mask_sum', action='store_true',
+                   help='Compute the sum of values for each input mask,\n '
+                        'this is equivalent to nb_voxel for binary mask.')
+
+    p.add_argument('--output_file',
+                   help='Save all average to a file (txt, csv, npy, json)')
+
     add_overwrite_arg(p)
     add_json_args(p)
 
@@ -68,33 +76,43 @@ def main():
     if args.metrics_dir and os.path.exists(args.metrics_dir):
         list_metrics_files = glob.glob(os.path.join(args.metrics_dir,
                                                     '*nii.gz'))
-        assert_inputs_exist(parser, [args.in_mask] + list_metrics_files)
+        assert_inputs_exist(parser, args.in_mask + list_metrics_files)
     elif args.metrics_file_list:
-        assert_inputs_exist(parser, [args.in_mask] + args.metrics_file_list)
+        assert_inputs_exist(parser, args.in_mask + args.metrics_file_list)
 
-    # Load mask and validate content depending on flags
-    mask_img = nib.load(args.in_mask)
+    assert_outputs_exist(parser, args, [], optional=args.output_file)
 
-    if len(mask_img.shape) > 3:
-        logging.error('Mask should be a 3D image.')
+    # Load masks and validate content depending on flags
+    mask_list = []
+    sum_list = []
+    for mask_file in args.in_mask:
+        mask_img = nib.load(mask_file)
 
-    # Can be a weighted image
-    mask_data = mask_img.get_fdata(dtype=np.float32)
+        if len(mask_img.shape) > 3:
+            logging.error('Masks should be a 3D image.')
 
-    if np.min(mask_data) < 0:
-        logging.error('Mask should not contain negative values.')
+        # Can be a weighted image
+        mask_data = mask_img.get_fdata(dtype=np.float32)
 
-    # Discussion about the way the normalization is done.
-    # https://github.com/scilus/scilpy/pull/202#discussion_r411355609
-    if args.normalize_weights:
-        mask_data /= np.max(mask_data)
+        if np.min(mask_data) < 0:
+            logging.error('Masks should not contain negative values.')
 
-    if np.min(mask_data) < 0.0 or np.max(mask_data) > 1.0:
-        parser.error('Mask data should only contain values between 0 and 1. '
-                     'Try --normalize_weights.')
+        # Discussion about the way the normalization is done.
+        # https://github.com/scilus/scilpy/pull/202#discussion_r411355609
+        if args.normalize_weights:
+            mask_data /= np.max(mask_data)
 
-    if args.bin:
-        mask_data[np.where(mask_data > 0.0)] = 1.0
+        if np.min(mask_data) < 0.0 or np.max(mask_data) > 1.0:
+            parser.error('Masks should only contain values between 0 and 1. '
+                         'Try --normalize_weights.')
+
+        if args.bin:
+            mask_data[np.where(mask_data > 0.0)] = 1.0
+
+        if args.compute_mask_sum:
+            sum_list.append(np.sum(mask_data))
+
+        mask_list.append(mask_data)
 
     # Load all metrics files.
     if args.metrics_dir:
@@ -104,19 +122,55 @@ def main():
         metrics_files = [nib.load(f) for f in args.metrics_file_list]
 
     # Compute the mean values and standard deviations
-    stats = get_roi_metrics_mean_std(mask_data, metrics_files)
+    nb_mask = len(mask_list)
+    nb_metric = len(metrics_files)
+    stats_list = []
+    for i in range(nb_mask):
+        mask_data = mask_list[i]
+        stats = get_roi_metrics_mean_std(mask_data, metrics_files)
+        stats_list.append(stats)
 
-    roi_name = split_name_with_nii(os.path.basename(args.in_mask))[0]
-    json_stats = {roi_name: {}}
-    for metric_file, (mean, std) in zip(metrics_files, stats):
-        metric_name = split_name_with_nii(
-            os.path.basename(metric_file.get_filename()))[0]
-        json_stats[roi_name][metric_name] = {
-            'mean': mean.item(),
-            'std': std.item()
-        }
+    json_stats = {}
+    avg_array = np.zeros([nb_mask, nb_metric], dtype=np.float)
+    for i in range(nb_mask):
+        mask_fname = args.in_mask[i]
+        roi_name = split_name_with_nii(os.path.basename(mask_fname))[0]
+        json_stats[roi_name] = {}
+
+        j = 0
+        for metric_file, (mean, std) in zip(metrics_files, stats_list[i]):
+            metric_name = split_name_with_nii(
+                os.path.basename(metric_file.get_filename()))[0]
+            json_stats[roi_name][metric_name] = {
+                'mean': mean.item(),
+                'std': std.item()
+            }
+            avg_array[i, j] = mean.item()
+            j += 1
+
+        if args.compute_mask_sum:
+            json_stats[roi_name]['sum'] = float(sum_list[i])
 
     print(json.dumps(json_stats, indent=args.indent, sort_keys=args.sort_keys))
+
+    if args.output_file:
+        _, file_ext = os.path.splitext(args.output_file)
+
+        if args.compute_mask_sum:
+            sum_array = np.asarray(sum_list).reshape((nb_mask, 1))
+            avg_array = np.hstack([avg_array, sum_array])
+
+        if file_ext == ".json":
+            with open(args.output_file, 'w') as fp:
+                json.dump(json_stats, fp, indent=args.indent,
+                          sort_keys=args.sort_keys)
+
+        elif file_ext == ".npy":
+            np.save(args.output_file, avg_array)
+        elif file_ext == ".csv":
+            np.savetxt(args.output_file, avg_array, delimiter=",")
+        else:
+            np.savetxt(args.output_file, avg_array, delimiter=",", newline=";")
 
 
 if __name__ == "__main__":

--- a/scripts/scil_compute_metrics_stats_in_ROI.py
+++ b/scripts/scil_compute_metrics_stats_in_ROI.py
@@ -5,7 +5,7 @@
 Compute the statistics (mean, std) of scalar maps, which can represent
 diffusion metrics, in a ROI (or multiples ROIs).
 
-ROIs mask can either be binary, or a weighted map. If the ROI is
+ROI mask can either be binary, or a weighted map. If the ROI is
 a weighting map it should either contain floats between 0 and 1 or should be
 normalized with --normalize_weights.
 

--- a/scripts/tests/test_compute_metrics_stats_in_ROI.py
+++ b/scripts/tests/test_compute_metrics_stats_in_ROI.py
@@ -23,5 +23,6 @@ def test_execution_tractometry(script_runner):
     in_ref = os.path.join(get_home(), 'tractometry',
                           'mni_masked.nii.gz')
     ret = script_runner.run('scil_compute_metrics_stats_in_ROI.py',
-                            in_mask, '--metrics', in_ref)
+                            in_mask, '--metrics', in_ref,
+                            '--output_file', 'IFGWM_avg.txt', '-f')
     assert ret.success

--- a/scripts/tests/test_compute_metrics_stats_in_ROI.py
+++ b/scripts/tests/test_compute_metrics_stats_in_ROI.py
@@ -24,5 +24,5 @@ def test_execution_tractometry(script_runner):
                           'mni_masked.nii.gz')
     ret = script_runner.run('scil_compute_metrics_stats_in_ROI.py',
                             in_mask, '--metrics', in_ref,
-                            '--output_file', 'IFGWM_avg.txt', '-f')
+                            '--out_file', 'IFGWM_avg.txt', '-f')
     assert ret.success


### PR DESCRIPTION
Generalized scil_compute_metrics_stats_in_ROI.py for multiple masks in input, 
and support few output formats (csv, npy, txt, json)

It always print the "json" to be backward compatible.
added an option to "compute_mask_sum" to have an efficient QC
with average values and "number of voxel" in masks