### PR TITLE
Support empty bundle in tractometry

### DIFF
--- a/scilpy/utils/streamlines.py
+++ b/scilpy/utils/streamlines.py
@@ -610,7 +610,8 @@ def cut_invalid_streamlines(sft):
     cutting_counter : int
         Number of streamlines that were cut.
     """
-
+    if not len(sft):
+        return sft, 0
     sft.to_vox()
     sft.to_corner()
 

--- a/scripts/scil_compute_bundle_voxel_label_map.py
+++ b/scripts/scil_compute_bundle_voxel_label_map.py
@@ -112,7 +112,7 @@ def main():
     if not len(sft_bundle.streamlines):
         logging.error('Empty bundle file {}. '
                       'Skipping'.format(args.in_bundle))
-        raise ValueError
+        return
 
     if len(sft_centroid.streamlines) < 1 \
             or len(sft_centroid.streamlines) > 1:


### PR DESCRIPTION
RBx-Flow does not output empty bundle, so it works well with Tractometry-Flow
However, bundles from other sources could be empty.

These minimal changes allow the pipeline to execute the same way if a bundle is just not there or if it is there, but empty.