### PR TITLE
FIX: Fix GT bundle reference in scoring

### DIFF
--- a/scripts/scil_score_tractogram.py
+++ b/scripts/scil_score_tractogram.py
@@ -150,7 +150,13 @@ def main():
 
     logging.info("Verifying compatibility with ground-truth")
     for gt in args.gt_bundles:
-        compatible = is_header_compatible(sft, gt)
+        _, gt_ext = os.path.splitext(gt)
+        if gt_ext in ['.trk', '.tck']:
+            gt_bundle = load_tractogram_with_reference(
+                parser, args, gt, bbox_check=False)
+        else:
+            gt_bundle = gt
+        compatible = is_header_compatible(sft, gt_bundle)
         if not compatible:
             parser.error("Input tractogram incompatible with"
                          " {}".format(gt))


### PR DESCRIPTION
Fix bug if GT bundles are `.tck`. Same reference is used for both the bundle to be scored and the GT bundles as they should be in the same space anyways (else scoring won't work).

PR test data: 

```
scil_score_tractogram.py prob_5_seeds.tck \
~/braindata/databases/fibercup/simulated/MICCAI2015/tracking/FiberCupGroundTruth_filtered_bundle_* \
--gt_heads ~/braindata/databases/fibercup/simulated/MICCAI2015/scoring_data/masks/rois/FiberCupGroundTruth_filtered_bundle_*_head.nii.gz \
--gt_tails ~/braindata/databases/fibercup/simulated/MICCAI2015/scoring_data/masks/rois/FiberCupGroundTruth_filtered_bundle_*_tail.nii.gz \
--dilate_endpoints 1 \
--reference ~/braindata/databases/fibercup/simulated/MICCAI2015/scoring_data/masks/wm.nii.gz -f 
```

Fixes #460 

@arnaudbore @GuillaumeTh 