### PR TITLE
[WIP] Add an option for excluding background in scil_execute_asymmetric_filtering

### DIFF
--- a/scilpy/denoise/asym_enhancement.py
+++ b/scilpy/denoise/asym_enhancement.py
@@ -9,7 +9,8 @@ from scipy.ndimage import correlate
 
 def local_asym_gaussian_filtering(in_sh, sh_order=8, sh_basis='descoteaux07',
                                   out_full_basis=True, dot_sharpness=1.0,
-                                  sphere_str='repulsion724', sigma=1.0):
+                                  sphere_str='repulsion724', sigma=1.0,
+                                  edge_mode='same'):
     """Average the SH projected on a sphere using a first-neighbor gaussian
     blur and a dot product weight between sphere directions and the direction
     to neighborhood voxels, forcing to 0 negative values and thus performing
@@ -32,6 +33,12 @@ def local_asym_gaussian_filtering(in_sh, sh_order=8, sh_basis='descoteaux07',
         Name of the sphere used to project SH coefficients to SF.
     sigma: float, optional
         Sigma for the Gaussian.
+    edge_mode: str, optional
+        How to manage edges (i.e. voxels bordering the background).
+        Available options are:
+            'same': Behave the same way near edges and anywhere else.
+            'wall': Discard empty voxels from average. Filter is updated
+                         and normalized for each voxel.
 
     Returns
     -------
@@ -48,8 +55,8 @@ def local_asym_gaussian_filtering(in_sh, sh_order=8, sh_basis='descoteaux07',
     # and the number of coefficients of the SH
     in_full_basis = in_sh.shape[-1] == (sh_order + 1)**2
 
-    nb_sf = len(sphere.vertices)
-    mean_sf = np.zeros(np.append(in_sh.shape[:-1], nb_sf))
+    nb_dir = len(sphere.vertices)
+    mean_sf = np.zeros(np.append(in_sh.shape[:-1], nb_dir))
     B = sh_to_sf_matrix(sphere, sh_order=sh_order, basis_type=sh_basis,
                         return_inv=False, full_basis=in_full_basis)
 
@@ -59,18 +66,29 @@ def local_asym_gaussian_filtering(in_sh, sh_order=8, sh_basis='descoteaux07',
                             basis_type=sh_basis, return_inv=False,
                             full_basis=in_full_basis)
 
+    # Based on edge_mode generate a mask to separate background and foreground
+    if edge_mode == 'wall':
+        mask = in_sh[..., 0] > 0.
+
     # Apply filter to each sphere vertice
-    for sf_i in range(nb_sf):
-        w_filter = weights[..., sf_i]
+    for dir_i in range(nb_dir):
+        w_filter = weights[..., dir_i]
+        curr_dir_eval = np.dot(in_sh, B[:, dir_i])
+        opposite_dir_eval = np.dot(in_sh, neg_B[:, dir_i])
+        if edge_mode == 'same':
+            # Calculate contribution of center voxel
+            mean_sf[..., dir_i] = w_filter[1, 1, 1] * curr_dir_eval
 
-        # Calculate contribution of center voxel
-        current_sf = np.dot(in_sh, B[:, sf_i])
-        mean_sf[..., sf_i] = w_filter[1, 1, 1] * current_sf
-
-        # Add contributions of neighbors using opposite hemispheres
-        current_sf = np.dot(in_sh, neg_B[:, sf_i])
-        w_filter[1, 1, 1] = 0.0
-        mean_sf[..., sf_i] += correlate(current_sf, w_filter, mode="constant")
+            # Add contributions of neighbors using opposite hemispheres
+            w_filter[1, 1, 1] = 0.0
+            mean_sf[..., dir_i] += correlate(opposite_dir_eval, w_filter,
+                                             mode='constant')
+        elif edge_mode == 'wall':
+            mean_sf[..., dir_i] = _apply_naive_correlation(curr_dir_eval,
+                                                           opposite_dir_eval,
+                                                           w_filter, mask)
+        else:
+            raise ValueError('Invalid edge_mode: {0}'.format(edge_mode))
 
     # Convert back to SH coefficients
     _, B_inv = sh_to_sf_matrix(sphere, sh_order=sh_order, basis_type=sh_basis,
@@ -124,3 +142,26 @@ def _get_weights(sphere, dot_sharpness, sigma):
     weights /= weights.reshape((-1, weights.shape[-1])).sum(axis=0)
 
     return weights
+
+
+def _apply_naive_correlation(curr_dir, opposite_dir, w_filter, mask):
+    shape = curr_dir.shape
+    out = np.zeros_like(curr_dir)
+    curr_dir = np.pad(curr_dir, ((1, 1), (1, 1), (1, 1)))
+    opposite_dir = np.pad(opposite_dir, ((1, 1), (1, 1), (1, 1)))
+    mask = np.pad(mask, ((1, 1), (1, 1), (1, 1)))
+    for ii in range(shape[0]):
+        for jj in range(shape[1]):
+            for kk in range(shape[2]):
+                win_arr = opposite_dir[ii:ii+3, jj:jj+3, kk:kk+3]
+                win_arr[1, 1, 1] = curr_dir[ii+1, jj+1, kk+1]
+                win_mask = mask[ii:ii+3, jj:jj+3, kk:kk+3]
+
+                curr_w = w_filter * win_mask
+                if curr_w.any():
+                    curr_w /= curr_w.sum()  # such that curr_w sums to 1
+
+                if win_mask[1, 1, 1] > 0.:  # only update non-zero fODF
+                    out[ii, jj, kk] = \
+                        (win_arr.flatten() * curr_w.flatten()).sum()
+    return out

--- a/scripts/scil_execute_asymmetric_filtering.py
+++ b/scripts/scil_execute_asymmetric_filtering.py
@@ -77,6 +77,15 @@ def _build_arg_parser():
     p.add_argument('--out_sym', action='store_true',
                    help='If set, saves output in symmetric SH basis.')
 
+    p.add_argument('--edge_mode', default='same',
+                   choices=['same', 'wall'],
+                   help='Specify how edges are processed.\n'
+                        '    \'same\': Edges are processed in the same way as'
+                        ' the rest of the image;\n'
+                        '    \'wall\': Background voxels are discarded from '
+                        'the average. The filter is updated and normalized for'
+                        ' each voxel. [%(default)s]')
+
     add_verbose_arg(p)
     add_overwrite_arg(p)
 
@@ -126,7 +135,8 @@ def main():
         out_full_basis=not(args.out_sym),
         sphere_str=args.sphere,
         dot_sharpness=args.sharpness,
-        sigma=args.sigma)
+        sigma=args.sigma,
+        edge_mode=args.edge_mode)
 
     logging.info('Saving filtered SH to file {0}.'.format(args.out_sh))
     nib.save(nib.Nifti1Image(filtered_sh, sh_img.affine), args.out_sh)


### PR DESCRIPTION
Update to `scil_execute_asymmetric_filtering.py`.
Add argument `--edge_mode` to specify how edges should be dealt with.

Choices are:
`same`: Do nothing special, average foreground with background when near edges (default behaviour);
`wall`: Only average sphere directions in non-zero voxels. A mask is computed by thresholding the input SH image and it is used during filtering to update the filter at each processed voxel. The filter is normalized for the remaining non zero filter weights.

@AntoineTheb @Florence-G
