### PR TITLE
Add inverse operation flag

### DIFF
--- a/scripts/scil_apply_transform_to_hdf5.py
+++ b/scripts/scil_apply_transform_to_hdf5.py
@@ -94,7 +94,7 @@ def main():
             deformation_data = None
             if args.in_deformation is not None:
                 deformation_data = np.squeeze(nib.load(
-                    args.in_deformation).get_fdata(dtype=np.float32))
+                    args.in_deformation).get_fdata(dtype=float))
             target_img = nib.load(args.in_target_file)
 
             for key in in_hdf5_file.keys():
@@ -135,7 +135,7 @@ def main():
 
                 group = out_hdf5_file[key]
                 group.create_dataset('data',
-                                     data=new_sft.streamlines._data.astype(np.float32))
+                                     data=new_sft.streamlines._data.astype(float))
                 group.create_dataset('offsets',
                                      data=new_sft.streamlines._offsets)
                 group.create_dataset('lengths',

--- a/scripts/scil_fix_dsi_studio_trk.py
+++ b/scripts/scil_fix_dsi_studio_trk.py
@@ -44,7 +44,7 @@ import numpy as np
 from scilpy.io.utils import (add_overwrite_arg,
                              assert_inputs_exist,
                              assert_outputs_exist)
-from scilpy.utils.streamlines import (transform_warp_streamlines,
+from scilpy.utils.streamlines import (transform_warp_sft,
                                       cut_invalid_streamlines)
 from scilpy.utils.transformation import flip_sft
 
@@ -191,10 +191,10 @@ def main():
             if args.save_transfo:
                 np.savetxt(args.save_transfo, transfo)
 
-        new_sft = transform_warp_streamlines(sft_flip_back, transfo,
-                                             static_img, inverse=True,
-                                             remove_invalid=args.remove_invalid,
-                                             cut_invalid=args.cut_invalid)
+        new_sft = transform_warp_sft(sft_flip_back, transfo,
+                                     static_img, inverse=True,
+                                     remove_invalid=args.remove_invalid,
+                                     cut_invalid=args.cut_invalid)
 
         if args.cut_invalid:
             new_sft, _ = cut_invalid_streamlines(new_sft)


### PR DESCRIPTION
Following an issue raised by @StongeEtienne (Sorry I forgot about it), this allows for a more intuitive usage of the transform script.
TestingData:
https://drive.google.com/file/d/1VcTaBS_eCfze4tmM7cpliTYyJ6S6Bp0i/view?usp=sharing

It is still very hard to know what it's doing for anyone not familiar with the convention.
```
Example:
To apply transform from ANTS to tractogram. If the ANTS commands was
MOVING->REFERENCE, this will bring a tractogram from MOVING->REFERENCE
scil_apply_transform_to_tractogram.py ${MOVING_FILE} ${REFERENCE_FILE}
                                        0GenericAffine.mat ${OUTPUT_NAME}
                                        --inverse
                                        --in_deformation 1InverseWarp.nii.gz

If the ANTS commands was MOVING->REFERENCE, this will bring a tractogram
from REFERENCE->MOVING
scil_apply_transform_to_tractogram.py ${MOVING_FILE} ${REFERENCE_FILE}
                                        0GenericAffine.mat ${OUTPUT_NAME}
                                        --in_deformation 1Warp.nii.gz
                                        --reverse_operation
```
Overall the idea is that a registration from ANTS has ''a direction'' SOURCE->TARGET, but ANTs nomenclature is made for image, so it has to be the inverse transformations (so --inverse + using InverseWarp).
When going against the initial direction of the ANTS command, the inverse transformations are no needed anymore BUT the order of the operation has to be inverted.

I use the flag "--_reverse_operation_", I am open to using a better name (--inverse cannot change, this is too common to change)
 
