### PR TITLE
[BF] Bug fix for when there is only tc when scoring tractogram

### DIFF
--- a/scilpy/tractanalysis/scoring.py
+++ b/scilpy/tractanalysis/scoring.py
@@ -372,10 +372,13 @@ def extract_false_connections(sft, mask_1_filename, mask_2_filename,
         mask_1 = binary_dilation(mask_1, iterations=dilate_endpoints)
         mask_2 = binary_dilation(mask_2, iterations=dilate_endpoints)
 
-    tmp_sft, sft = extract_streamlines(mask_1, mask_2, sft)
+    if len(sft.streamlines) > 0:
+        tmp_sft, sft = extract_streamlines(mask_1, mask_2, sft)
 
-    streamlines = tmp_sft.streamlines
-    fc_streamlines = streamlines
+        streamlines = tmp_sft.streamlines
+        fc_streamlines = streamlines
 
-    fc_sft = StatefulTractogram.from_sft(fc_streamlines, sft)
-    return fc_sft, sft
+        fc_sft = StatefulTractogram.from_sft(fc_streamlines, sft)
+        return fc_sft, sft
+    else:
+        return sft, sft

--- a/scripts/scil_score_tractogram.py
+++ b/scripts/scil_score_tractogram.py
@@ -268,8 +268,9 @@ def main():
 
     final_results = {}
     no_conn_sft = StatefulTractogram.from_sft(nc_streamlines, sft)
-    save_tractogram(no_conn_sft, os.path.join(
-        args.out_dir, "nc{}".format(ext)), bbox_valid_check=False)
+    if len(no_conn_sft) > 0:
+        save_tractogram(no_conn_sft, os.path.join(
+            args.out_dir, "nc{}".format(ext)), bbox_valid_check=False)
 
     # Total number of streamlines for each category
     # and statistic that are not "bundle-wise"

--- a/scripts/scil_score_tractogram.py
+++ b/scripts/scil_score_tractogram.py
@@ -103,6 +103,8 @@ def _build_arg_parser():
                         *_wpc.[tck|trk].")
     p.add_argument("--remove_invalid", action="store_true",
                    help="Remove invalid streamlines before scoring.")
+    p.add_argument("--no_empty", action='store_true',
+                   help='Do not write file if there is no streamline.')
 
     add_json_args(p)
     add_overwrite_arg(p)
@@ -208,17 +210,18 @@ def main():
             extract_prefix(args.gt_bundles[i]), gt_bundle_inv_masks[i],
             args.dilate_endpoints, args.wrong_path_as_separate)
         nc_streamlines.extend(nc)
-        if len(tc_sft) > 0:
+        if len(tc_sft) > 0 or not args.no_empty:
             save_tractogram(tc_sft, os.path.join(
                 args.out_dir, "{}_{}_tc{}".format(prefix_1, prefix_2, ext)),
                 bbox_valid_check=False)
 
-        if len(wpc_sft) > 0:
+        if ((len(wpc_sft) > 0 or not args.no_empty)
+           and args.wrong_path_as_separate):
             save_tractogram(
                 wpc_sft, os.path.join(args.out_dir, "{}_{}_wpc{}".format(
                     prefix_1, prefix_2, ext)), bbox_valid_check=False)
 
-        if len(fc_sft) > 0:
+        if len(fc_sft) > 0 or not args.no_empty:
             save_tractogram(fc_sft, os.path.join(
                 args.out_dir, "{}_{}_fc{}".format(prefix_1, prefix_2, ext)),
                 bbox_valid_check=False)
@@ -254,7 +257,7 @@ def main():
         fc_sft, sft = extract_false_connections(
             sft, mask_1_filename, mask_2_filename, args.dilate_endpoints)
 
-        if len(fc_sft) > 0:
+        if len(fc_sft) > 0 or not args.no_empty:
             save_tractogram(fc_sft, os.path.join(
                 args.out_dir, "{}_{}_fc{}".format(prefix_1, prefix_2, ext)),
                 bbox_valid_check=False)
@@ -268,7 +271,7 @@ def main():
 
     final_results = {}
     no_conn_sft = StatefulTractogram.from_sft(nc_streamlines, sft)
-    if len(no_conn_sft) > 0:
+    if len(no_conn_sft) > 0 or not args.no_empty:
         save_tractogram(no_conn_sft, os.path.join(
             args.out_dir, "nc{}".format(ext)), bbox_valid_check=False)
 


### PR DESCRIPTION
So I was trying out `scil_score_tractogram.py`.

I get a crash when scoring the ground truth tractogram on itself, because there are no false connections. I added a case for when the tractogram minus the true connections is empty to prevent crashing. Also, I added a check to not save the nc tractogram when it is empty.

@AntoineTheb If I remember correctly you worked quite a lot on this script, does the fix look ok?