### PR TITLE
[BF] scil_compute_todi output misaligned with tractogram

### DIFF
--- a/scripts/scil_compute_todi.py
+++ b/scripts/scil_compute_todi.py
@@ -99,7 +99,13 @@ def main():
 
     sft = load_tractogram_with_reference(parser, args, args.in_tractogram)
     affine, data_shape, _, _ = sft.space_attributes
+
     sft.to_vox()
+    # Because compute_todi expects streamline points (in voxel coordinates)
+    # to be in the range (0..size) rather than (-0.5..size - 0.5), we shift
+    # the voxel origin to corner (will only be done if it's not already the
+    # case).
+    sft.to_corner()
 
     logging.info('Computing length-weighted TODI ...')
     todi_obj = TrackOrientationDensityImaging(tuple(data_shape), args.sphere)


### PR DESCRIPTION
Hi!
I was playing with scil_compute_todi on a Fibercup phantom with big voxels (6 mm) and noticed what appears to be an offset between the tractogram and the TODI output. This is shown in the screenshot from MI-Brain below.

![center](https://user-images.githubusercontent.com/41654474/126341050-e7bd8e0c-f822-4f8a-8364-9b41401c17ad.png)

Because `compute_todi` expects the voxel origin to be in the corner rather than at the center of the voxel, calling `stateful_tractogram.to_corner()` in `scil_compute_todi.py` results in the following.

![corner](https://user-images.githubusercontent.com/41654474/126342008-0afda576-dd49-4377-bf00-a2ccf740bafb.png)

Is this a good enough fix or am I missing something?
Thanks!