### PR TITLE
[ENH] Add capacities to prepare Topup and Eddy

### DIFF
--- a/scilpy/preprocessing/distortion_correction.py
+++ b/scilpy/preprocessing/distortion_correction.py
@@ -17,6 +17,7 @@ def create_acqparams(readout, encoding_direction, nb_b0s=1, nb_rev_b0s=1):
         Number of B=0 images
     nb_rev_b0s: int
         number of reverse b=0 images
+
     Returns
     -------
     acqparams: np.array
@@ -41,6 +42,8 @@ def create_index(bvals, n_rev=0):
     ----------
     bvals: np.array
         b-values
+    n_rev: int, optional
+        Number of reverse phase images to take into account
 
     Returns
     -------
@@ -53,6 +56,29 @@ def create_index(bvals, n_rev=0):
 
 
 def create_multi_topup_index(bvals, mean, n_rev, b0_thr=0):
+    """
+    Create index of bvals for Eddy in cases where Topup ran on more
+    than one b0 volume in both phase directions. The volumes must be
+    ordered such as all forward phase acquisition are followed by all
+    reverse phase ones (In the case of AP-PA, PA_1, PA_2, ..., PA_N,
+    AP_1, AP_2, ..., AP_N).
+
+    Parameters
+    ----------
+    bvals: np.array
+        b-values
+    mean: string
+        Mean strategy used to subset the b0 volumes
+        passed to topup (cluster or none)
+    n_rev: int, optional
+        Number of reverse phase images to take into account
+    b0_thr: int
+        All bvals under or equal to this threshold are considered as b0
+
+    Returns
+    -------
+    index: np.array
+    """
     index = np.zeros_like(bvals, dtype=int)
     cnt = 1
 

--- a/scripts/scil_prepare_eddy_command.py
+++ b/scripts/scil_prepare_eddy_command.py
@@ -119,7 +119,10 @@ def main():
         devnull = open(os.devnull)
         subprocess.call(args.eddy_cmd, stderr=devnull)
     except:
-        parser.error("Please download the {} command.".format(args.eddy_cmd))
+        logging.warning(
+            "{} not found. If executing locally, please install "
+            "the command from the FSL library and make sure it is "
+            "available in your path.".format(args.eddy_cmd))
 
     if args.verbose:
         logging.basicConfig(level=logging.INFO)

--- a/scripts/scil_prepare_eddy_command.py
+++ b/scripts/scil_prepare_eddy_command.py
@@ -34,14 +34,14 @@ def _build_arg_parser():
                    help='b-vectors file in FSL format')
 
     p.add_argument('in_mask',
-                   help='binary brain mask.')
+                   help='Binary brain mask.')
 
     p.add_argument('--n_reverse', type=int, default=0,
                    help='Number of reverse phase volumes included '
                         'in the DWI image [%(default)s].')
 
     p.add_argument('--topup',
-                   help='topup output name. ' +
+                   help='Topup output name. ' +
                         'If given, apply topup during eddy.\n' +
                         'Should be the same as --out_prefix from ' +
                         'scil_prepare_topup_command.py')
@@ -52,7 +52,7 @@ def _build_arg_parser():
 
     p.add_argument('--eddy_cmd', default='eddy_openmp',
                    choices=['eddy_openmp', 'eddy_cuda'],
-                   help='eddy command [%(default)s].')
+                   help='Eddy command [%(default)s].')
 
     p.add_argument('--b0_thr', type=float, default=20,
                    help='All b-values with values less than or equal ' +
@@ -61,36 +61,36 @@ def _build_arg_parser():
 
     p.add_argument('--encoding_direction', default='y',
                    choices=['x', 'y', 'z'],
-                   help='acquisition direction, default is AP-PA '
+                   help='Acquisition direction, default is AP-PA '
                         '[%(default)s].')
 
     p.add_argument('--readout', type=float, default=0.062,
-                   help='total readout time from the DICOM metadata '
+                   help='Total readout time from the DICOM metadata '
                         '[%(default)s].')
 
     p.add_argument('--slice_drop_correction', action='store_true',
-                   help="if set, will activate eddy's outlier correction,\n"
+                   help="If set, will activate eddy's outlier correction,\n"
                         "which includes slice drop correction.")
 
     p.add_argument('--lsr_resampling', action='store_true',
-                   help='perform least-square resampling, allowing eddy to '
+                   help='Perform least-square resampling, allowing eddy to '
                         'combine forward and reverse phase acquisitions for '
                         'better reconstruction. Only works if directions and '
                         'b-values are identical in both phase direction.')
 
     p.add_argument('--out_directory', default='.',
-                   help='output directory for eddy files [%(default)s].')
+                   help='Output directory for eddy files [%(default)s].')
 
     p.add_argument('--out_prefix', default='dwi_eddy_corrected',
-                   help='prefix of the eddy-corrected DWI [%(default)s].')
+                   help='Prefix of the eddy-corrected DWI [%(default)s].')
 
     p.add_argument('--out_script', action='store_true',
-                   help='if set, will output a .sh script (eddy.sh).\n' +
+                   help='If set, will output a .sh script (eddy.sh).\n' +
                         'else, will output the lines to the ' +
                         'terminal [%(default)s].')
 
     p.add_argument('--fix_seed', action='store_true',
-                   help='if set, will use the fixed seed strategy for eddy.\n'
+                   help='If set, will use the fixed seed strategy for eddy.\n'
                         'Enhances reproducibility.')
 
     p.add_argument('--eddy_options',  default='',
@@ -188,7 +188,7 @@ def main():
             forward_bb = bvals[:n_rev, None] * bvecs[:n_rev, :]
             reverse_bb = bvals[n_rev:, None] * bvecs[n_rev:, :]
             if np.allclose(forward_bb, reverse_bb):
-                additional_args += "--resamp lsr "
+                additional_args += "--resamp=lsr --fep=true "
             else:
                 logging.warning('Least-square resampling disabled since '
                                 'directions in both phase directions differ.')

--- a/scripts/scil_prepare_topup_command.py
+++ b/scripts/scil_prepare_topup_command.py
@@ -25,38 +25,38 @@ def _build_arg_parser():
                                 formatter_class=argparse.RawTextHelpFormatter)
 
     p.add_argument('in_forward_b0',
-                   help='input b0 Nifti image with forward phase encoding')
+                   help='Input b0 Nifti image with forward phase encoding.')
 
     p.add_argument('in_reverse_b0',
-                   help='input b0 Nifti image with reversed phase encoding.')
+                   help='Input b0 Nifti image with reversed phase encoding.')
 
     p.add_argument('--config', default='b02b0.cnf',
-                   help='topup config file [%(default)s].')
+                   help='Topup config file [%(default)s].')
 
     p.add_argument('--encoding_direction', default='y',
                    choices=['x', 'y', 'z'],
-                   help='acquisition direction of the forward b0 '
+                   help='Acquisition direction of the forward b0 '
                         'image, default is AP [%(default)s].')
 
     p.add_argument('--readout', type=float, default=0.062,
-                   help='total readout time from the DICOM metadata '
+                   help='Total readout time from the DICOM metadata '
                         '[%(default)s].')
 
     p.add_argument('--out_b0s', default='fused_b0s.nii.gz',
-                   help='output fused b0 file [%(default)s].')
+                   help='Output fused b0 file [%(default)s].')
 
     p.add_argument('--out_directory', default='.',
-                   help='output directory for topup files [%(default)s].')
+                   help='Output directory for topup files [%(default)s].')
 
     p.add_argument('--out_prefix', default='topup_results',
-                   help='prefix of the topup results [%(default)s].')
+                   help='Prefix of the topup results [%(default)s].')
 
     p.add_argument('--out_params', default='acqparams.txt',
-                   help='filename for the acquisition '
+                   help='Filename for the acquisition '
                         'parameters file [%(default)s].')
 
     p.add_argument('--out_script', action='store_true',
-                   help='if set, will output a .sh script (topup.sh).\n' +
+                   help='If set, will output a .sh script (topup.sh).\n' +
                         'else, will output the lines to the ' +
                         'terminal [%(default)s].')
 

--- a/scripts/scil_prepare_topup_command.py
+++ b/scripts/scil_prepare_topup_command.py
@@ -9,6 +9,7 @@ The reversed b0 must be in a different file.
 import argparse
 import logging
 import os
+import subprocess
 
 from dipy.core.gradients import gradient_table
 from dipy.io.gradients import read_bvals_bvecs
@@ -74,6 +75,15 @@ def _build_arg_parser():
 def main():
     parser = _build_arg_parser()
     args = parser.parse_args()
+
+    try:
+        devnull = open(os.devnull)
+        subprocess.call("topup", stderr=devnull)
+    except:
+        logging.warning(
+            "topup not found. If executing locally, please install "
+            "the command from the FSL library and make sure it is "
+            "available in your path.")
 
     if args.verbose:
         logging.basicConfig(level=logging.INFO)

--- a/scripts/scil_prepare_topup_command.py
+++ b/scripts/scil_prepare_topup_command.py
@@ -24,30 +24,19 @@ def _build_arg_parser():
     p = argparse.ArgumentParser(description=__doc__,
                                 formatter_class=argparse.RawTextHelpFormatter)
 
-    p.add_argument('in_dwi',
-                   help='input DWI Nifti image')
-
-    p.add_argument('in_bvals',
-                   help='b-values file in FSL format')
-
-    p.add_argument('in_bvecs',
-                   help='b-vectors file in FSL format')
+    p.add_argument('in_forward_b0',
+                   help='input b0 Nifti image with forward phase encoding')
 
     p.add_argument('in_reverse_b0',
-                   help='b0 image with reversed phase encoding.')
+                   help='input b0 Nifti image with reversed phase encoding.')
 
     p.add_argument('--config', default='b02b0.cnf',
                    help='topup config file [%(default)s].')
 
-    p.add_argument('--b0_thr', type=float, default=20,
-                   help='All b-values with values less than or equal ' +
-                        'to b0_thr are considered as b0s i.e. without ' +
-                        'diffusion weighting')
-
     p.add_argument('--encoding_direction', default='y',
                    choices=['x', 'y', 'z'],
-                   help='acquisition direction, default is AP-PA '
-                        '[%(default)s].')
+                   help='acquisition direction of the forward b0 '
+                        'image, default is AP [%(default)s].')
 
     p.add_argument('--readout', type=float, default=0.062,
                    help='total readout time from the DICOM metadata '
@@ -61,6 +50,10 @@ def _build_arg_parser():
 
     p.add_argument('--out_prefix', default='topup_results',
                    help='prefix of the topup results [%(default)s].')
+
+    p.add_argument('--out_params', default='acqparams.txt',
+                   help='filename for the acquisition '
+                        'parameters file [%(default)s].')
 
     p.add_argument('--out_script', action='store_true',
                    help='if set, will output a .sh script (topup.sh).\n' +
@@ -85,8 +78,7 @@ def main():
     if args.verbose:
         logging.basicConfig(level=logging.INFO)
 
-    required_args = [args.in_dwi, args.in_bvals, args.in_bvecs,
-                     args.in_reverse_b0]
+    required_args = [args.in_forward_b0, args.in_reverse_b0]
 
     assert_inputs_exist(parser, required_args)
     assert_outputs_exist(parser, args, [], args.out_b0s)
@@ -95,52 +87,37 @@ def main():
     if os.path.splitext(args.out_prefix)[1] != '':
         parser.error('The prefix must not contain any extension.')
 
-    bvals, bvecs = read_bvals_bvecs(args.in_bvals, args.in_bvecs)
-    bvals_min = bvals.min()
+    b0_img = nib.load(args.in_forward_b0)
+    b0 = b0_img.get_fdata(dtype=np.float32)
 
-    # TODO refactor this
-    b0_threshold = args.b0_thr
-    if bvals_min < 0 or bvals_min > b0_threshold:
-        raise ValueError('The minimal b-value is lesser than 0 or greater '
-                         'than {0}. This is highly suspicious. Please check '
-                         'your data to ensure everything is correct. '
-                         'Value found: {1}'.format(b0_threshold, bvals_min))
+    if len(b0.shape) == 4 and b0.shape[3] > 1:
+        logging.warning("B0 is 4D. To speed up Topup, we recommend "
+                        "using only one b0 in both phase encoding "
+                        "direction, unless necessary.")
+    elif len(b0.shape) == 3:
+        b0 = b0[..., None]
 
     rev_b0_img = nib.load(args.in_reverse_b0)
     rev_b0 = rev_b0_img.get_fdata(dtype=np.float32)
 
-    if len(rev_b0.shape) == 4:
-        logging.warning("Reverse B0 is 4D. To speed up Topup, the mean of all "
-                        "reverse B0 will be taken.")
-        rev_b0 = np.mean(rev_b0, axis=3)
+    if len(rev_b0.shape) == 4 and rev_b0.shape[3] > 1:
+        logging.warning("Reverse B0 is 4D. To speed up Topup, we "
+                        "recommend using only one b0 in both phase "
+                        "encoding direction, unless necessary.")
+    elif len(rev_b0.shape) == 3:
+        rev_b0 = rev_b0[..., None]
 
-    gtab = gradient_table(bvals, bvecs, b0_threshold=b0_threshold)
-
-    dwi_image = nib.load(args.in_dwi)
-    dwi = dwi_image.get_fdata(dtype=np.float32)
-    b0 = dwi[..., gtab.b0s_mask]
-
-    if b0.shape[3] > 1:
-        logging.warning("More than one B0 was found. To speed up Topup, "
-                        "the mean of all B0 will be taken.")
-        b0 = np.mean(b0, axis=3)
-    else:
-        b0 = np.squeeze(b0, axis=3)
-
-    fused_b0s = np.zeros(b0.shape+(2,))
-    fused_b0s[..., 0] = b0
-    fused_b0s[..., 1] = rev_b0
+    fused_b0s = np.concatenate((b0, rev_b0), axis=-1)
     fused_b0s_path = os.path.join(args.out_directory, args.out_b0s)
-    nib.save(nib.Nifti1Image(fused_b0s,
-                             rev_b0_img.affine),
-             fused_b0s_path)
+    nib.save(nib.Nifti1Image(fused_b0s, b0_img.affine), fused_b0s_path)
 
-    acqparams = create_acqparams(args.readout, args.encoding_direction)
+    acqparams = create_acqparams(
+        args.readout, args.encoding_direction, b0.shape[-1], rev_b0.shape[-1])
 
     if not os.path.exists(args.out_directory):
         os.makedirs(args.out_directory)
 
-    acqparams_path = os.path.join(args.out_directory, 'acqparams.txt')
+    acqparams_path = os.path.join(args.out_directory, args.out_params)
     np.savetxt(acqparams_path, acqparams, fmt='%1.4f', delimiter=' ')
 
     output_path = os.path.join(args.out_directory, args.out_prefix)


### PR DESCRIPTION
Modifications to prepare_topup :
- Handles b0 images composed of multiple forward and reverse phase acquired volumes
- Added parameter to change the name of the acquisition parameters file outputed
- IMPORTANT : the script does not accept a DWI as input for the forward acquired image, only a b0 volume. Users must handle the extraction of the b0s using scil_extract_b0

Modifications to prepare_eddy :
- Added logic to handle the different sizes of b0 images that Topup ran on
- Added parameters to input the number of reverse phase volumes present in the input DWI image
- Added parameter that takes a acquisition parameters file as an input, required to know the number of b0 volumes to take into account when creating the index file
-  Added parameter to get least-square resampling outputs when executing Eddy, as well as checks on the b-values and b-vectors to ensure such resampling is possible