### PR TITLE
ENH: Resample volume to resolution

### DIFF
--- a/scilpy/image/resample_volume.py
+++ b/scilpy/image/resample_volume.py
@@ -33,7 +33,7 @@ def resample_volume(img, ref=None, res=None, iso_min=False, zoom=None,
     iso_min: bool, optional
         If true, resample the volume to R x R x R with R being the smallest
         current voxel dimension. If false, this method is not used.
-    zoom: float, optional
+    zoom: tuple, shape (3,) or float, optional
         Set the zoom property of the image at the value specified.
     interp: str, optional
         Interpolation mode. 'nn' = nearest neighbour, 'lin' = linear,
@@ -77,7 +77,9 @@ def resample_volume(img, ref=None, res=None, iso_min=False, zoom=None,
         min_zoom = min(original_zooms)
         new_zooms = (min_zoom, min_zoom, min_zoom)
     elif zoom:
-        new_zooms = [zoom] * 3
+        new_zooms = zoom
+        if len(zoom) == 1:
+            new_zooms = zoom * 3
     else:
         raise ValueError("You must choose the resampling method. Either with"
                          "a reference volume, or a chosen isometric resolution"

--- a/scilpy/image/resample_volume.py
+++ b/scilpy/image/resample_volume.py
@@ -51,7 +51,6 @@ def resample_volume(img, ref=None, res=None, iso_min=False, zoom=None,
     data = np.asanyarray(img.dataobj)
     original_res = data.shape
     affine = img.affine
-    offset = img.header['vox_offset']
     original_zooms = img.header.get_zooms()[:3]
 
     if ref is not None:
@@ -79,9 +78,9 @@ def resample_volume(img, ref=None, res=None, iso_min=False, zoom=None,
         new_zooms = tuple(o * zoom for o in original_zooms)
     else:
         raise ValueError("You must choose the resampling method. Either with"
-                         "a reference volume, or a chosen isometric resolution,"
-                         "or an isometric resampling to the smallest current "
-                         "voxel dimension!")
+                         "a reference volume, or a chosen isometric resolution"
+                         ", or an isometric resampling to the smallest current"
+                         " voxel dimension!")
 
     interp_choices = ['nn', 'lin', 'quad', 'cubic']
     if interp not in interp_choices:
@@ -93,7 +92,7 @@ def resample_volume(img, ref=None, res=None, iso_min=False, zoom=None,
     logging.debug('Resampling data to %s with mode %s', new_zooms, interp)
 
     data2, affine2 = reslice(data, affine, original_zooms, new_zooms,
-                             _interp_code_to_order(interp), offset=offset)
+                             _interp_code_to_order(interp))
 
     logging.debug('Resampled data shape: %s', data2.shape)
     logging.debug('Resampled data affine: %s', affine2)

--- a/scilpy/image/resample_volume.py
+++ b/scilpy/image/resample_volume.py
@@ -26,13 +26,16 @@ def resample_volume(img, ref=None, res=None, iso_min=False, zoom=None,
     ref: nib.Nifti1Image
         Reference volume to resample to. This method is used only if ref is not
         None. (default: None)
-    res: float, optional
+    res: tuple, shape (3,) or int, optional
         Resolution to resample to. If the value it is set to is Y, it will
         resample to an isotropic resolution of Y x Y x Y. This method is used
         only if res is not None. (default: None)
     iso_min: bool, optional
         If true, resample the volume to R x R x R with R being the smallest
         current voxel dimension. If false, this method is not used.
+    zoom: float, optional
+        Zoom into the image by the factor specified. A zoom above 1 will
+        zoom-in, a zoom betweem 0 and 1 will zoom-out.
     interp: str, optional
         Interpolation mode. 'nn' = nearest neighbour, 'lin' = linear,
         'quad' = quadratic, 'cubic' = cubic. (Default: linear)

--- a/scilpy/image/resample_volume.py
+++ b/scilpy/image/resample_volume.py
@@ -45,7 +45,7 @@ def resample_volume(img, ref=None, res=None, iso_min=False, zoom=None,
     resampled_image: nib.Nifti1Image
         Resampled image.
     """
-    data = img.get_fdata(dtype=np.float32)
+    data = np.asanyarray(img.dataobj)
     original_res = data.shape
     affine = img.affine
     offset = img.header['vox_offset']
@@ -68,8 +68,10 @@ def resample_volume(img, ref=None, res=None, iso_min=False, zoom=None,
 
     elif iso_min:
         if zoom:
-            min_zoom = min(original_zooms)
-            new_zooms = (min_zoom, min_zoom, min_zoom)
+            raise ValueError('Please only provide one option amongst ref, res '
+                             ', zoom or iso_min.')
+        min_zoom = min(original_zooms)
+        new_zooms = (min_zoom, min_zoom, min_zoom)
     elif zoom:
         new_zooms = tuple(o * zoom for o in original_zooms)
     else:
@@ -111,4 +113,4 @@ def resample_volume(img, ref=None, res=None, iso_min=False, zoom=None,
                     data2[:x_dim, :y_dim, :z_dim]
                 data2 = fix_dim_volume
 
-    return nib.Nifti1Image(data2, affine2)
+    return nib.Nifti1Image(data2.astype(data.dtype), affine2)

--- a/scilpy/image/resample_volume.py
+++ b/scilpy/image/resample_volume.py
@@ -63,7 +63,8 @@ def resample_volume(img, ref=None, res=None, iso_min=False, zoom=None,
                              ', zoom or iso_min.')
         if len(res) == 1:
             res = res * 3
-        new_zooms = tuple((o / r) * z for o, r, z in zip(original_res, res, original_zooms))
+        new_zooms = tuple((o / r) * z for o, r,
+                          z in zip(original_res, res, original_zooms))
 
     elif iso_min:
         if zoom:

--- a/scilpy/image/resample_volume.py
+++ b/scilpy/image/resample_volume.py
@@ -13,7 +13,7 @@ def _interp_code_to_order(interp_code):
 
 
 def resample_volume(img, ref=None, res=None, iso_min=False, zoom=None,
-                    interp='lin', enforce_dimensions=False):
+                    interp='lin', enforce_dimensions=False, offset=-0.5):
     """
     Function to resample a dataset to match the resolution of another
     reference dataset or to the resolution specified as in argument.
@@ -92,7 +92,7 @@ def resample_volume(img, ref=None, res=None, iso_min=False, zoom=None,
     logging.debug('Resampling data to %s with mode %s', new_zooms, interp)
 
     data2, affine2 = reslice(data, affine, original_zooms, new_zooms,
-                             _interp_code_to_order(interp))
+                             _interp_code_to_order(interp), offset=offset)
 
     logging.debug('Resampled data shape: %s', data2.shape)
     logging.debug('Resampled data affine: %s', affine2)

--- a/scilpy/image/resample_volume.py
+++ b/scilpy/image/resample_volume.py
@@ -34,14 +34,16 @@ def resample_volume(img, ref=None, res=None, iso_min=False, zoom=None,
         If true, resample the volume to R x R x R with R being the smallest
         current voxel dimension. If false, this method is not used.
     zoom: float, optional
-        Zoom into the image by the factor specified. A zoom above 1 will
-        zoom-in, a zoom betweem 0 and 1 will zoom-out.
+        Set the zoom property of the image at the value specified.
     interp: str, optional
         Interpolation mode. 'nn' = nearest neighbour, 'lin' = linear,
         'quad' = quadratic, 'cubic' = cubic. (Default: linear)
     enforce_dimensions: bool, optional
         If True, enforce the reference volume dimension (only if res is not
         None). (Default = False)
+    offset: float
+        Offset property for the volume. Be careful when setting something else
+        than the default. (Default = -0.5)
 
     Returns
     -------
@@ -75,7 +77,7 @@ def resample_volume(img, ref=None, res=None, iso_min=False, zoom=None,
         min_zoom = min(original_zooms)
         new_zooms = (min_zoom, min_zoom, min_zoom)
     elif zoom:
-        new_zooms = tuple(o * zoom for o in original_zooms)
+        new_zooms = [zoom] * 3
     else:
         raise ValueError("You must choose the resampling method. Either with"
                          "a reference volume, or a chosen isometric resolution"

--- a/scilpy/image/reslice.py
+++ b/scilpy/image/reslice.py
@@ -16,7 +16,7 @@ def _affine_transform(kwargs):
 
 
 def reslice(data, affine, zooms, new_zooms, order=1, mode='constant', cval=0,
-            offset=-0.5, num_processes=1):
+            offset=-0.0, num_processes=1):
     """Reslice data with new voxel resolution defined by ``new_zooms``
 
     Parameters

--- a/scilpy/image/reslice.py
+++ b/scilpy/image/reslice.py
@@ -16,7 +16,7 @@ def _affine_transform(kwargs):
 
 
 def reslice(data, affine, zooms, new_zooms, order=1, mode='constant', cval=0,
-            offset=-0.0, num_processes=1):
+            offset=-0.5, num_processes=1):
     """Reslice data with new voxel resolution defined by ``new_zooms``
 
     Parameters
@@ -40,7 +40,7 @@ def reslice(data, affine, zooms, new_zooms, order=1, mode='constant', cval=0,
         Value used for points outside the boundaries of the input if
         mode='constant'.
     offset: float
-        Offset for values in the image
+        Offset for voxels in the volume
     num_processes : int
         Split the calculation to a pool of children processes. This only
         applies to 4D `data` arrays. If a positive integer then it defines

--- a/scilpy/image/reslice.py
+++ b/scilpy/image/reslice.py
@@ -39,6 +39,8 @@ def reslice(data, affine, zooms, new_zooms, order=1, mode='constant', cval=0,
     cval : float
         Value used for points outside the boundaries of the input if
         mode='constant'.
+    offset: float
+        Offset for values in the image
     num_processes : int
         Split the calculation to a pool of children processes. This only
         applies to 4D `data` arrays. If a positive integer then it defines

--- a/scilpy/image/reslice.py
+++ b/scilpy/image/reslice.py
@@ -16,7 +16,7 @@ def _affine_transform(kwargs):
 
 
 def reslice(data, affine, zooms, new_zooms, order=1, mode='constant', cval=0,
-            num_processes=1):
+            offset=-0.5, num_processes=1):
     """Reslice data with new voxel resolution defined by ``new_zooms``
 
     Parameters
@@ -83,7 +83,7 @@ def reslice(data, affine, zooms, new_zooms, order=1, mode='constant', cval=0,
         new_shape = zooms / new_zooms * np.array(data.shape[:3])
         new_shape = tuple(np.round(new_shape).astype('i8'))
         kwargs = {'matrix': R, 'output_shape': new_shape, 'order': order,
-                  'mode': mode, 'cval': cval, 'offset': -0.5 * R}
+                  'mode': mode, 'cval': cval, 'offset': offset * R}
         if data.ndim == 3:
             data2 = affine_transform(input=data, **kwargs)
         if data.ndim == 4:

--- a/scripts/scil_resample_volume.py
+++ b/scripts/scil_resample_volume.py
@@ -30,9 +30,9 @@ def _build_arg_parser():
         '--ref',
         help='Reference volume to resample to.')
     res_group.add_argument(
-        '--resolution', nargs='+', type=int,
-        help='New resolution for the volume. If the value is set to is Y, '
-             'it will resample to an isotropic resolution of Y x Y x Y.')
+        '--volume_size', nargs='+', type=int,
+        help='Sets the size for the volume. If the value is set to is Y, '
+             'it will resample to a shape of Y x Y x Y.')
     res_group.add_argument(
         '--voxel_size', nargs='+', type=float,
         help='Sets the voxel size. If the value is set to is Y, it will set '
@@ -71,9 +71,9 @@ def main():
     if args.verbose:
         logging.basicConfig(level=logging.DEBUG)
 
-    if args.resolution and (not len(args.resolution) == 1 and
-                            not len(args.resolution) == 3):
-        parser.error('Invalid dimensions for --resolution.')
+    if args.volume_size and (not len(args.volume_size) == 1 and
+                             not len(args.volume_size) == 3):
+        parser.error('Invalid dimensions for --volume_size.')
 
     if args.voxel_size and (not len(args.voxel_size) == 1 and
                             not len(args.voxel_size) == 3):
@@ -88,7 +88,7 @@ def main():
     img = nib.load(args.in_image)
 
     # Resampling volume
-    resampled_img = resample_volume(img, ref=args.ref, res=args.resolution,
+    resampled_img = resample_volume(img, ref=args.ref, res=args.volume_size,
                                     iso_min=args.iso_min, zoom=args.voxel_size,
                                     interp=args.interp,
                                     enforce_dimensions=args.enforce_dimensions,

--- a/scripts/scil_resample_volume.py
+++ b/scripts/scil_resample_volume.py
@@ -31,14 +31,16 @@ def _build_arg_parser():
         help='Reference volume to resample to.')
     res_group.add_argument(
         '--resolution', nargs='+', type=int,
-        help='New resolution for the volume. If the value it is set to is Y, '
+        help='New resolution for the volume. If the value is set to is Y, '
              'it will resample to an isotropic resolution of Y x Y x Y.')
-    res_group.add_argument('--zoom', type=float,
-                           help='Set the zoom of the image.')
+    res_group.add_argument(
+        '--voxel_size', nargs='+', type=float,
+        help='Sets the voxel size. If the value is set to is Y, it will set '
+             'a voxel size of Y x Y x Y.')
     res_group.add_argument(
         '--iso_min', action='store_true',
         help='Resample the volume to R x R x R with R being the smallest '
-             'current voxel dimension ')
+             'current voxel dimension.')
 
     p.add_argument(
         '--interp', default='lin',
@@ -73,6 +75,10 @@ def main():
                             not len(args.resolution) == 3):
         parser.error('Invalid dimensions for --resolution.')
 
+    if args.voxel_size and (not len(args.voxel_size) == 1 and
+                            not len(args.voxel_size) == 3):
+        parser.error('Invalid dimensions for --voxel_size.')
+
     if args.offset != parser.get_default('offset'):
         logging.warning('--offset is a dangerous parameter to modify. Make '
                         'sure you know what you are doing.')
@@ -83,7 +89,7 @@ def main():
 
     # Resampling volume
     resampled_img = resample_volume(img, ref=args.ref, res=args.resolution,
-                                    iso_min=args.iso_min, zoom=args.zoom,
+                                    iso_min=args.iso_min, zoom=args.voxel_size,
                                     interp=args.interp,
                                     enforce_dimensions=args.enforce_dimensions,
                                     offset=args.offset)

--- a/scripts/scil_resample_volume.py
+++ b/scripts/scil_resample_volume.py
@@ -30,9 +30,11 @@ def _build_arg_parser():
         '--ref',
         help='Reference volume to resample to.')
     res_group.add_argument(
-        '--resolution', type=float,
+        '--resolution', nargs='+', type=int,
         help='Resolution to resample to. If the value it is set to is Y, it '
              'will resample to an isotropic resolution of Y x Y x Y.')
+    res_group.add_argument('--zoom', type=float,
+        help='Zoom uniformly into the image.')
     res_group.add_argument(
         '--iso_min', action='store_true',
         help='Resample the volume to R x R x R with R being the smallest '
@@ -65,13 +67,17 @@ def main():
     if args.verbose:
         logging.basicConfig(level=logging.DEBUG)
 
-    logging.debug('Loading Raw data from %s', args.in_image)
+    if args.resolution and (not len(args.resolution) == 1 and
+                            not len(args.resolution) == 3):
+        parser.error('Invalid dimensions for --resolution.')
+
+    logging.debug('Loading raw data from %s', args.in_image)
 
     img = nib.load(args.in_image)
 
     # Resampling volume
     resampled_img = resample_volume(img, ref=args.ref, res=args.resolution,
-                                    iso_min=args.iso_min, interp=args.interp,
+                                    iso_min=args.iso_min, zoom=args.zoom, interp=args.interp,
                                     enforce_dimensions=args.enforce_dimensions)
 
     # Saving results

--- a/scripts/scil_resample_volume.py
+++ b/scripts/scil_resample_volume.py
@@ -34,7 +34,7 @@ def _build_arg_parser():
         help='Resolution to resample to. If the value it is set to is Y, it '
              'will resample to an isotropic resolution of Y x Y x Y.')
     res_group.add_argument('--zoom', type=float,
-        help='Zoom uniformly into the image.')
+                           help='Zoom uniformly into the image.')
     res_group.add_argument(
         '--iso_min', action='store_true',
         help='Resample the volume to R x R x R with R being the smallest '
@@ -77,7 +77,8 @@ def main():
 
     # Resampling volume
     resampled_img = resample_volume(img, ref=args.ref, res=args.resolution,
-                                    iso_min=args.iso_min, zoom=args.zoom, interp=args.interp,
+                                    iso_min=args.iso_min, zoom=args.zoom,
+                                    interp=args.interp,
                                     enforce_dimensions=args.enforce_dimensions)
 
     # Saving results

--- a/scripts/scil_resample_volume.py
+++ b/scripts/scil_resample_volume.py
@@ -31,10 +31,10 @@ def _build_arg_parser():
         help='Reference volume to resample to.')
     res_group.add_argument(
         '--resolution', nargs='+', type=int,
-        help='Resolution to resample to. If the value it is set to is Y, it '
-             'will resample to an isotropic resolution of Y x Y x Y.')
+        help='New resolution for the volume. If the value it is set to is Y, '
+             'it will resample to an isotropic resolution of Y x Y x Y.')
     res_group.add_argument('--zoom', type=float,
-                           help='Zoom uniformly into the image.')
+                           help='Set the zoom of the image.')
     res_group.add_argument(
         '--iso_min', action='store_true',
         help='Resample the volume to R x R x R with R being the smallest '
@@ -48,7 +48,7 @@ def _build_arg_parser():
     p.add_argument('--enforce_dimensions', action='store_true',
                    help='Enforce the reference volume dimension.')
     p.add_argument('--offset', default=-0.5, type=float,
-                   help='Add offset to voxels in the volume.')
+                   help='Add offset to voxels in the volume [%(default)s].')
 
     add_verbose_arg(p)
     add_overwrite_arg(p)

--- a/scripts/scil_resample_volume.py
+++ b/scripts/scil_resample_volume.py
@@ -47,6 +47,8 @@ def _build_arg_parser():
              "quad: quadratic\ncubic: cubic\nDefaults to linear")
     p.add_argument('--enforce_dimensions', action='store_true',
                    help='Enforce the reference volume dimension.')
+    p.add_argument('--offset', default=-0.5, type=float,
+                   help='Add offset to voxels in the volume.')
 
     add_verbose_arg(p)
     add_overwrite_arg(p)
@@ -71,6 +73,10 @@ def main():
                             not len(args.resolution) == 3):
         parser.error('Invalid dimensions for --resolution.')
 
+    if args.offset != parser.get_default('offset'):
+        logging.warning('--offset is a dangerous parameter to modify. Make '
+                        'sure you know what you are doing.')
+
     logging.debug('Loading raw data from %s', args.in_image)
 
     img = nib.load(args.in_image)
@@ -79,7 +85,8 @@ def main():
     resampled_img = resample_volume(img, ref=args.ref, res=args.resolution,
                                     iso_min=args.iso_min, zoom=args.zoom,
                                     interp=args.interp,
-                                    enforce_dimensions=args.enforce_dimensions)
+                                    enforce_dimensions=args.enforce_dimensions,
+                                    offset=args.offset)
 
     # Saving results
     logging.debug('Saving resampled data to %s', args.out_image)

--- a/scripts/tests/test_resample_volume.py
+++ b/scripts/tests/test_resample_volume.py
@@ -22,5 +22,5 @@ def test_execution_others(script_runner):
     in_img = os.path.join(get_home(), 'others',
                           'fa.nii.gz')
     ret = script_runner.run('scil_resample_volume.py', in_img,
-                            'fa_resample.nii.gz', '--resolution', '2')
+                            'fa_resample.nii.gz', '--voxel_size', '2')
     assert ret.success


### PR DESCRIPTION
`scil_resample_volume` now handles resampling to arbitrary resolutions. Will be useful for future multi-resolution tracking.
Also fixes a bug with the offset of resampled volumes. "Old" behavior is still available through the `zoom` argument.

Test data: https://drive.google.com/file/d/1k0vqk4tp5y0q3SRGOtU2esY2a8h0zGT8/view?usp=sharing

To test:
`$ scil_resample_volume.py Simulated_FiberCup_fodf_6.nii.gz Simulated_FiberCup_fodf_6_32_32_3.nii.gz --resolution 32 32 3 -f`
Downsamples the fibercup from 64x64x3 to 32x32x3

@arnaudbore @frheault @GuillaumeTh @mdesco 