### PR TITLE
fix_dsi_studio_trk

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,4 +33,4 @@ bctpy==0.5.*
 statsmodels==0.11.*
 dmri-commit==1.4.*
 openpyxl==2.6.*
-cvxpy==1.0.*
+cvxpy==1.1.*

--- a/scilpy/utils/transformation.py
+++ b/scilpy/utils/transformation.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+
+from dipy.io.stateful_tractogram import StatefulTractogram
+import numpy as np
+
+def get_axis_flip_vector(flip_axes):
+    flip_vector = np.ones(3)
+    if 'x' in flip_axes:
+        flip_vector[0] = -1.0
+    if 'y' in flip_axes:
+        flip_vector[1] = -1.0
+    if 'z' in flip_axes:
+        flip_vector[2] = -1.0
+
+    return flip_vector
+
+
+def get_shift_vector(sft):
+    dims = sft.space_attributes[1]
+    shift_vector = -1.0 * (np.array(dims) / 2.0)
+
+    return shift_vector
+
+
+def flip_sft(sft, flip_axes):
+    flip_vector = get_axis_flip_vector(flip_axes)
+    shift_vector = get_shift_vector(sft)
+
+    flipped_streamlines = []
+
+    streamlines = sft.streamlines
+
+    for streamline in streamlines:
+        mod_streamline = streamline + shift_vector
+        mod_streamline *= flip_vector
+        mod_streamline -= shift_vector
+        flipped_streamlines.append(mod_streamline)
+
+    new_sft = StatefulTractogram.from_sft(flipped_streamlines, sft,
+                                          data_per_point=sft.data_per_point,
+                                          data_per_streamline=sft.data_per_streamline)
+    return new_sft

--- a/scilpy/utils/transformation.py
+++ b/scilpy/utils/transformation.py
@@ -3,6 +3,7 @@
 from dipy.io.stateful_tractogram import StatefulTractogram
 import numpy as np
 
+
 def get_axis_flip_vector(flip_axes):
     flip_vector = np.ones(3)
     if 'x' in flip_axes:

--- a/scripts/scil_fix_dsi_studio_trk.py
+++ b/scripts/scil_fix_dsi_studio_trk.py
@@ -23,6 +23,9 @@ removing entire streamlines.
 This script was tested on various datasets and worked on all of them. However,
 always verify the results and if a specific case does not work. Open an issue
 on the Scilpy GitHub repository.
+
+WARNING: This script is still experimental, DSI-Studio evolves quickly and
+results may vary depending on the data itself as well as DSI-studio version.
 """
 
 import argparse

--- a/scripts/scil_fix_dsi_studio_trk.py
+++ b/scripts/scil_fix_dsi_studio_trk.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+
+"""
+
+import argparse
+
+from dipy.align.imaffine import (transform_centers_of_mass,
+                                 AffineMap,
+                                 MutualInformationMetric,
+                                 AffineRegistration)
+from dipy.align.transforms import (TranslationTransform3D,
+                                   RigidTransform3D,
+                                   AffineTransform3D)
+from dipy.io.stateful_tractogram import StatefulTractogram, Space, Origin
+from dipy.io.utils import get_reference_info
+from dipy.io.streamline import save_tractogram, load_tractogram
+from dipy.reconst.utils import _roi_in_volume, _mask_from_roi
+import nibabel as nib
+import numpy as np
+
+from scilpy.io.utils import (add_reference_arg,
+                             add_overwrite_arg,
+                             assert_inputs_exist,
+                             assert_outputs_exist)
+from scilpy.utils.streamlines import (transform_warp_streamlines,
+                                      cut_invalid_streamlines)
+from scilpy.utils.transformation import (get_axis_flip_vector,
+                                         get_shift_vector,
+                                         flip_sft)
+
+
+def _build_arg_parser():
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+
+    p.add_argument('in_dsi_tractogram',
+                   help='Path of the input tractogram file from DSI studio (.trk).')
+    p.add_argument('in_dsi_fa',
+                   help='Path of the input FA from DSI Studio (.nii.gz).')
+    p.add_argument('out_tractogram',
+                   help='Path of the output tractogram file.')
+    p.add_argument('--in_native_fa',
+                   help='Path of the input FA from Dipy/MRtrix (.nii.gz).\n'
+                        'Move the tractogram back to a "proper" space, include'
+                        'registration.')
+    p.add_argument('--auto_crop', action='store_true',
+                   help='If both FA are not already BET, perform registration \n'
+                        'using a centered-cube crop to ignore the skull.\n'
+                        'A good BET for both is more robust.')
+    transfo = p.add_mutually_exclusive_group()
+    transfo.add_argument('--save_transfo', metavar='FILE',
+                         help='Save estimated transformation to avoid '
+                              'recomputing (.txt).')
+    transfo.add_argument('--load_transfo', metavar='FILE',
+                         help='Load estimated transformation to apply to other '
+                              'files (.txt).')
+    invalid = p.add_mutually_exclusive_group()
+    invalid.add_argument('--cut_invalid', action='store_true',
+                         help='Cut invalid streamlines rather than removing '
+                              'them.\nKeep the longest segment only.')
+    invalid.add_argument('--remove_invalid', action='store_true',
+                         help='Remove the streamlines landing out of the '
+                              'bounding box.')
+    invalid.add_argument('--keep_invalid', action='store_true',
+                         help='Keep the streamlines landing out of the '
+                              'bounding box.')
+    add_overwrite_arg(p)
+
+    return p
+
+def get_axis_shift_vector(flip_axes):
+    shift_vector = np.zeros(3)
+    if 'x' in flip_axes:
+        shift_vector[0] = -1.0
+    if 'y' in flip_axes:
+        shift_vector[1] = -1.0
+    if 'z' in flip_axes:
+        shift_vector[2] = -1.0
+
+    return shift_vector
+
+
+def cube_crop_data(data):
+    shape = np.array(data.shape[:3])
+    roi_center = shape // 2
+    roi_radii = _roi_in_volume(shape, roi_center, shape // 3)
+    roi_mask = _mask_from_roi(shape, roi_center, roi_radii)
+
+    return data * roi_mask
+
+
+def main():
+    parser = _build_arg_parser()
+    args = parser.parse_args()
+    if args.load_transfo and args.in_native_fa is None:
+        parser.error('When loading a transformation, the final reference is '
+                     'needed, use --in_native_fa.')
+    assert_inputs_exist(parser, [args.in_dsi_tractogram, args.in_dsi_fa],
+                        optional=args.in_native_fa)
+    assert_outputs_exist(parser, args, args.out_tractogram)
+
+    sft = load_tractogram(args.in_dsi_tractogram, 'same',
+                          bbox_valid_check=False)
+
+    # LPS -> RAS convention in voxel space
+    sft.to_vox()
+    flip_axis = ['x', 'y']
+    sft.streamlines._data -= get_axis_shift_vector(flip_axis)
+    sft_fix = StatefulTractogram(sft.streamlines, args.in_dsi_fa,
+                                 Space.VOX)
+    sft_flip = flip_sft(sft_fix, flip_axis)
+
+    if not args.in_native_fa:
+        if args.cut_invalid:
+            sft_flip, _ = cut_invalid_streamlines(sft_flip)
+        elif args.remove_invalid:
+            sft_flip.remove_invalid_streamlines()
+        save_tractogram(sft_flip, args.out_tractogram,
+                        bbox_valid_check=not args.keep_invalid)
+    else:
+        static_img = nib.load(args.in_native_fa)
+        static_data = static_img.get_fdata()
+        moving_img = nib.load(args.in_dsi_fa)
+        moving_data = moving_img.get_fdata()
+        
+        # DSI-Studio flips the volume without changing the affine (I think)
+        # So this has to be reversed (not the same problem as above)
+        vox_order = get_reference_info(moving_img)[3]
+        flip_axis = []
+        if vox_order[0] == 'L':
+            moving_data = moving_data[::-1, :, :]
+            flip_axis.append('x')
+        if vox_order[1] == 'P':
+            moving_data = moving_data[:, ::-1, :]
+            flip_axis.append('y')
+        if vox_order[2] == 'I':
+            moving_data = moving_data[:, :, ::-1]
+            flip_axis.append('z')
+        sft_flip_back = flip_sft(sft_flip, flip_axis)
+
+        if args.load_transfo:
+            transfo = np.loadtxt(args.load_transfo)
+        else:
+            # Sometimes DSI studio has quite a lot of skull left
+            # Dipy Median Otsu does not work with FA/GFA
+            if args.auto_crop:
+                moving_data = cube_crop_data(moving_data)
+                static_data = cube_crop_data(static_data)
+
+            # Since DSI Studio register to AC/PC and does not save the transformation
+            # We must estimate the transformation, since its rigid it is 'easy'
+            c_of_mass = transform_centers_of_mass(static_data, static_img.affine,
+                                                  moving_data, moving_img.affine)
+
+            nbins = 32
+            sampling_prop = None
+            level_iters = [1000, 100, 10]
+            sigmas = [3.0, 2.0, 1.0]
+            factors = [3, 2, 1]
+            metric = MutualInformationMetric(nbins, sampling_prop)
+            affreg = AffineRegistration(metric=metric, level_iters=level_iters,
+                                        sigmas=sigmas, factors=factors)
+            transform = RigidTransform3D()
+            nib.save(nib.Nifti1Image(
+                static_data, static_img.affine), 'lol1.nii.gz')
+            rigid = affreg.optimize(static_data, moving_data, transform, None,
+                                    static_img.affine, moving_img.affine,
+                                    starting_affine=c_of_mass.affine)
+            transfo = rigid.affine
+            transformed = rigid.transform(moving_data)
+            nib.save(nib.Nifti1Image(
+                transformed, static_img.affine), 'lol.nii.gz')
+
+            if args.save_transfo:
+                np.savetxt(args.save_transfo, transfo)
+
+        new_sft = transform_warp_streamlines(sft_flip_back, transfo,
+                                             static_img, inverse=True,
+                                             remove_invalid=args.remove_invalid,
+                                             cut_invalid=args.cut_invalid)
+
+        if args.cut_invalid:
+            new_sft, _ = cut_invalid_streamlines(new_sft)
+        elif args.remove_invalid:
+            new_sft.remove_invalid_streamlines()
+        save_tractogram(new_sft, args.out_tractogram,
+                        bbox_valid_check=not args.keep_invalid)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/scil_flip_streamlines.py
+++ b/scripts/scil_flip_streamlines.py
@@ -20,6 +20,7 @@ from scilpy.io.utils import (add_reference_arg,
                              add_overwrite_arg,
                              assert_inputs_exist,
                              assert_outputs_exist)
+from scilpy.utils.transformation import flip_sft
 
 
 def _build_arg_parser():
@@ -39,45 +40,6 @@ def _build_arg_parser():
     add_reference_arg(p)
     add_overwrite_arg(p)
     return p
-
-
-def get_axis_flip_vector(flip_axes):
-    flip_vector = np.ones(3)
-    if 'x' in flip_axes:
-        flip_vector[0] = -1.0
-    if 'y' in flip_axes:
-        flip_vector[1] = -1.0
-    if 'z' in flip_axes:
-        flip_vector[2] = -1.0
-
-    return flip_vector
-
-
-def get_shift_vector(sft):
-    dims = sft.space_attributes[1]
-    shift_vector = -1.0 * (np.array(dims) / 2.0)
-
-    return shift_vector
-
-
-def flip_sft(sft, flip_axes):
-    flip_vector = get_axis_flip_vector(flip_axes)
-    shift_vector = get_shift_vector(sft)
-
-    flipped_streamlines = []
-
-    streamlines = sft.streamlines
-
-    for streamline in streamlines:
-        mod_streamline = streamline + shift_vector
-        mod_streamline *= flip_vector
-        mod_streamline -= shift_vector
-        flipped_streamlines.append(mod_streamline)
-
-    new_sft = StatefulTractogram.from_sft(flipped_streamlines, sft,
-                                          data_per_point=sft.data_per_point,
-                                          data_per_streamline=sft.data_per_streamline)
-    return new_sft
 
 
 def main():

--- a/scripts/tests/test_fix_dsi_studio_trk.py
+++ b/scripts/tests/test_fix_dsi_studio_trk.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import os
+import tempfile
+
+from scilpy.io.fetcher import fetch_data, get_home, get_testing_files_dict
+
+# If they already exist, this only takes 5 seconds (check md5sum)
+fetch_data(get_testing_files_dict(), keys=['tracking.zip'])
+tmp_dir = tempfile.TemporaryDirectory()
+
+
+def test_help_option(script_runner):
+    ret = script_runner.run('scil_fix_dsi_studio_trk.py', '--help')
+    assert ret.success
+

--- a/scripts/tests/test_fix_dsi_studio_trk.py
+++ b/scripts/tests/test_fix_dsi_studio_trk.py
@@ -6,10 +6,6 @@ import tempfile
 
 from scilpy.io.fetcher import fetch_data, get_home, get_testing_files_dict
 
-# If they already exist, this only takes 5 seconds (check md5sum)
-fetch_data(get_testing_files_dict(), keys=['tracking.zip'])
-tmp_dir = tempfile.TemporaryDirectory()
-
 
 def test_help_option(script_runner):
     ret = script_runner.run('scil_fix_dsi_studio_trk.py', '--help')


### PR DESCRIPTION
After some time I gathered enough DSI-Studio corner case data to find exactly how to fix them.

Its working perfectly on 1 datasets from Leon C., 1 from Kurt S., HCP, old surgery case from Sherbrooke and the TractEM (BLSA) data
There is at least 2 thing wrong with the TRK header, 2 thing wrong with the TRK data, 1 thing wrong with the NIFTI and the NIFTI is moved to AC-PC.
That 4 things to fix to get it aligned with itself in MI-Brain and 2 more step to get to "native space'' (including rigid registration).

I can't garantee its perfect, but I think its close to it. If the data does not have too much skull and voxels smaller than 2mm iso, its pretty robust.

In summary:

1. Read the tractogram with nibabel API
2. Shift the origin by 1 voxel in X and Y
3. Flip tractogram in X/Y around its center
4. Multiply this by the affine of the DSI nifti, now this is a valid RASMM trk that you can save and it will be lined up with the DSI nifti.

If you want it on top of the original

1. If the native was already LPS, fine. If not, re-flip the TRK & the NIFTI itself around its center for each axis not being L/P/S
2. If the data has a lot of skull, crop a medium cube of from the center and register it (rigid) to the native image
3. Apply transfo to tractogram, cut invalid streamlines and save