### PR TITLE
Refactor scil_compute_sf_from_sh.py

### DIFF
--- a/scilpy/reconst/multi_processes.py
+++ b/scilpy/reconst/multi_processes.py
@@ -12,6 +12,7 @@ import numpy as np
 
 cvx, have_cvxpy, _ = optional_package("cvxpy")
 
+
 def fit_from_model_parallel(args):
     model = args[0]
     data = args[1]
@@ -59,7 +60,7 @@ def fit_from_model(model, data, mask=None, nbr_processes=None):
         mask *= mask_any
 
     nbr_processes = multiprocessing.cpu_count() if nbr_processes is None \
-        or nbr_processes <= 0 else nbr_processes
+                                                   or nbr_processes <= 0 else nbr_processes
 
     # Ravel the first 3 dimensions while keeping the 4th intact, like a list of
     # 1D time series voxels. Then separate it in chunks of len(nbr_processes).
@@ -79,7 +80,7 @@ def fit_from_model(model, data, mask=None, nbr_processes=None):
     fit_array = np.zeros(data_shape[0:3], dtype='object')
     tmp_fit_array = np.zeros((np.count_nonzero(mask)), dtype='object')
     for i, fit in results:
-        tmp_fit_array[chunk_len[i]:chunk_len[i+1]] = fit
+        tmp_fit_array[chunk_len[i]:chunk_len[i + 1]] = fit
 
     fit_array[mask] = tmp_fit_array
     fit_array = MultiVoxelFit(model, fit_array, mask)
@@ -180,7 +181,7 @@ def peaks_from_sh(shm_coeff, sphere, mask=None, relative_peak_threshold=0.5,
         mask = np.sum(shm_coeff, axis=3).astype(bool)
 
     nbr_processes = multiprocessing.cpu_count() if nbr_processes is None \
-        or nbr_processes < 0 else nbr_processes
+                                                   or nbr_processes < 0 else nbr_processes
 
     # Ravel the first 3 dimensions while keeping the 4th intact, like a list of
     # 1D time series voxels. Then separate it in chunks of len(nbr_processes).
@@ -214,9 +215,9 @@ def peaks_from_sh(shm_coeff, sphere, mask=None, relative_peak_threshold=0.5,
     tmp_peak_values_array = np.zeros((np.count_nonzero(mask), npeaks))
     tmp_peak_indices_array = np.zeros((np.count_nonzero(mask), npeaks))
     for i, peak_dirs, peak_values, peak_indices in results:
-        tmp_peak_dirs_array[chunk_len[i]:chunk_len[i+1], :, :] = peak_dirs
-        tmp_peak_values_array[chunk_len[i]:chunk_len[i+1], :] = peak_values
-        tmp_peak_indices_array[chunk_len[i]:chunk_len[i+1], :] = peak_indices
+        tmp_peak_dirs_array[chunk_len[i]:chunk_len[i + 1], :, :] = peak_dirs
+        tmp_peak_values_array[chunk_len[i]:chunk_len[i + 1], :] = peak_values
+        tmp_peak_indices_array[chunk_len[i]:chunk_len[i + 1], :] = peak_indices
 
     peak_dirs_array[mask] = tmp_peak_dirs_array
     peak_values_array[mask] = tmp_peak_values_array
@@ -266,7 +267,7 @@ def maps_from_sh_parallel(args):
                 global_max = max(global_max, peak_values[idx][0])
 
     return chunk_id, nufo_map, afd_max, afd_sum, rgb_map, gfa_map, qa_map, \
-        max_odf, global_max
+           max_odf, global_max
 
 
 def maps_from_sh(shm_coeff, peak_dirs, peak_values, peak_indices, sphere,
@@ -314,7 +315,7 @@ def maps_from_sh(shm_coeff, peak_dirs, peak_values, peak_indices, sphere,
         mask = np.sum(shm_coeff, axis=3).astype(bool)
 
     nbr_processes = multiprocessing.cpu_count() if nbr_processes is None \
-        or nbr_processes < 0 else nbr_processes
+                                                   or nbr_processes < 0 else nbr_processes
 
     npeaks = peak_values.shape[3]
     # Ravel the first 3 dimensions while keeping the 4th intact, like a list of
@@ -363,16 +364,16 @@ def maps_from_sh(shm_coeff, peak_dirs, peak_values, peak_indices, sphere,
     all_time_max_odf = -np.inf
     all_time_global_max = -np.inf
     for i, nufo_map, afd_max, afd_sum, rgb_map, gfa_map, qa_map, \
-            max_odf, global_max in results:
+        max_odf, global_max in results:
         all_time_max_odf = max(all_time_global_max, max_odf)
         all_time_global_max = max(all_time_global_max, global_max)
 
-        tmp_nufo_map_array[chunk_len[i]:chunk_len[i+1]] = nufo_map
-        tmp_afd_max_array[chunk_len[i]:chunk_len[i+1]] = afd_max
-        tmp_afd_sum_array[chunk_len[i]:chunk_len[i+1]] = afd_sum
-        tmp_rgb_map_array[chunk_len[i]:chunk_len[i+1], :] = rgb_map
-        tmp_gfa_map_array[chunk_len[i]:chunk_len[i+1]] = gfa_map
-        tmp_qa_map_array[chunk_len[i]:chunk_len[i+1], :] = qa_map
+        tmp_nufo_map_array[chunk_len[i]:chunk_len[i + 1]] = nufo_map
+        tmp_afd_max_array[chunk_len[i]:chunk_len[i + 1]] = afd_max
+        tmp_afd_sum_array[chunk_len[i]:chunk_len[i + 1]] = afd_sum
+        tmp_rgb_map_array[chunk_len[i]:chunk_len[i + 1], :] = rgb_map
+        tmp_gfa_map_array[chunk_len[i]:chunk_len[i + 1]] = gfa_map
+        tmp_qa_map_array[chunk_len[i]:chunk_len[i + 1], :] = qa_map
 
     nufo_map_array[mask] = tmp_nufo_map_array
     afd_max_array[mask] = tmp_afd_max_array
@@ -390,8 +391,8 @@ def maps_from_sh(shm_coeff, peak_dirs, peak_values, peak_indices, sphere,
             or np.array_equal(np.array([1]), afd_unique):
         logging.warning('All AFD_max values are 1. The peaks seem normalized.')
 
-    return(nufo_map_array, afd_max_array, afd_sum_array,
-           rgb_map_array, gfa_map_array, qa_map_array)
+    return (nufo_map_array, afd_max_array, afd_sum_array,
+            rgb_map_array, gfa_map_array, qa_map_array)
 
 
 def convert_sh_basis_parallel(args):
@@ -445,7 +446,7 @@ def convert_sh_basis(shm_coeff, sphere, mask=None,
         mask = np.sum(shm_coeff, axis=3).astype(bool)
 
     nbr_processes = multiprocessing.cpu_count() if nbr_processes is None \
-        or nbr_processes < 0 else nbr_processes
+                                                   or nbr_processes < 0 else nbr_processes
 
     # Ravel the first 3 dimensions while keeping the 4th intact, like a list of
     # 1D time series voxels. Then separate it in chunks of len(nbr_processes).
@@ -467,7 +468,7 @@ def convert_sh_basis(shm_coeff, sphere, mask=None,
     shm_coeff_array = np.zeros(data_shape)
     tmp_shm_coeff_array = np.zeros((np.count_nonzero(mask), data_shape[3]))
     for i, new_shm_coeff in results:
-        tmp_shm_coeff_array[chunk_len[i]:chunk_len[i+1], :] = new_shm_coeff
+        tmp_shm_coeff_array[chunk_len[i]:chunk_len[i + 1], :] = new_shm_coeff
 
     shm_coeff_array[mask] = tmp_shm_coeff_array
 
@@ -524,7 +525,8 @@ def convert_sh_to_sf(shm_coeff, sphere, mask=None, dtype="float32",
     assert dtype in ["float32", "float64"], "Only `float32` and `float64` " \
                                             "should be used."
 
-    sh_order = order_from_ncoef(shm_coeff.shape[-1])
+    sh_order = order_from_ncoef(shm_coeff.shape[-1],
+                                full_basis=input_full_basis)
     B_in, _ = sh_to_sf_matrix(sphere, sh_order, basis_type=input_basis,
                               full_basis=input_full_basis)
     B_in = B_in.astype(dtype)

--- a/scilpy/reconst/multi_processes.py
+++ b/scilpy/reconst/multi_processes.py
@@ -3,13 +3,13 @@ import logging
 import multiprocessing
 
 from dipy.direction.peaks import peak_directions
+from dipy.reconst.mcsd import MSDeconvFit
 from dipy.reconst.multi_voxel import MultiVoxelFit
 from dipy.reconst.odf import gfa
-from dipy.reconst.shm import sh_to_sf_matrix, order_from_ncoef
-from dipy.reconst.mcsd import MSDeconvFit
+from dipy.reconst.shm import order_from_ncoef, sh_to_sf_matrix
+from dipy.utils.optpkg import optional_package
 import numpy as np
 
-from dipy.utils.optpkg import optional_package
 cvx, have_cvxpy, _ = optional_package("cvxpy")
 
 def fit_from_model_parallel(args):
@@ -472,3 +472,80 @@ def convert_sh_basis(shm_coeff, sphere, mask=None,
     shm_coeff_array[mask] = tmp_shm_coeff_array
 
     return shm_coeff_array
+
+
+def convert_sh_to_sf_parallel(args):
+    sh = args[0]
+    B_in = args[1]
+    chunk_id = args[2]
+
+    for idx in range(sh.shape[0]):
+        if sh[idx].any():
+            sf = np.dot(sh[idx], B_in)
+
+    return chunk_id, sf
+
+
+def convert_sh_to_sf(shm_coeff, sphere, mask=None,
+                     input_basis='descoteaux07', nbr_processes=None):
+    """Converts spherical harmonic coefficients to an SF sphere
+
+    Parameters
+    ----------
+    shm_coeff : np.ndarray
+        Spherical harmonic coefficients
+    sphere : Sphere
+        The Sphere providing discrete directions for evaluation.
+    mask : np.ndarray, optional
+        If `mask` is provided, only the data inside the mask will be
+        used for computations.
+    input_basis : str, optional
+        Type of spherical harmonic basis used for `shm_coeff`. Either
+        `descoteaux07` or `tournier07`.
+        Default: `descoteaux07`
+    nbr_processes: int, optional
+        The number of subprocesses to use.
+        Default: multiprocessing.cpu_count()
+
+    Returns
+    -------
+    shm_coeff_array : np.ndarray
+        Spherical harmonic coefficients in the desired basis.
+    """
+    sh_order = order_from_ncoef(shm_coeff.shape[-1])
+    B_in, _ = sh_to_sf_matrix(sphere, sh_order, input_basis)
+    B_in = B_in.astype(np.float32)
+
+    data_shape = shm_coeff.shape
+    if mask is None:
+        mask = np.sum(shm_coeff, axis=3).astype(bool)
+
+    nbr_processes = multiprocessing.cpu_count() if nbr_processes is None \
+                                                   or nbr_processes < 0 else nbr_processes
+
+    # Ravel the first 3 dimensions while keeping the 4th intact, like a list of
+    # 1D time series voxels. Then separate it in chunks of len(nbr_processes).
+    shm_coeff = shm_coeff[mask].reshape(
+        (np.count_nonzero(mask), data_shape[3]))
+    shm_coeff_chunks = np.array_split(shm_coeff, nbr_processes)
+    chunk_len = np.cumsum([0] + [len(c) for c in shm_coeff_chunks])
+
+    pool = multiprocessing.Pool(nbr_processes)
+    results = pool.map(convert_sh_to_sf_parallel,
+                       zip(shm_coeff_chunks,
+                           itertools.repeat(B_in),
+                           np.arange(len(shm_coeff_chunks))))
+    pool.close()
+    pool.join()
+
+    # Re-assemble the chunk together in the original shape.
+    new_shape = data_shape[:3] + (len(sphere.vertices),)
+    sf_array = np.zeros(new_shape, dtype=np.float32)
+    tmp_sf_array = np.zeros((np.count_nonzero(mask), new_shape[3]),
+                            dtype=np.float32)
+    for i, new_sf in results:
+        tmp_sf_array[chunk_len[i]:chunk_len[i + 1], :] = new_sf
+
+    sf_array[mask] = tmp_sf_array
+
+    return sf_array

--- a/scilpy/reconst/multi_processes.py
+++ b/scilpy/reconst/multi_processes.py
@@ -491,7 +491,7 @@ def convert_sh_to_sf_parallel(args):
 
 def convert_sh_to_sf(shm_coeff, sphere, mask=None, dtype="float32",
                      input_basis='descoteaux07', input_full_basis=False,
-                     nbr_processes=None):
+                     nbr_processes=multiprocessing.cpu_count()):
     """Converts spherical harmonic coefficients to an SF sphere
 
     Parameters
@@ -534,9 +534,6 @@ def convert_sh_to_sf(shm_coeff, sphere, mask=None, dtype="float32",
     data_shape = shm_coeff.shape
     if mask is None:
         mask = np.sum(shm_coeff, axis=3).astype(bool)
-
-    nbr_processes = multiprocessing.cpu_count() \
-        if nbr_processes is None or nbr_processes < 0 else nbr_processes
 
     # Ravel the first 3 dimensions while keeping the 4th intact, like a list of
     # 1D time series voxels. Then separate it in chunks of len(nbr_processes).

--- a/scilpy/reconst/multi_processes.py
+++ b/scilpy/reconst/multi_processes.py
@@ -489,7 +489,8 @@ def convert_sh_to_sf_parallel(args):
 
 
 def convert_sh_to_sf(shm_coeff, sphere, mask=None, dtype="float32",
-                     input_basis='descoteaux07', nbr_processes=None):
+                     input_basis='descoteaux07', input_full_basis=False,
+                     nbr_processes=None):
     """Converts spherical harmonic coefficients to an SF sphere
 
     Parameters
@@ -508,6 +509,9 @@ def convert_sh_to_sf(shm_coeff, sphere, mask=None, dtype="float32",
         Type of spherical harmonic basis used for `shm_coeff`. Either
         `descoteaux07` or `tournier07`.
         Default: `descoteaux07`
+    input_full_basis : bool
+        If True, use a full SH basis (even and odd orders) for the input SH
+        coefficients.
     nbr_processes: int, optional
         The number of subprocesses to use.
         Default: multiprocessing.cpu_count()
@@ -521,7 +525,8 @@ def convert_sh_to_sf(shm_coeff, sphere, mask=None, dtype="float32",
                                             "should be used."
 
     sh_order = order_from_ncoef(shm_coeff.shape[-1])
-    B_in, _ = sh_to_sf_matrix(sphere, sh_order, input_basis)
+    B_in, _ = sh_to_sf_matrix(sphere, sh_order, basis_type=input_basis,
+                              full_basis=input_full_basis)
     B_in = B_in.astype(dtype)
 
     data_shape = shm_coeff.shape

--- a/scilpy/reconst/multi_processes.py
+++ b/scilpy/reconst/multi_processes.py
@@ -477,11 +477,13 @@ def convert_sh_basis(shm_coeff, sphere, mask=None,
 def convert_sh_to_sf_parallel(args):
     sh = args[0]
     B_in = args[1]
-    chunk_id = args[2]
+    new_output_dim = args[2]
+    chunk_id = args[3]
+    sf = np.zeros((sh.shape[0], new_output_dim), dtype=np.float32)
 
     for idx in range(sh.shape[0]):
         if sh[idx].any():
-            sf = np.dot(sh[idx], B_in)
+            sf[idx] = np.dot(sh[idx], B_in)
 
     return chunk_id, sf
 
@@ -534,6 +536,7 @@ def convert_sh_to_sf(shm_coeff, sphere, mask=None,
     results = pool.map(convert_sh_to_sf_parallel,
                        zip(shm_coeff_chunks,
                            itertools.repeat(B_in),
+                           itertools.repeat(len(sphere.vertices)),
                            np.arange(len(shm_coeff_chunks))))
     pool.close()
     pool.join()

--- a/scripts/scil_compute_sf_from_sh.py
+++ b/scripts/scil_compute_sf_from_sh.py
@@ -21,7 +21,7 @@ import numpy as np
 from scilpy.io.utils import (add_force_b0_arg, add_overwrite_arg,
                              add_processes_arg, add_sh_basis_args,
                              assert_inputs_exist,
-                             assert_outputs_exist)
+                             assert_outputs_exist, validate_nbr_processes)
 from scilpy.reconst.multi_processes import convert_sh_to_sf
 from scilpy.utils.bvec_bval_tools import (check_b0_threshold)
 
@@ -88,6 +88,8 @@ def main():
         parser.error("--out_bval is required if --in_bval is provided, "
                      "and vice-versa.")
 
+    nbr_processes = validate_nbr_processes(parser, args)
+
     # Load SH
     vol_sh = nib.load(args.in_sh)
     data_sh = vol_sh.get_fdata(dtype=np.float32)
@@ -103,7 +105,7 @@ def main():
                           input_basis=args.sh_basis,
                           input_full_basis=args.full_basis,
                           dtype=args.dtype,
-                          nbr_processes=args.nbr_processes)
+                          nbr_processes=nbr_processes)
     new_bvecs = sphere.vertices.astype(np.float32)
 
     # Assign bval to SF if --in_bval was provided

--- a/scripts/scil_compute_sf_from_sh.py
+++ b/scripts/scil_compute_sf_from_sh.py
@@ -40,6 +40,11 @@ def _build_arg_parser():
                    help='Sphere used for the SH to SF projection. '
                         '[%(default)s]')
 
+    p.add_argument('--dtype', default="float32",
+                   choices=["float32", "float64"],
+                   help="Datatype to use for SF computation and output array."
+                        "'[%(default)s]'")
+
     # Optional args for a DWI-like volume
     p.add_argument("--extract_as_dwi", action="store_true",
                    help="Generate a DWI-like output, including a `.bval` file "
@@ -86,6 +91,7 @@ def main():
     sphere = get_sphere(args.sphere)
     sf = convert_sh_to_sf(data_sh, sphere,
                           input_basis=args.sh_basis,
+                          dtype=args.dtype,
                           nbr_processes=args.nbr_processes)
     new_bvecs = sphere.vertices.astype(np.float32)
 

--- a/scripts/scil_compute_sf_from_sh.py
+++ b/scripts/scil_compute_sf_from_sh.py
@@ -102,7 +102,7 @@ def main():
     if args.extract_as_dwi:
         # Load b0
         vol_b0 = nib.load(args.b0)
-        data_b0 = vol_b0.get_fdata(dtype=np.float32)
+        data_b0 = vol_b0.get_fdata(dtype=args.dtype)
         if data_b0.ndim == 3:
             data_b0 = data_b0[..., np.newaxis]
 
@@ -129,7 +129,7 @@ def main():
     np.savetxt(out_bvecs, new_bvecs.T, fmt='%.8f')
 
     # Save SF
-    nib.save(nib.Nifti1Image(sf.astype(np.float32), vol_sh.affine), args.out_sf)
+    nib.save(nib.Nifti1Image(sf, vol_sh.affine), args.out_sf)
 
 
 if __name__ == "__main__":

--- a/scripts/scil_compute_sf_from_sh.py
+++ b/scripts/scil_compute_sf_from_sh.py
@@ -34,12 +34,15 @@ def _build_arg_parser():
                    help='Name of the output SF file to save (bvals/bvecs will '
                         'be automatically named when necessary).')
 
+    p.add_argument('--full_basis', action="store_true",
+                   help="If true, use a full basis for the input SH "
+                        "coefficients.")
+
     # Sphere choice for SF
     p.add_argument('--sphere', default='repulsion724',
                    choices=sorted(SPHERE_FILES.keys()),
                    help='Sphere used for the SH to SF projection. '
                         '[%(default)s]')
-
     p.add_argument('--dtype', default="float32",
                    choices=["float32", "float64"],
                    help="Datatype to use for SF computation and output array."
@@ -91,6 +94,7 @@ def main():
     sphere = get_sphere(args.sphere)
     sf = convert_sh_to_sf(data_sh, sphere,
                           input_basis=args.sh_basis,
+                          input_full_basis=args.full_basis,
                           dtype=args.dtype,
                           nbr_processes=args.nbr_processes)
     new_bvecs = sphere.vertices.astype(np.float32)

--- a/scripts/scil_compute_sf_from_sh.py
+++ b/scripts/scil_compute_sf_from_sh.py
@@ -43,11 +43,11 @@ def _build_arg_parser():
     p.add_argument("--extract_as_dwi", action="store_true",
                    help="Generate a DWI-like output, including a `.bval` file "
                         "and b0 images in the sf file.")
-    p.add_argument('--bval', required=True,
+    p.add_argument('--bval',
                    help='b-value file, in FSL format, '
                         'used to assign a b-value to the '
                         'output SF and generate a `.bval` file.')
-    p.add_argument('--b0', required=True,
+    p.add_argument('--b0',
                    help='b0 volume to concatenate to the '
                         'final SF volume.')
     add_sh_basis_args(p)

--- a/scripts/tests/test_compute_sf_from_sh.py
+++ b/scripts/tests/test_compute_sf_from_sh.py
@@ -23,6 +23,8 @@ def test_execution_processing(script_runner):
     in_bval = os.path.join(get_home(), 'processing', '1000.bval')
 
     ret = script_runner.run('scil_compute_sf_from_sh.py', in_sh,
-                            'sf_724.nii.gz', '--extract_as_dwi', '--bval',
-                            in_bval, '--b0', in_b0)
+                            'sf_724.nii.gz', '--in_bval',
+                            in_bval, '--in_b0', in_b0, '--out_bval',
+                            'sf_724.bval', '--out_bvec', 'sf_724.bvec',
+                            '--sphere', 'symmetric724', '--dtype', 'float32')
     assert ret.success


### PR DESCRIPTION
Using Dipy's `sh_to_sf` caused memory problems because everything is computed in float64. I refactored the code to work like `convert_sh_basis`, so it can run in parallel, and I use float32 to make it fit in memory, especially when working with 1x1x1 volumes with > 200 SF directions.