### PR TITLE
FIX: TODI chunk-size bug + reference arg

### DIFF
--- a/scilpy/tractanalysis/todi.py
+++ b/scilpy/tractanalysis/todi.py
@@ -200,7 +200,8 @@ class TrackOrientationDensityImaging(object):
                 new_todi = deepcopy(tmp_todi)
             else:
                 new_todi = np.hstack((new_todi, tmp_todi))
-            self.todi = np.delete(self.todi, range(0, chunk_size), axis=1)
+            self.todi = np.delete(self.todi, range(
+                0, min(self.todi.shape[1], chunk_size)), axis=1)
             chunk_count -= 1
 
         self.mask = new_mask


### PR DESCRIPTION
Fix a bug where the TODI computation might crash. Also add `--reference` arg in `scil_generate_prior_from_bundle`

Behavior before:
![image](https://user-images.githubusercontent.com/10272382/121043339-84a4c980-c782-11eb-964f-90f1ece3d14b.png)

How to test:
```bash
$ scil_generate_priors_from_bundle.py low.tck mid.nii.gz mid_wm.nii.gz -f
```

Test data: https://drive.google.com/drive/folders/1P4TsS-ESvhbIIf_U_Y-_WAchEmlTfNwz?usp=sharing

@arnaudbore @GuillaumeTh 