### PR TITLE
Update numpy version for CVXPY

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ kiwisolver==1.0.*
 matplotlib==2.2.*
 nibabel==3.0.*
 nilearn==0.6.*
-numpy==1.18.*
+numpy==1.20.*
 Pillow==7.1.*
 bids-validator==1.6.0
 pybids==0.10.*


### PR DESCRIPTION
- Fixes error : `ModuleNotFoundError: No module named 'cvxpy.cvxcore.python._cvxcore'
During handling of the above exception, another exception occurred:
RuntimeError: module compiled against API version 0xe but this version of numpy is 0xd`