### PR TITLE
Modifications in the (bitbucket) tracking scripts - part 2

### DIFF
--- a/scilpy/image/datasets.py
+++ b/scilpy/image/datasets.py
@@ -2,7 +2,7 @@
 import numpy as np
 
 from dipy.core.interpolation import trilinear_interpolate4d, \
-                                    nearestneighbor_interpolate
+    nearestneighbor_interpolate
 
 
 class DataVolume(object):
@@ -46,9 +46,8 @@ class DataVolume(object):
 
     def get_voxel_value(self, i, j, k):
         """
-        Get the voxel value at x, y, z in the dataset
-        if the coordinates are out of bound, the nearest voxel
-        value is taken.
+        Get the voxel value at x, y, z in the dataset.
+        If the coordinates are out of bound, the nearest voxel value is taken.
 
         Parameters
         ----------
@@ -84,7 +83,7 @@ class DataVolume(object):
         return (0 <= i < self.dim[0] and 0 <= j < self.dim[1] and
                 0 <= k < self.dim[2])
 
-    def get_voxel_at_position(self, x, y, z):
+    def voxmm_to_idx(self, x, y, z, origin='center'):
         """
         Get the 3D indice of the closest voxel at position x, y, z expressed
         in mm.
@@ -93,17 +92,29 @@ class DataVolume(object):
         ----------
         x, y, z: floats
             Position coordinate (mm) along x, y, z axis.
+        origin: str
+            'Center': Voxel 0,0,0 goes from [-resx/2, -resy/2, -resz/2] to
+                [resx/2, resy/2, resz/2].
+            'Corner': Voxel 0,0,0 goes from [0,0,0] to [resx, resy, resz].
 
         Return
         ------
         out: list
             3D indice of voxel at position x, y, z.
         """
-        return [(x + self.pixdim[0] / 2) // self.pixdim[0],
-                (y + self.pixdim[1] / 2) // self.pixdim[1],
-                (z + self.pixdim[2] / 2) // self.pixdim[2]]
+        if origin == 'center':
+            return np.asarray([(x + self.pixdim[0] / 2) // self.pixdim[0],
+                               (y + self.pixdim[1] / 2) // self.pixdim[1],
+                               (z + self.pixdim[2] / 2) // self.pixdim[2]],
+                              dtype=int)
+        elif origin == 'corner':
+            return np.asarray([x // self.pixdim[0],
+                               y // self.pixdim[1],
+                               z // self.pixdim[2]], dtype=int)
+        else:
+            raise ValueError("Origin must be one of 'center' or 'corner'.")
 
-    def get_voxel_coordinate(self, x, y, z):
+    def voxmm_to_vox(self, x, y, z):
         """
         Get voxel space coordinates at position x, y, z (mm).
 
@@ -119,24 +130,7 @@ class DataVolume(object):
         """
         return [x / self.pixdim[0], y / self.pixdim[1], z / self.pixdim[2]]
 
-    def get_voxel_value_at_position(self, x, y, z):
-        """
-        Get value of the voxel closest to position x, y, z (mm) in the dataset.
-        No interpolation is done.
-
-        Parameters
-        ----------
-        x, y, z: floats
-            Position coordinate (mm) along x, y, z axis.
-
-        Return
-        ------
-        value: ndarray (self.dim[-1],)
-            The value evaluated at position x, y, z.
-        """
-        return self.get_voxel_value(*self.get_voxel_at_position(x, y, z))
-
-    def get_position_value(self, x, y, z):
+    def voxmm_to_value(self, x, y, z):
         """
         Get the voxel value at voxel position x, y, z (mm) in the dataset.
         If the coordinates are out of bound, the nearest voxel value is taken.
@@ -154,7 +148,7 @@ class DataVolume(object):
             is of length 1, return a scalar value.
         """
         if self.interpolation is not None:
-            if not self.is_position_in_bound(x, y, z):
+            if not self.is_voxmm_in_bound(x, y, z):
                 eps = float(1e-8)  # Epsilon to exclude upper borders
                 x = max(-self.pixdim[0] / 2,
                         min(self.pixdim[0] * (self.dim[0] - 0.5 - eps), x))
@@ -162,8 +156,7 @@ class DataVolume(object):
                         min(self.pixdim[1] * (self.dim[1] - 0.5 - eps), y))
                 z = max(-self.pixdim[2] / 2,
                         min(self.pixdim[2] * (self.dim[2] - 0.5 - eps), z))
-            coord = np.array(self.get_voxel_coordinate(x, y, z),
-                             dtype=np.float64)
+            coord = np.array(self.voxmm_to_vox(x, y, z), dtype=np.float64)
 
             if self.interpolation == 'nearest':
                 result = nearestneighbor_interpolate(self.data, coord)
@@ -174,12 +167,11 @@ class DataVolume(object):
             # Squeezing returns only value instead of array of length 1 if 3D
             # data
             return np.squeeze(result)
-
         else:
             raise Exception("No interpolation method was given, cannot run "
                             "this method..")
 
-    def is_position_in_bound(self, x, y, z):
+    def is_voxmm_in_bound(self, x, y, z, origin='center'):
         """
         Test if the position x, y, z mm is in the dataset range.
 
@@ -187,10 +179,14 @@ class DataVolume(object):
         ----------
         x, y, z: floats
             Position coordinate (mm) along x, y, z axis.
+        origin: str
+            'Center': Voxel 0,0,0 goes from [-resx/2, -resy/2, -resz/2] to
+                [resx/2, resy/2, resz/2].
+            'Corner': Voxel 0,0,0 goes from [0,0,0] to [resx, resy, resz].
 
         Return
         ------
         value: bool
             True if position is in dataset range and false otherwise.
         """
-        return self.is_voxel_in_bound(*self.get_voxel_at_position(x, y, z))
+        return self.is_voxel_in_bound(*self.voxmm_to_idx(x, y, z, origin))

--- a/scilpy/io/utils.py
+++ b/scilpy/io/utils.py
@@ -273,12 +273,20 @@ def validate_sh_basis_choice(sh_basis):
 
 
 def verify_compression_th(compress_th):
+    """
+    Verify that the compression threshold is between 0.001 and 1. Else,
+    produce a warning.
+
+    Parameters
+    -----------
+    compress_th: float, the compression threshold.
+    """
     if compress_th:
         if compress_th < 0.001 or compress_th > 1:
             logging.warning(
                 'You are using an error rate of {}.\nWe recommend setting it '
                 'between 0.001 and 1.\n0.001 will do almost nothing to the '
-                'tracts while 1 will higly compress/linearize the tracts'
+                'tracts while 1 will higly compress/linearize the tracts.'
                 .format(compress_th))
 
 

--- a/scilpy/tracking/local_tracking.py
+++ b/scilpy/tracking/local_tracking.py
@@ -21,8 +21,8 @@ data_file_info = None
 
 class Tracker(object):
     def __init__(self, propagator: AbstractPropagator, mask: DataVolume,
-                 seed_generator: SeedGenerator, nbr_seeds, min_nbr_points,
-                 max_nbr_points, max_invalid_dirs, compression_th=0.1,
+                 seed_generator: SeedGenerator, nbr_seeds, min_nbr_pts,
+                 max_nbr_pts, max_invalid_dirs, compression_th=0.1,
                  nbr_processes=1, save_seeds=False, mmap_mode=None,
                  rng_seed=1234, track_forward_only=False, skip=0):
         """
@@ -36,8 +36,8 @@ class Tracker(object):
             Seeding volume.
         nbr_seeds: int
             Number of seeds to create via the seed generator.
-        min_nbr_points: int
-        max_nbr_points: int
+        min_nbr_pts: int
+        max_nbr_pts: int
         max_invalid_dirs: int
             Number of consecutives invalid directions allowed during tracking.
         compression_th : float,
@@ -65,8 +65,8 @@ class Tracker(object):
         self.mask = mask
         self.seed_generator = seed_generator
         self.nbr_seeds = nbr_seeds
-        self.min_nbr_pts = min_nbr_points
-        self.max_nbr_pts = max_nbr_points
+        self.min_nbr_pts = min_nbr_pts
+        self.max_nbr_pts = max_nbr_pts
         self.max_invalid_dirs = max_invalid_dirs
         self.compression_th = compression_th
         self.save_seeds = save_seeds

--- a/scilpy/tracking/local_tracking.py
+++ b/scilpy/tracking/local_tracking.py
@@ -13,307 +13,267 @@ import numpy as np
 from dipy.tracking.streamlinespeed import compress_streamlines
 
 from scilpy.image.datasets import DataVolume
-from scilpy.tracking.tracker import AbstractPropagator
+from scilpy.tracking.propagator import AbstractPropagator
 from scilpy.tracking.seed import SeedGenerator
 from scilpy.tracking.utils import TrackingParams
 
+# For the multi-processing:
 data_file_info = None
 
 
-def track(tracker: AbstractPropagator, mask: DataVolume,
-          seed_generator: SeedGenerator, params: TrackingParams,
-          compression_th=0.1, nbr_processes=1, save_seeds=False):
-    """
-    Generate a set of streamline from seed, mask and odf files.
+class Tracker(object):
+    def __init__(self, propagator: AbstractPropagator, mask: DataVolume,
+                 seed_generator: SeedGenerator, params: TrackingParams,
+                 compression_th=0.1, nbr_processes=1, save_seeds=False):
+        """
+        Parameters
+        ----------
+        propagator : AbstractPropagator
+            Tracking object.
+        mask : DataVolume
+            Tracking volume(s).
+        seed_generator : SeedGenerator
+            Seeding volume.
+        params: TrackingParams
+            Tracking parameters, see scilpy.tracking.utils.py.
+        compression_th : float,
+            Maximal distance threshold for compression. If None or 0, no
+            compression is applied.
+        nbr_processes: int
+            Number of sub processes to use.
+        save_seeds: bool
+            Whether to save the seeds associated to their respective
+            streamlines.
+        """
+        self.propagator = propagator
+        self.mask = mask
+        self.seed_generator = seed_generator
+        self.params = params
+        self.compression_th = compression_th
+        self.save_seeds = save_seeds
 
-    Parameters
-    ----------
-    tracker : AbstractPropagator
-        Tracking object.
-    mask : DataVolume
-        Tracking volume(s).
-    seed_generator : SeedGenerator
-        Seeding volume.
-    params: TrackingParams
-        Tracking parameters, see scilpy.tracking.utils.py.
-    compression_th : float,
-        Maximal distance threshold for compression. If None or 0, no
-        compression is applied.
-    nbr_processes: int
-        Number of sub processes to use.
-    save_seeds: bool
-        Whether to save the seeds associated to their respective streamlines.
+        self.nbr_processes = self._set_nbr_processes(nbr_processes)
 
-    Return
-    ------
-    streamlines: list of numpy.array
-    seeds: list of numpy.array
-    """
-    nbr_processes = set_nbr_processes(nbr_processes, params)
+    def track(self):
+        """
+        Generate a set of streamline from seed, mask and odf files.
 
-    if nbr_processes < 2:
-        chunk_id = 1
-        lines, seeds = get_streamlines(
-            tracker, mask, seed_generator, chunk_id, params, compression_th,
-            nbr_processes=1, save_seeds=save_seeds)
-    else:
-        # Each process will use get_streamlines_at_seeds
-        chunk_ids = np.arange(nbr_processes)
-        with nib.tmpdirs.InTemporaryDirectory() as tmpdir:
-            # toDo
-            # must be better designed for dipy
-            # the tracking should not know which data to deal with
-            data_file_name = os.path.join(tmpdir, 'data.npy')
-            np.save(data_file_name, tracker.tracking_field.dataset.data)
-            tracker.tracking_field.dataset.data = None
-
-            pool = multiprocessing.Pool(nbr_processes,
-                                        initializer=_init_sub_process,
-                                        initargs=(data_file_name,
-                                                  params.mmap_mode))
-
-            lines_per_process, seeds_per_process = zip(*pool.map(
-                _get_streamlines_sub,
-                zip(itertools.repeat(tracker),
-                    itertools.repeat(mask),
-                    itertools.repeat(seed_generator),
-                    chunk_ids,
-                    itertools.repeat(params),
-                    itertools.repeat(compression_th),
-                    itertools.repeat(nbr_processes),
-                    itertools.repeat(save_seeds))))
-            pool.close()
-            # Make sure all worker processes have exited before leaving
-            # context manager.
-            pool.join()
-            lines = [line for line in itertools.chain(*lines_per_process)]
-            seeds = [seed for seed in itertools.chain(*seeds_per_process)]
-
-    return lines, seeds
-
-
-def set_nbr_processes(nbr_processes, params):
-    # Verifying the number of processes
-    if nbr_processes <= 0:
-        try:
-            nbr_processes = multiprocessing.cpu_count()
-        except NotImplementedError:
-            warnings.warn("Cannot determine number of cpus. \
-                    returns nbr_processes set to 1.")
-            nbr_processes = 1
-
-    if nbr_processes > params.nbr_seeds:
-        nbr_processes = params.nbr_seeds
-        logging.debug('Setting number of processes to ' +
-                      str(nbr_processes) +
-                      ' since there were less seeds than processes.')
-    return nbr_processes
-
-
-def _init_sub_process(date_file_name, mmap_mod):
-    global data_file_info
-    data_file_info = (date_file_name, mmap_mod)
-    return
-
-
-def _get_streamlines_sub(args):
-    """
-    multiprocessing.pool.map input function.
-
-    Parameters
-    ----------
-    args : List, parameters for the get_streamlines_at_seeds function.
-
-    Return
-    -------
-    lines: list, list of list of 3D positions (streamlines).
-    """
-    global data_file_info
-
-    # args[0] is the Tracker.
-    args[0].tracking_field.dataset.data = np.load(data_file_info[0],
-                                                  mmap_mode=data_file_info[1])
-
-    try:
-        streamlines, seeds = get_streamlines(*args)
-        return streamlines, seeds
-    except Exception as e:
-        logging.error("Operation _get_streamlines_sub() failed.")
-        traceback.print_exception(*sys.exc_info(), file=sys.stderr)
-        raise e
-
-
-def get_streamlines(tracker, mask, seed_generator, chunk_id, params,
-                    compression_th=0.1, nbr_processes=1,
-                    save_seeds=True):
-    """
-    Generate streamlines from all initial positions following the tracking
-    parameters.
-
-    Parameters
-    ----------
-    tracker : AbstractPropagator
-        Tracking object.
-    mask : BinaryMask
-        Tracking volume(s).
-    seed_generator : SeedGenerator
-        Seeding volume.
-    chunk_id: int
-        This chunk of seeds id. Chunks sizes depend on the number of processes.
-    params: TrackingParams
-        Tracking parameters, see scilpy.tracking.utils.py.
-    compression_th : float,
-        Maximal distance threshold for compression. If None or 0, no
-        compression is applied.
-    nbr_processes: int
-        Number of sub processes to use.
-    save_seeds: bool
-        Whether to save the seeds associated to their respective streamlines.
-
-    Returns
-    -------
-    lines: list, list of list of 3D positions
-    """
-
-    streamlines = []
-    seeds = []
-    # Initialize the random number generator to cover multiprocessing, skip,
-    # which voxel to seed and the subvoxel random position
-    chunk_size = int(params.nbr_seeds / nbr_processes)
-    skip = params.skip
-
-    first_seed_of_chunk = chunk_id * chunk_size + skip
-    random_generator, indices = \
-        seed_generator.init_pos(params.random, first_seed_of_chunk)
-
-    if chunk_id == nbr_processes - 1:
-        chunk_size += params.nbr_seeds % nbr_processes
-    for s in range(chunk_size):
-        if s % 1000 == 0:
-            logging.info(str(os.getpid()) + " : " + str(s)
-                         + " / " + str(chunk_size))
-
-        seed = \
-            seed_generator.get_next_pos(random_generator, indices,
-                                        first_seed_of_chunk + s)
-        line = get_line_both_directions(tracker, mask, seed, params)
-        if line is not None:
-            if compression_th and compression_th > 0:
-                streamlines.append(
-                    compress_streamlines(np.array(line, dtype='float32'),
-                                         compression_th))
-            else:
-                streamlines.append((np.array(line, dtype='float32')))
-
-            if save_seeds:
-                seeds.append(np.asarray(seed, dtype='float32'))
-
-    return streamlines, seeds
-
-
-def get_line_both_directions(tracker: AbstractPropagator, mask: DataVolume,
-                             pos, params):
-    """
-    Generate a streamline from an initial position following the tracking
-    parameters.
-
-    Parameters
-    ----------
-    tracker : AbstractPropagator
-        Tracking object.
-    mask : BinaryMask
-        Tracking volume(s).
-    pos : tuple
-        3D position, the seed position.
-    params: TrackingParams
-        Tracking parameters.
-
-    Returns
-    -------
-    line: list of 3D positions
-    """
-    np.random.seed(np.uint32(hash((pos, params.random))))
-    line = []
-    if tracker.initialize(pos):
-        forward = _propagate_line(tracker, mask, params, True)
-        if forward is not None and len(forward) > 0:
-            line.extend(forward)
-
-        if not params.is_single_direction and forward is not None:
-            backward = _propagate_line(tracker, mask, params, False)
-            if backward is not None and len(backward) > 0:
-                line.reverse()
-                line.pop()
-                line.extend(backward)
+        Return
+        ------
+        streamlines: list of numpy.array
+        seeds: list of numpy.array
+        """
+        if self.nbr_processes < 2:
+            chunk_id = 1
+            lines, seeds = self._get_streamlines(chunk_id)
         else:
-            backward = []
+            # Each process will use get_streamlines_at_seeds
+            chunk_ids = np.arange(self.nbr_processes)
+            with nib.tmpdirs.InTemporaryDirectory() as tmpdir:
+                # toDo
+                # must be better designed for dipy
+                # the tracking should not know which data to deal with
+                data_file_name = os.path.join(tmpdir, 'data.npy')
+                np.save(data_file_name,
+                        self.propagator.tracking_field.dataset.data)
+                self.propagator.tracking_field.dataset.data = None
 
-        if ((len(line) > 1 and
-             forward is not None and
-             backward is not None and
-             params.min_nbr_pts <= len(line) <= params.max_nbr_pts)):
-            return line
-        elif params.is_keep_single_pts and params.min_nbr_pts == 1:
+                # Using pool with a class method will serialize all parameters
+                # in the class, which can be heavy, but it is what we would be
+                # doing manually with a static class.
+                # Be careful however, parameter changes inside the method will
+                # not be kept.
+                pool = multiprocessing.Pool(self.nbr_processes,
+                                            initializer=self._init_sub_process,
+                                            initargs=(data_file_name,
+                                                      self.params.mmap_mode))
+
+                lines_per_process, seeds_per_process = zip(*pool.map(
+                    self._get_streamlines_sub, chunk_ids))
+                pool.close()
+                # Make sure all worker processes have exited before leaving
+                # context manager.
+                pool.join()
+                lines = [line for line in itertools.chain(*lines_per_process)]
+                seeds = [seed for seed in itertools.chain(*seeds_per_process)]
+
+        return lines, seeds
+
+    def _set_nbr_processes(self, nbr_processes):
+        # Verifying the number of processes
+        if nbr_processes <= 0:
+            try:
+                nbr_processes = multiprocessing.cpu_count()
+            except NotImplementedError:
+                warnings.warn("Cannot determine number of cpus. \
+                        returns nbr_processes set to 1.")
+                nbr_processes = 1
+
+        if nbr_processes > self.params.nbr_seeds:
+            nbr_processes = self.params.nbr_seeds
+            logging.debug('Setting number of processes to ' +
+                          str(nbr_processes) +
+                          ' since there were less seeds than processes.')
+        return nbr_processes
+
+    @staticmethod
+    def _init_sub_process(date_file_name, mmap_mod):
+        global data_file_info
+        data_file_info = (date_file_name, mmap_mod)
+        return
+
+    def _get_streamlines_sub(self, args):
+        """
+        multiprocessing.pool.map input function.
+
+        Parameters
+        ----------
+        args : List, parameters for the get_streamlines_at_seeds function.
+
+        Return
+        -------
+        lines: list, list of list of 3D positions (streamlines).
+        """
+        global data_file_info
+
+        # args[0] is the Tracker.
+        args[0].tracking_field.dataset.data = np.load(
+            data_file_info[0], mmap_mode=data_file_info[1])
+
+        try:
+            streamlines, seeds = self._get_streamlines(*args)
+            return streamlines, seeds
+        except Exception as e:
+            logging.error("Operation _get_streamlines_sub() failed.")
+            traceback.print_exception(*sys.exc_info(), file=sys.stderr)
+            raise e
+
+    def _get_streamlines(self, chunk_id):
+        streamlines = []
+        seeds = []
+        # Initialize the random number generator to cover multiprocessing,
+        # skip, which voxel to seed and the subvoxel random position
+        chunk_size = int(self.params.nbr_seeds / self.nbr_processes)
+        skip = self.params.skip
+
+        first_seed_of_chunk = chunk_id * chunk_size + skip
+        random_generator, indices = self.seed_generator.init_pos(
+            self.params.random, first_seed_of_chunk)
+
+        if chunk_id == self.nbr_processes - 1:
+            chunk_size += self.params.nbr_seeds % self.nbr_processes
+        for s in range(chunk_size):
+            if s % 1000 == 0:
+                logging.info(str(os.getpid()) + " : " + str(s)
+                             + " / " + str(chunk_size))
+
+            seed = self.seed_generator.get_next_pos(
+                random_generator, indices, first_seed_of_chunk + s)
+            line = self._get_line_both_directions(seed)
+            if line is not None:
+                if self.compression_th and self.compression_th > 0:
+                    streamlines.append(
+                        compress_streamlines(np.array(line, dtype='float32'),
+                                             self.compression_th))
+                else:
+                    streamlines.append((np.array(line, dtype='float32')))
+
+                if self.save_seeds:
+                    seeds.append(np.asarray(seed, dtype='float32'))
+
+        return streamlines, seeds
+
+    def _get_line_both_directions(self, pos):
+        """
+        Generate a streamline from an initial position following the tracking
+        parameters.
+
+        Parameters
+        ----------
+        pos : tuple
+            3D position, the seed position.
+
+        Returns
+        -------
+        line: list of 3D positions
+        """
+        np.random.seed(np.uint32(hash((pos, self.params.random))))
+        line = []
+        if self.propagator.initialize(pos):
+            forward = self._propagate_line(True)
+            if forward is not None and len(forward) > 0:
+                line.extend(forward)
+
+            if not self.params.is_single_direction and forward is not None:
+                backward = self._propagate_line(False)
+                if backward is not None and len(backward) > 0:
+                    line.reverse()
+                    line.pop()
+                    line.extend(backward)
+            else:
+                backward = []
+
+            if ((len(line) > 1 and
+                 forward is not None and
+                 backward is not None and
+                 self.params.min_nbr_pts <= len(line) <=
+                 self.params.max_nbr_pts)):
+                return line
+            elif (self.params.is_keep_single_pts and
+                  self.params.min_nbr_pts == 1):
+                return [pos]
+            return None
+        if ((self.params.is_keep_single_pts and
+             self.params.min_nbr_pts == 1)):
             return [pos]
         return None
-    if ((params.is_keep_single_pts and
-         params.min_nbr_pts == 1)):
-        return [pos]
-    return None
 
+    def _propagate_line(self, is_forward):
+        """
+        Generate a streamline in forward or backward direction from an initial
+        position following the tracking parameters.
 
-def _propagate_line(tracker: AbstractPropagator, mask: DataVolume, params,
-                    is_forward):
-    """
-    Generate a streamline in forward or backward direction from an initial
-    position following the tracking parameters.
-
-    Parameters
-    ----------
-    tracker : AbstractPropagator
-        Tracking object.
-    mask : DataVolume
         Propagation will stop if the current position is out of bounds (mask's
         bounds and data's bounds should be the same) or if mask's value at
         current position is 0 (usual use is with a binary mask but this is not
         mandatory).
-    params: TrackingParams, tracking parameters.
-    is_forward: bool, track in forward direction if True,
-                      track in backward direction if False.
 
-    Returns
-    -------
-    line: list of 3D positions
-    """
-    line = [tracker.init_pos]
-    line_dirs = [tracker.forward_dir] if is_forward else [tracker.backward_dir]
+        Returns
+        -------
+        line: list of 3D positions
+        """
+        line = [self.propagator.init_pos]
+        line_dirs = [self.propagator.forward_dir] if is_forward else [
+            self.propagator.backward_dir]
 
-    no_valid_direction_count = 0
+        no_valid_direction_count = 0
 
-    propagation_can_continue = True
-    while len(line) < params.max_nbr_pts and propagation_can_continue:
-        new_pos, new_dir, is_valid_direction = tracker.propagate(
-            line[-1], line_dirs[-1])
-        line.append(new_pos)
-        line_dirs.append(new_dir)
+        propagation_can_continue = True
+        while len(line) < self.params.max_nbr_pts and propagation_can_continue:
+            new_pos, new_dir, is_valid_direction = self.propagator.propagate(
+                line[-1], line_dirs[-1])
+            line.append(new_pos)
+            line_dirs.append(new_dir)
 
-        if is_valid_direction:
-            no_valid_direction_count = 0
-        else:
-            no_valid_direction_count += 1
+            if is_valid_direction:
+                no_valid_direction_count = 0
+            else:
+                no_valid_direction_count += 1
 
-        if no_valid_direction_count > params.max_no_dir:
-            return line
+            if no_valid_direction_count > self.params.max_no_dir:
+                return line
 
-        propagation_can_continue = (mask.get_position_value(*line[-1]) > 0 and
-                                    mask.is_position_in_bound(*line[-1]))
+            propagation_can_continue = (
+                    self.mask.get_position_value(*line[-1]) > 0 and
+                    self.mask.is_position_in_bound(*line[-1]))
 
-    # Make a last step in the last direction
-    line.append(line[-1] + tracker.step_size * np.array(line_dirs[-1]))
+        # Make a last step in the last direction
+        line.append(line[-1] +
+                    self.propagator.step_size * np.array(line_dirs[-1]))
 
-    # Last cleaning of the streamline
-    while (line is not None and len(line) > 0 and
-           not tracker.is_position_in_bound(line[-1])):
-        line.pop()
+        # Last cleaning of the streamline
+        while (line is not None and len(line) > 0 and
+               not self.propagator.is_position_in_bound(line[-1])):
+            line.pop()
 
-    return line
+        return line

--- a/scilpy/tracking/propagator.py
+++ b/scilpy/tracking/propagator.py
@@ -36,7 +36,7 @@ class AbstractPropagator(object):
         self.forward_dir = None
         self.backward_dir = None
 
-    def initialize(self, pos):
+    def initialize(self, pos, track_forward_only):
         """
         Initialize the tracking at position pos. Initial tracking directions
         are picked, the propagete_foward() and propagate_backward() functions
@@ -46,6 +46,8 @@ class AbstractPropagator(object):
         ----------
         pos: ndarray (3,)
             Initial tracking position.
+        track_forward_only: bool
+            If true, verifies validity of forward direction only.
 
         Return
         ------
@@ -57,6 +59,14 @@ class AbstractPropagator(object):
         self.backward_pos = pos
         self.forward_dir, self.backward_dir =\
             self.tracking_field.get_init_direction(pos)
+
+        if track_forward_only:
+            if self.forward_dir is not None:
+                return True
+            elif self.backward_dir is not None:
+                self.forward_dir = self.backward_dir
+                return True
+            return False
         return self.forward_dir is not None and self.backward_dir is not None
 
     def _get_next_valid_direction(self, pos, v_in):

--- a/scilpy/tracking/propagator.py
+++ b/scilpy/tracking/propagator.py
@@ -4,7 +4,7 @@ import numpy as np
 from scilpy.tracking.tools import sample_distribution
 from scilpy.tracking.utils import TrackingDirection
 from scilpy.tracking.tracking_field import AbstractTrackingField, \
-                                           SphericalHarmonicField
+                                           ODFField
 
 
 class AbstractPropagator(object):
@@ -194,7 +194,7 @@ class AbstractPropagator(object):
         pass
 
 
-class ProbabilisticSHPropagator(AbstractPropagator):
+class ProbabilisticODFPropagator(AbstractPropagator):
     """
     Probabilistic direction tracker.
 
@@ -207,9 +207,9 @@ class ProbabilisticSHPropagator(AbstractPropagator):
     rk_order: int
         Order for the Runge Kutta integration.
     """
-    def __init__(self, tracking_field: SphericalHarmonicField, step_size,
+    def __init__(self, tracking_field: ODFField, step_size,
                  rk_order):
-        super(ProbabilisticSHPropagator, self).__init__(
+        super(ProbabilisticODFPropagator, self).__init__(
             tracking_field, step_size, rk_order)
 
     def _get_next_direction(self, pos, v_in):
@@ -237,9 +237,10 @@ class ProbabilisticSHPropagator(AbstractPropagator):
         return None
 
 
-class DeterministicMaximaSHPropagator(AbstractPropagator):
+class DeterministicODFPropagator(AbstractPropagator):
     """
-    Deterministic direction tracker.
+    Deterministic direction tracker on the ODF. Direction is the maximum
+    direction on the sphere.
 
     Parameters
     ----------
@@ -250,9 +251,9 @@ class DeterministicMaximaSHPropagator(AbstractPropagator):
     rk_order: int
         Order for the Runge Kutta integration.
     """
-    def __init__(self, tracking_field: SphericalHarmonicField, step_size,
+    def __init__(self, tracking_field: ODFField, step_size,
                  rk_order):
-        super(DeterministicMaximaSHPropagator, self).__init__(
+        super(DeterministicODFPropagator, self).__init__(
             tracking_field, step_size, rk_order)
 
     def _get_next_direction(self, pos, v_in):

--- a/scilpy/tracking/propagator.py
+++ b/scilpy/tracking/propagator.py
@@ -70,6 +70,11 @@ class AbstractPropagator(object):
             return False
         return self.forward_dir is not None and self.backward_dir is not None
 
+    def start_backward(self):
+        """Called at the beginning of backward tracking, in case we need to
+        reset some parameters"""
+        pass
+
     def _sample_init_direction(self, pos):
         return self.tracking_field.get_init_direction(pos)
 

--- a/scilpy/tracking/propagator.py
+++ b/scilpy/tracking/propagator.py
@@ -57,8 +57,7 @@ class AbstractPropagator(object):
         self.init_pos = pos
         self.forward_pos = pos
         self.backward_pos = pos
-        self.forward_dir, self.backward_dir =\
-            self.tracking_field.get_init_direction(pos)
+        self.forward_dir, self.backward_dir = self._sample_init_direction(pos)
 
         if track_forward_only:
             if self.forward_dir is not None:
@@ -68,6 +67,9 @@ class AbstractPropagator(object):
                 return True
             return False
         return self.forward_dir is not None and self.backward_dir is not None
+
+    def _sample_init_direction(self, pos):
+        return self.tracking_field.get_init_direction(pos)
 
     def _sample_next_direction_or_go_straight(self, pos, v_in):
         """

--- a/scilpy/tracking/propagator.py
+++ b/scilpy/tracking/propagator.py
@@ -74,7 +74,8 @@ class AbstractPropagator(object):
         Get the next direction given the position pos, input direction
         v_in, and tracking method (ex, probabilistic or deterministic), and
         verify if it is valid. If it is not valid, return v_in as next
-        direction.
+        direction. "Valid" means that the output of _get_next_direction is not
+        None.
 
         Uses self._get_next_direction, which must be implemented by each child
         class.
@@ -178,10 +179,10 @@ class AbstractPropagator(object):
 
     def _get_next_direction(self, pos, v_in):
         """
-        Abstract method. Return the next tracking direction, given
-        the current position pos and the previous direction v_in.
-        This direction must respect tracking constraint defined in
-        the tracking_field.
+        Return the next tracking direction, given the current position
+        pos and the previous direction v_in.
+
+        Should use self.tracking_field.get_next_direction.
 
         Parameters
         ----------

--- a/scilpy/tracking/propagator.py
+++ b/scilpy/tracking/propagator.py
@@ -156,7 +156,7 @@ class AbstractPropagator(object):
 
         return new_pos, new_dir, is_direction_valid
 
-    def is_position_in_bound(self, pos):
+    def is_voxmm_in_bound(self, pos, origin='center'):
         """
         Test if the streamline point is inside the boundary of the image.
 
@@ -164,13 +164,17 @@ class AbstractPropagator(object):
         ----------
         pos : tuple
             3D positions.
+        origin: str
+            'Center': Voxel 0,0,0 goes from [-resx/2, -resy/2, -resz/2] to
+                [resx/2, resy/2, resz/2].
+            'Corner': Voxel 0,0,0 goes from [0,0,0] to [resx, resy, resz].
 
         Return
         ------
         value: bool
             True if the streamline point is inside the boundary of the image.
         """
-        return self.tracking_field.dataset.is_position_in_bound(*pos)
+        return self.tracking_field.dataset.is_voxmm_in_bound(*pos, origin)
 
     def _get_next_direction(self, pos, v_in):
         """

--- a/scilpy/tracking/propagator.py
+++ b/scilpy/tracking/propagator.py
@@ -9,7 +9,9 @@ from scilpy.tracking.tracking_field import AbstractTrackingField, \
 
 class AbstractPropagator(object):
     """
-    Abstract class for tracker object.
+    Abstract class for propagator object. Responsible for sampling the final
+    direction out of the possible directions offered by the tracking field, and
+    for the propagation through Runge-Kutta integration.
 
     Parameters
     ----------
@@ -138,7 +140,7 @@ class AbstractPropagator(object):
 
         return new_pos, new_dir, is_direction_valid
 
-    def is_voxmm_in_bound(self, pos, origin='center'):
+    def is_voxmm_in_bound(self, pos, origin):
         """
         Test if the streamline point is inside the boundary of the image.
 

--- a/scilpy/tracking/propagator.py
+++ b/scilpy/tracking/propagator.py
@@ -169,7 +169,7 @@ class AbstractPropagator(object):
         v_in: ndarray (3,)
             Previous tracking direction.
         """
-        pass
+        raise NotImplementedError
 
 
 class ProbabilisticODFPropagator(AbstractPropagator):

--- a/scilpy/tracking/seed.py
+++ b/scilpy/tracking/seed.py
@@ -28,6 +28,10 @@ class SeedGenerator(object):
         self.data = data
         self.voxres = voxres
 
+        # Everything scilpy.tracking is in 'corner', 'voxmm'
+        self.origin = 'corner'
+        self.space = 'voxmm'
+
         # self.seed are all the voxels where a seed could be placed
         # (voxel space, int numbers).
         self.seeds = np.array(np.where(np.squeeze(data) > 0),

--- a/scilpy/tracking/seed.py
+++ b/scilpy/tracking/seed.py
@@ -8,13 +8,13 @@ class SeedGenerator(object):
     """
     Class to get seeding positions.
 
-    Generated seeds are in voxmm space. Ex: a seed sampled exactly at voxel
-    i,j,k = (0,1,2), thus at voxel center (0.5, 1.5, 2.5), with resolution
-    3x3x3mm will have coordinates x,y,z = (1.5, 4.5, 7.5)
+    Generated seeds are in voxmm space, origin=corner. Ex: a seed sampled
+    exactly at voxel i,j,k = (0,1,2), with resolution 3x3x3mm will have
+    coordinates x,y,z = (0, 3, 6).
 
-    Seeds are placed randomly within the voxel. In the same example as above,
-    seed sampled in voxel i,j,k = (0,1,2) will be somewhere in the range
-    x = [0, 3], y = [3, 6], z = [6, 9].
+    Using get_next_pos, seeds are placed randomly within the voxel. In the same
+    example as above, seed sampled in voxel i,j,k = (0,1,2) will be somewhere
+    in the range x = [0, 3], y = [3, 6], z = [6, 9].
     """
     def __init__(self, data, voxres):
         """
@@ -28,17 +28,16 @@ class SeedGenerator(object):
         self.data = data
         self.voxres = voxres
 
-        # self.seed_voxels are all the voxels where a seed could be placed
-        # (voxel space, int numbers). Sending "to center" by adding
-        # 0.5, 0.5, 0.5.
+        # self.seed are all the voxels where a seed could be placed
+        # (voxel space, int numbers).
         self.seeds = np.array(np.where(np.squeeze(data) > 0),
-                              dtype=float).transpose() + 0.5
+                              dtype=float).transpose()
         if len(self.seeds) == 0:
             logging.warning("There are positive voxels in the seeding mask!")
 
     def get_next_pos(self, random_generator, indices, which_seed):
         """
-        Generate the next seed position.
+        Generate the next seed position (Space=voxmm, origin=corner).
 
         Parameters
         ----------
@@ -58,19 +57,19 @@ class SeedGenerator(object):
         if len_seeds == 0:
             return []
 
-        half_voxel_dim = np.asarray(self.voxres) / 2
+        voxel_dim = np.asarray(self.voxres)
 
         # Voxel selection from the seeding mask
         ind = which_seed % len_seeds
         x, y, z = self.seeds[indices[ind]]
 
         # Subvoxel initial positioning
-        r_x = random_generator.uniform(-half_voxel_dim[0], half_voxel_dim[0])
-        r_y = random_generator.uniform(-half_voxel_dim[1], half_voxel_dim[1])
-        r_z = random_generator.uniform(-half_voxel_dim[2], half_voxel_dim[2])
+        r_x = random_generator.uniform(0, voxel_dim[0])
+        r_y = random_generator.uniform(0, voxel_dim[1])
+        r_z = random_generator.uniform(0, voxel_dim[2])
 
         return x * self.voxres[0] + r_x, y * self.voxres[1] \
-               + r_y, z * self.voxres[2] + r_z
+            + r_y, z * self.voxres[2] + r_z
 
     def init_generator(self, random_initial_value, first_seed_of_chunk):
         """

--- a/scilpy/tracking/seed.py
+++ b/scilpy/tracking/seed.py
@@ -16,17 +16,17 @@ class SeedGenerator(object):
     seed sampled in voxel i,j,k = (0,1,2) will be somewhere in the range
     x = [0, 3], y = [3, 6], z = [6, 9].
     """
-    def __init__(self, img):
+    def __init__(self, data, voxres):
         """
         Parameters
         ----------
-        img: nibabel image
-            The seeding mask. Seeds will be randomly placed in voxels with
-            value >0.
+        data: np.array
+            The data, ex, loaded from nibabel img.get_fdata().
+        voxres: np.array(3,)
+            The pixel resolution, ex, using img.header.get_zooms()[:3].
         """
-        self.pixdim = img.header.get_zooms()[:3]
-
-        data = img.get_fdata(caching='unchanged', dtype=np.float64)
+        self.data = data
+        self.voxres = voxres
 
         # self.seed_voxels are all the voxels where a seed could be placed
         # (voxel space, int numbers). Sending "to center" by adding
@@ -58,7 +58,7 @@ class SeedGenerator(object):
         if len_seeds == 0:
             return []
 
-        half_voxel_dim = np.asarray(self.pixdim) / 2
+        half_voxel_dim = np.asarray(self.voxres) / 2
 
         # Voxel selection from the seeding mask
         ind = which_seed % len_seeds
@@ -69,8 +69,8 @@ class SeedGenerator(object):
         r_y = random_generator.uniform(-half_voxel_dim[1], half_voxel_dim[1])
         r_z = random_generator.uniform(-half_voxel_dim[2], half_voxel_dim[2])
 
-        return x * self.pixdim[0] + r_x, y * self.pixdim[1] \
-            + r_y, z * self.pixdim[2] + r_z
+        return x * self.voxres[0] + r_x, y * self.voxres[1] \
+               + r_y, z * self.voxres[2] + r_z
 
     def init_generator(self, random_initial_value, first_seed_of_chunk):
         """

--- a/scilpy/tracking/seed.py
+++ b/scilpy/tracking/seed.py
@@ -1,10 +1,20 @@
 # -*- coding: utf-8 -*-
+import logging
+
 import numpy as np
 
 
 class SeedGenerator(object):
     """
-    Class to get seeding positions
+    Class to get seeding positions.
+
+    Generated seeds are in voxmm space. Ex: a seed sampled exactly at voxel
+    i,j,k = (0,1,2), thus at voxel center (0.5, 1.5, 2.5), with resolution
+    3x3x3mm will have coordinates x,y,z = (1.5, 4.5, 7.5)
+
+    Seeds are placed randomly within the voxel. In the same example as above,
+    seed sampled in voxel i,j,k = (0,1,2) will be somewhere in the range
+    x = [0, 3], y = [3, 6], z = [6, 9].
     """
     def __init__(self, img):
         """
@@ -17,7 +27,14 @@ class SeedGenerator(object):
         self.pixdim = img.header.get_zooms()[:3]
 
         data = img.get_fdata(caching='unchanged', dtype=np.float64)
-        self.seeds = np.array(np.where(np.squeeze(data) > 0)).transpose()
+
+        # self.seed_voxels are all the voxels where a seed could be placed
+        # (voxel space, int numbers). Sending "to center" by adding
+        # 0.5, 0.5, 0.5.
+        self.seeds = np.array(np.where(np.squeeze(data) > 0),
+                              dtype=float).transpose() + 0.5
+        if len(self.seeds) == 0:
+            logging.warning("There are positive voxels in the seeding mask!")
 
     def get_next_pos(self, random_generator, indices, which_seed):
         """
@@ -41,26 +58,21 @@ class SeedGenerator(object):
         if len_seeds == 0:
             return []
 
-        half_voxel_range = [self.pixdim[0] / 2,
-                            self.pixdim[1] / 2,
-                            self.pixdim[2] / 2]
+        half_voxel_dim = np.asarray(self.pixdim) / 2
 
         # Voxel selection from the seeding mask
         ind = which_seed % len_seeds
         x, y, z = self.seeds[indices[ind]]
 
         # Subvoxel initial positioning
-        r_x = random_generator.uniform(-half_voxel_range[0],
-                                       half_voxel_range[0])
-        r_y = random_generator.uniform(-half_voxel_range[1],
-                                       half_voxel_range[1])
-        r_z = random_generator.uniform(-half_voxel_range[2],
-                                       half_voxel_range[2])
+        r_x = random_generator.uniform(-half_voxel_dim[0], half_voxel_dim[0])
+        r_y = random_generator.uniform(-half_voxel_dim[1], half_voxel_dim[1])
+        r_z = random_generator.uniform(-half_voxel_dim[2], half_voxel_dim[2])
 
         return x * self.pixdim[0] + r_x, y * self.pixdim[1] \
             + r_y, z * self.pixdim[2] + r_z
 
-    def init_pos(self, random_initial_value, first_seed_of_chunk):
+    def init_generator(self, random_initial_value, first_seed_of_chunk):
         """
         Initialize numpy number generator according to user's parameter
         and indexes from the seeding map.

--- a/scilpy/tracking/tracker.py
+++ b/scilpy/tracking/tracker.py
@@ -75,6 +75,10 @@ class Tracker(object):
         self.track_forward_only = track_forward_only
         self.skip = skip
 
+        # Everything scilpy.tracking is in 'corner', 'voxmm'
+        self.origin = 'corner'
+        self.space = 'voxmm'
+
         if self.min_nbr_pts <= 0:
             logging.warning("Minimum number of points cannot be 0. Changed to "
                             "1.")
@@ -164,7 +168,6 @@ class Tracker(object):
         """
         global data_file_info
 
-        # args[0] is the Tracker.
         self.propagator.tracking_field.dataset.data = np.load(
             data_file_info[0], mmap_mode=data_file_info[1])
 
@@ -315,8 +318,10 @@ class Tracker(object):
             # Bound can be checked with mask or tracking field
             # (through self.propagator.is_voxmm_in_bound)
             propagation_can_continue = (
-                    self.mask.voxmm_to_value(*line[-1]) > 0 and
-                    self.mask.is_voxmm_in_bound(*line[-1], origin='corner'))
+                    self.mask.voxmm_to_value(*line[-1],
+                                             origin=self.origin) > 0 and
+                    self.mask.is_voxmm_in_bound(*line[-1],
+                                                origin=self.origin))
             last_dir = new_dir
 
         if propagation_can_continue:
@@ -328,7 +333,8 @@ class Tracker(object):
         # Last cleaning of the streamline
         # First position is the seed: necessarily in bound.
         while (len(line) > 1 and
-               not self.propagator.is_voxmm_in_bound(line[-1], 'corner')):
+               not self.propagator.is_voxmm_in_bound(line[-1],
+                                                     origin=self.origin)):
             line.pop()
 
         return line

--- a/scilpy/tracking/tracker.py
+++ b/scilpy/tracking/tracker.py
@@ -177,6 +177,25 @@ class Tracker(object):
             raise e
 
     def _get_streamlines(self, chunk_id):
+        """
+        Tracks the n streamlines associates with current process (identified by
+        chunk_id). The number n is the total number of seeds / the number of
+        processes. If asked by user, may compress the streamlines and save the
+        seeds.
+
+        Parameters
+        ----------
+        chunk_id: int
+            This process ID.
+
+        Returns
+        -------
+        streamlines: list
+            The successful streamlines.
+        seeds: list
+            The list of seeds for each streamline, if self.save_seeds. Else, an
+            empty list.
+        """
         streamlines = []
         seeds = []
 
@@ -310,7 +329,6 @@ class Tracker(object):
         # First position is the seed: necessarily in bound.
         while (len(line) > 1 and
                not self.propagator.is_voxmm_in_bound(line[-1], 'corner')):
-            # print("popping {}".format(line[-1]))
             line.pop()
 
         return line

--- a/scilpy/tracking/tracker.py
+++ b/scilpy/tracking/tracker.py
@@ -266,6 +266,10 @@ class Tracker(object):
 
             # Backward
             if not self.track_forward_only:
+                # Depending on the propagator, adding possibility to reset some
+                # parameters at this point.
+                self.propagator.start_backward()
+
                 backward = self._propagate_line(False)
                 if len(backward) > 0:
                     line.reverse()

--- a/scilpy/tracking/tracker.py
+++ b/scilpy/tracking/tracker.py
@@ -198,7 +198,6 @@ class Tracker(object):
             seed = self.seed_generator.get_next_pos(
                 random_generator, indices, first_seed_of_chunk + s)
             line = self._get_line_both_directions(seed)
-            #print("line {}: {}".format(s, line))
 
             if line is not None:
                 if self.compression_th and self.compression_th > 0:
@@ -227,6 +226,11 @@ class Tracker(object):
         -------
         line: list of 3D positions
         """
+
+        # toDo See numpy's doc: np.random.seed:
+        #  This is a convenience, legacy function.
+        #  The best practice is to not reseed a BitGenerator, rather to
+        #  recreate a new one. This method is here for legacy reasons.
         np.random.seed(np.uint32(hash((pos, self.rng_seed))))
         line = [pos]
 

--- a/scilpy/tracking/tracking_field.py
+++ b/scilpy/tracking/tracking_field.py
@@ -7,7 +7,105 @@ from scilpy.tracking.tools import sample_distribution
 from scilpy.tracking.utils import TrackingDirection
 
 
-class SphericalHarmonicField(object):
+class AbstractTrackingField(object):
+    """
+    Spherical harmonics tracking field.
+
+    Parameters
+    ----------
+    dataset: Any
+        Dataset object.
+    theta: float
+        Maximum angle (radians) between two steps.
+    dipy_sphere: string, optional
+        Name of the DIPY sphere object to use for evaluating SH.
+    """
+    def __init__(self, dataset, theta, dipy_sphere):
+        self.theta = theta
+        self.dataset = dataset
+
+        if 'symmetric' not in dipy_sphere:
+            raise ValueError('Sphere must be symmetric. Call to '
+                             'get_opposite_direction will fail.')
+        self.sphere = dipy.data.get_sphere(dipy_sphere)
+        self.dirs = np.zeros(len(self.sphere.vertices), dtype=np.ndarray)
+        for i in range(len(self.sphere.vertices)):
+            self.dirs[i] = TrackingDirection(self.sphere.vertices[i], i)
+        self.tracking_neighbours = self._get_sphere_neighbours(self.theta)
+
+    def _get_sphere_neighbours(self, max_angle):
+        """
+        Get a matrix of neighbours for each direction on the sphere, within
+        the min_separation_angle.
+
+        min_separation_angle: float
+            Maximum angle in radians defining the neighbourhood
+            of each direction.
+
+        Return
+        ------
+        neighbours: ndarray
+            Neighbour directions for each direction on the sphere.
+        """
+        xs = self.sphere.vertices[:, 0]
+        ys = self.sphere.vertices[:, 1]
+        zs = self.sphere.vertices[:, 2]
+        scalar_prods = np.outer(xs, xs) + np.outer(ys, ys) + np.outer(zs, zs)
+        neighbours = scalar_prods >= np.cos(max_angle)
+        return neighbours
+
+    def get_init_direction(self, pos):
+        """
+        Get a tuple with an initial direction to follow from position pos,
+        with the opposite direction.
+
+        Must be instantiated by each child class.
+
+        Parameters
+        ----------
+        pos: Any
+            Current position in the dataset.
+        """
+        raise NotImplementedError
+
+    def get_opposite_direction(self, ind):
+        """
+        Get the indice of the opposite direction on the sphere to the indice
+        ind.
+
+        Parameters
+        ----------
+        ind: int
+            Indice of sphere direction
+
+        Return
+        ------
+        value: int
+            Indice of opposite sphere direction.
+        """
+        return (len(self.dirs) // 2 + ind) % len(self.dirs)
+
+    def get_next_direction(self, pos, previous_direction, args=None):
+        """
+        Get next direction. Depends on the type of tracking field and probably
+        on some alorithm parameter choices.
+
+        Must be instantiated by each child class.
+
+        Parameters
+        ----------
+        pos: ndarray (3,)
+            Position in trackable dataset, expressed in mm.
+        previous_direction: TrackingDirection
+            Incoming direction. Outcoming direction won't be further than an
+            angle theta.
+        args: Any
+            Tracking options, influencing the way to choose the next direction.
+        """
+        raise NotImplementedError
+
+
+class SphericalHarmonicField(AbstractTrackingField):
     """
     Spherical harmonics tracking field.
 
@@ -35,51 +133,18 @@ class SphericalHarmonicField(object):
     def __init__(self, odf_dataset, basis, sf_threshold, sf_threshold_init,
                  theta, dipy_sphere='symmetric724',
                  min_separation_angle=np.pi / 16.):
+        super().__init__(odf_dataset, theta, dipy_sphere)
+
         self.sf_threshold = sf_threshold
         self.sf_threshold_init = sf_threshold_init
-        self.theta = theta
-
-        self.vertices = dipy.data.get_sphere(dipy_sphere).vertices
-        self.dirs = np.zeros(len(self.vertices), dtype=np.ndarray)
-        for i in range(len(self.vertices)):
-            self.dirs[i] = TrackingDirection(self.vertices[i], i)
-        self.maxima_neighbours = self._get_direction_neighbours(
-            min_separation_angle)
-        self.tracking_neighbours = self._get_direction_neighbours(self.theta)
-        self.dataset = odf_dataset
-        self.basis = basis
-
-        if 'symmetric' not in dipy_sphere:
-            raise ValueError('Sphere must be symmetric. Call to '
-                             'get_opposite_direction will fail.')
-
-        sphere = dipy.data.get_sphere(dipy_sphere)
         sh_order = order_from_ncoef(self.dataset.data.shape[-1])
-        self.B = sh_to_sf_matrix(sphere, sh_order, self.basis,
+        self.basis = basis
+        self.B = sh_to_sf_matrix(self.sphere, sh_order, self.basis,
                                  smooth=0.006, return_inv=False)
 
-    def _get_direction_neighbours(self, min_separation_angle):
-        """
-        Get a matrix of neighbours for each direction on the sphere, within
-        the min_separation_angle.
-
-        Parameters
-        ----------
-        min_separation_angle: float
-            Maximum angle in radians defining the neighbourhood
-            of each direction.
-
-        Return
-        ------
-        neighbours: ndarray
-            Neighbour directions for each direction on the sphere.
-        """
-        xs = self.vertices[:, 0]
-        ys = self.vertices[:, 1]
-        zs = self.vertices[:, 2]
-        scalar_prods = np.outer(xs, xs) + np.outer(ys, ys) + np.outer(zs, zs)
-        neighbours = scalar_prods >= np.cos(min_separation_angle)
-        return neighbours
+        # For deterministic tracking:
+        self.maxima_neighbours = self._get_sphere_neighbours(
+            min_separation_angle)
 
     def _get_sf(self, pos):
         """
@@ -92,7 +157,7 @@ class SphericalHarmonicField(object):
 
         Return
         ------
-        sf: ndarray (len(self.vertices),)
+        sf: ndarray (len(self.sphere.vertices),)
             Spherical function evaluated at pos, normalized by
             its maximum amplitude.
         """
@@ -104,17 +169,40 @@ class SphericalHarmonicField(object):
             sf = sf / sf_max
         return sf
 
-    def get_tracking_sf(self, pos, direction):
+    def get_next_direction(self, pos, previous_direction,
+                           tracking_choice='prob'):
         """
-        Get the spherical functions thresholded
-        at position pos, for a given direction.
+        Get the set of next possible directions, for a direction.
 
         Parameters
         ----------
         pos: ndarray (3,)
             Position in trackable dataset, expressed in mm.
-        direction: TrackingDirection
-            A given direction.
+        previous_direction: TrackingDirection
+            Incoming direction. Outcoming direction won't be further than an
+            angle theta.
+        tracking_choice: str
+            Either "prob" or "det"
+        """
+        if tracking_choice == 'prob':
+            # Getting direction from the SF
+            return self._get_next_dir_prob(pos, previous_direction)
+        if tracking_choice == 'det':
+            # Getting direction from the maxima
+            return self._get_next_dir_det(pos, previous_direction)
+
+    def _get_next_dir_prob(self, pos, previous_direction):
+        """
+        Get the spherical functions thresholded at position pos, for a given
+        direction.
+
+        Parameters
+        ----------
+        pos: ndarray (3,)
+            Position in trackable dataset, expressed in mm.
+        previous_direction: TrackingDirection
+            Incoming direction. Outcoming direction won't be further than an
+            angle theta.
 
         Return
         ------
@@ -124,10 +212,11 @@ class SphericalHarmonicField(object):
         """
         sf = self._get_sf(pos)
         sf[sf < self.sf_threshold] = 0
-        inds = np.nonzero(self.tracking_neighbours[direction.index])[0]
+        inds = np.nonzero(
+            self.tracking_neighbours[previous_direction.index])[0]
         return sf[inds], self.dirs[inds]
 
-    def get_tracking_maxima(self, pos, direction):
+    def _get_next_dir_det(self, pos, previous_direction):
         """
         Get the set of maxima directions from the thresholded
         SF at position pos, for a direction.
@@ -136,8 +225,9 @@ class SphericalHarmonicField(object):
         ----------
         pos: ndarray (3,)
             Position in trackable dataset, expressed in mm.
-        direction: TrackingDirection
-            A given direction.
+        previous_direction: TrackingDirection
+            Incoming direction. Outcoming direction won't be further than an
+            angle theta.
 
         Return
         ------
@@ -147,7 +237,8 @@ class SphericalHarmonicField(object):
         sf = self._get_sf(pos)
         sf[sf < self.sf_threshold] = 0
         maxima = []
-        for i in np.nonzero(self.tracking_neighbours[direction.index])[0]:
+        for i in np.nonzero(self.tracking_neighbours[
+                                previous_direction.index])[0]:
             if 0 < sf[i] == np.max(sf[self.maxima_neighbours[i]]):
                 maxima.append(self.dirs[i])
         return maxima
@@ -160,7 +251,7 @@ class SphericalHarmonicField(object):
         Parameters
         ----------
         pos: ndarray (3,)
-            Position in trackable dataset, expressed in mm.
+            Position in the dataset, expressed in mm.
 
         Return
         ------
@@ -175,20 +266,3 @@ class SphericalHarmonicField(object):
             ind_opposite = self.get_opposite_direction(ind)
             return self.dirs[ind], self.dirs[ind_opposite]
         return None, None
-
-    def get_opposite_direction(self, ind):
-        """
-        Get the indice of the opposite direction on the sphere
-        to the indice ind.
-
-        Parameters
-        ----------
-        ind: int
-            Indice of sphere direction
-
-        Return
-        ------
-        value: int
-            Indice of opposite sphere direction.
-        """
-        return (len(self.dirs) // 2 + ind) % len(self.dirs)

--- a/scilpy/tracking/tracking_field.py
+++ b/scilpy/tracking/tracking_field.py
@@ -168,7 +168,7 @@ class SphericalHarmonicField(AbstractTrackingField):
             Spherical function evaluated at pos, normalized by
             its maximum amplitude.
         """
-        sh = self.dataset.get_position_value(*pos)
+        sh = self.dataset.voxmm_to_value(*pos)
         sf = np.dot(self.B.T, sh).reshape((-1, 1))
 
         sf_max = np.max(sf)

--- a/scilpy/tracking/tracking_field.py
+++ b/scilpy/tracking/tracking_field.py
@@ -119,9 +119,9 @@ class AbstractTrackingField(object):
         return (len(self.dirs) // 2 + ind) % len(self.dirs)
 
 
-class SphericalHarmonicField(AbstractTrackingField):
+class ODFField(AbstractTrackingField):
     """
-    Spherical harmonics tracking field.
+    ODF (Spherical harmonics) tracking field.
 
     Parameters
     ----------

--- a/scilpy/tracking/tracking_field.py
+++ b/scilpy/tracking/tracking_field.py
@@ -30,6 +30,10 @@ class AbstractTrackingField(object):
         self.theta = theta
         self.dataset = dataset
 
+        # Everything scilpy.tracking is in 'corner', 'voxmm'
+        self.origin = 'corner'
+        self.space = 'voxmm'
+
         if dipy_sphere:
             if 'symmetric' not in dipy_sphere:
                 raise ValueError('Sphere must be symmetric. Call to '
@@ -175,7 +179,7 @@ class ODFField(AbstractTrackingField):
         Parameters
         ----------
         pos: ndarray (3,)
-            Position in mm in the trackable dataset.
+            Position in voxmm in the trackable dataset.
 
         Return
         ------
@@ -183,7 +187,7 @@ class ODFField(AbstractTrackingField):
             Spherical function evaluated at pos, normalized by
             its maximum amplitude.
         """
-        sh = self.dataset.voxmm_to_value(*pos)
+        sh = self.dataset.voxmm_to_value(*pos, self.origin)
         sf = np.dot(self.B.T, sh).reshape((-1, 1))
 
         sf_max = np.max(sf)

--- a/scilpy/tracking/tracking_field.py
+++ b/scilpy/tracking/tracking_field.py
@@ -11,7 +11,9 @@ from scilpy.tracking.utils import TrackingDirection
 
 class AbstractTrackingField(object):
     """
-    Spherical harmonics tracking field.
+    Abstract tracking field. The class is used to get directions from the
+    dataset (ex, peaks, ODF, fODF, machine learning models), and returns only
+    the subset of possible directions that are inside a cone of angle theta.
 
     Parameters
     ----------
@@ -113,7 +115,7 @@ class AbstractTrackingField(object):
         Parameters
         ----------
         ind: int
-            Indice of sphere direction
+            Indice of sphere direction.
 
         Return
         ------

--- a/scilpy/tracking/utils.py
+++ b/scilpy/tracking/utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from scilpy.io.utils import add_sh_basis_args
+from scilpy.io.utils import add_sh_basis_args, add_overwrite_arg
 
 
 class TrackingDirection(list):
@@ -15,7 +15,7 @@ class TrackingDirection(list):
 
 def add_mandatory_options_tracking(p):
     p.add_argument('in_sh',
-                   help='Spherical harmonic file (.nii.gz).')
+                   help='Spherical harmonic file (.nii.gz). Ex: ODF or fODF.')
     p.add_argument('in_seed',
                    help='Seeding mask (.nii.gz).')
     p.add_argument('in_mask',
@@ -61,6 +61,23 @@ def add_seeding_options(p):
                                     help='Number of seeds per voxel.')
     seed_sub_exclusive.add_argument('--nt', type=int,
                                     help='Total number of seeds to use.')
+
+
+def add_out_options(p):
+    out_g = p.add_argument_group('  Output options')
+    out_g.add_argument('--compress', type=float, metavar='thresh',
+                       help='If set, will compress streamlines. The parameter '
+                            'value is the \ndistance threshold. A rule of '
+                            'thumb is to set it to 0.1mm for \ndeterministic '
+                            'streamlines and 0.2mm for probabilitic '
+                            'streamlines.')
+    add_overwrite_arg(out_g)
+    out_g.add_argument('--save_seeds', action='store_true',
+                       help='If set, save the seeds used for the tracking \n '
+                            'in the data_per_streamline property.\n'
+                            'Hint: you can then use '
+                            'scilpy_compute_seed_density_map.')
+    return out_g
 
 
 def verify_streamline_length_options(parser, args):

--- a/scilpy/tracking/utils.py
+++ b/scilpy/tracking/utils.py
@@ -11,32 +11,3 @@ class TrackingDirection(list):
     def __init__(self, cartesian, index=None):
         super(TrackingDirection, self).__init__(cartesian)
         self.index = index
-
-
-class TrackingParams(object):
-    """
-    Container for tracking parameters.
-    """
-    def __init__(self):
-        self.random = None
-        self.skip = None
-        self.algo = None
-        self.mask_interp = None
-        self.field_interp = None
-        self.theta = None
-        self.sf_threshold = None
-        self.sf_threshold_init = None
-        self.step_size = None
-        self.rk_order = None
-        self.max_length = None
-        self.min_length = None
-        self.max_nbr_pts = None
-        self.min_nbr_pts = None
-        self.is_single_direction = None
-        self.nbr_seeds = None
-        self.nbr_seeds_voxel = None
-        self.nbr_streamlines = None
-        self.max_no_dir = None
-        self.is_all = None
-        self.is_keep_single_pts = None
-        self.mmap_mode = None

--- a/scilpy/tracking/utils.py
+++ b/scilpy/tracking/utils.py
@@ -14,8 +14,10 @@ class TrackingDirection(list):
 
 
 def add_mandatory_options_tracking(p):
-    p.add_argument('in_sh',
-                   help='Spherical harmonic file (.nii.gz). Ex: ODF or fODF.')
+    p.add_argument('in_odf',
+                   help='File containing the orientation diffusion function \n'
+                        'as spherical harmonics file (.nii.gz). Ex: ODF or '
+                        'fODF.')
     p.add_argument('in_seed',
                    help='Seeding mask (.nii.gz).')
     p.add_argument('in_mask',

--- a/scilpy/tracking/utils.py
+++ b/scilpy/tracking/utils.py
@@ -28,10 +28,7 @@ def add_mandatory_options_tracking(p):
 
 
 def add_tracking_options(p):
-    track_g = p.add_argument_group('  Tracking options')
-    track_g.add_argument('--algo', default='prob',
-                         choices=['det', 'prob', 'eudx'],
-                         help='Algorithm to use [%(default)s]')
+    track_g = p.add_argument_group('Tracking options')
     track_g.add_argument('--step', dest='step_size', type=float, default=0.5,
                          help='Step size in mm. [%(default)s]')
     track_g.add_argument('--min_length', type=float, default=10.,
@@ -56,8 +53,7 @@ def add_tracking_options(p):
 
 def add_seeding_options(p):
     seed_group = p.add_argument_group(
-        '  Seeding options',
-        'When no option is provided, uses --npv 1.')
+        'Seeding options', 'When no option is provided, uses --npv 1.')
     seed_sub_exclusive = seed_group.add_mutually_exclusive_group()
     seed_sub_exclusive.add_argument('--npv', type=int,
                                     help='Number of seeds per voxel.')
@@ -66,7 +62,7 @@ def add_seeding_options(p):
 
 
 def add_out_options(p):
-    out_g = p.add_argument_group('  Output options')
+    out_g = p.add_argument_group('Output options')
     out_g.add_argument('--compress', type=float, metavar='thresh',
                        help='If set, will compress streamlines. The parameter '
                             'value is the \ndistance threshold. A rule of '

--- a/scilpy/tracking/utils.py
+++ b/scilpy/tracking/utils.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
+from scilpy.io.utils import add_sh_basis_args
 
 
 class TrackingDirection(list):
-
     """
     Tracking direction use as 3D cartesian direction (list(x,y,z))
     and has an index to work with discrete sphere.
@@ -11,3 +11,70 @@ class TrackingDirection(list):
     def __init__(self, cartesian, index=None):
         super(TrackingDirection, self).__init__(cartesian)
         self.index = index
+
+
+def add_mandatory_options_tracking(p):
+    p.add_argument('in_sh',
+                   help='Spherical harmonic file (.nii.gz).')
+    p.add_argument('in_seed',
+                   help='Seeding mask (.nii.gz).')
+    p.add_argument('in_mask',
+                   help='Tracking mask (.nii.gz).\n'
+                        'Tracking will stop outside this mask.')
+    p.add_argument('out_tractogram',
+                   help='Tractogram output file (must be .trk or .tck).')
+
+
+def add_tracking_options(p):
+    track_g = p.add_argument_group('  Tracking options')
+    track_g.add_argument('--algo', default='prob',
+                         choices=['det', 'prob', 'eudx'],
+                         help='Algorithm to use [%(default)s]')
+    track_g.add_argument('--step', dest='step_size', type=float, default=0.5,
+                         help='Step size in mm. [%(default)s]')
+    track_g.add_argument('--min_length', type=float, default=10.,
+                         metavar='m',
+                         help='Minimum length of a streamline in mm. '
+                              '[%(default)s]')
+    track_g.add_argument('--max_length', type=float, default=300.,
+                         metavar='M',
+                         help='Maximum length of a streamline in mm. '
+                              '[%(default)s]')
+    track_g.add_argument('--theta', type=float,
+                         help='Maximum angle between 2 steps.\n'
+                              '["eudx"=60, "det"=45, "prob"=20]')
+    track_g.add_argument('--sfthres', dest='sf_threshold', metavar='sf_th',
+                         type=float, default=0.1,
+                         help='Spherical function relative threshold. '
+                              '[%(default)s]')
+    add_sh_basis_args(track_g)
+
+    return track_g
+
+
+def add_seeding_options(p):
+    seed_group = p.add_argument_group(
+        '  Seeding options',
+        'When no option is provided, uses --npv 1.')
+    seed_sub_exclusive = seed_group.add_mutually_exclusive_group()
+    seed_sub_exclusive.add_argument('--npv', type=int,
+                                    help='Number of seeds per voxel.')
+    seed_sub_exclusive.add_argument('--nt', type=int,
+                                    help='Total number of seeds to use.')
+
+
+def verify_streamline_length_options(parser, args):
+    if not args.min_length > 0:
+        parser.error('min_length must be > 0, {}mm was provided.'
+                     .format(args.min_length))
+    if args.max_length < args.min_length:
+        parser.error('max_length must be > than minL, but minL={}mm and '
+                     'maxL={}mm.'.format(args.min_length, args.max_length))
+
+
+def verify_seed_options(parser, args):
+    if args.npv and args.npv <= 0:
+        parser.error('Number of seeds per voxel must be > 0.')
+
+    if args.nt and args.nt <= 0:
+        parser.error('Total number of seeds must be > 0.')

--- a/scripts/scil_compute_local_tracking.py
+++ b/scripts/scil_compute_local_tracking.py
@@ -59,6 +59,9 @@ def _build_arg_parser():
     add_mandatory_options_tracking(p)
 
     track_g = add_tracking_options(p)
+    track_g.add_argument('--algo', default='prob',
+                         choices=['det', 'prob', 'eudx'],
+                         help='Algorithm to use [%(default)s]')
     add_sphere_arg(track_g, symmetric_only=True)
 
     add_seeding_options(p)

--- a/scripts/scil_compute_local_tracking.py
+++ b/scripts/scil_compute_local_tracking.py
@@ -13,9 +13,6 @@ to the previous direction.
 Algo 'prob': a direction drawn from the empirical distribution function defined
 from the SF.
 
-For streamline compression, a rule of thumb is to set it to 0.1mm for the
-deterministic algorithm and 0.2mm for probabilitic algorithm.
-
 NOTE: eudx can be used with pre-computed peaks from fodf as well as
 evecs_v1.nii.gz from scil_compute_dti_metrics.py (experimental).
 
@@ -43,12 +40,13 @@ import numpy as np
 from scilpy.reconst.utils import (find_order_from_nb_coeff,
                                   get_b_matrix, get_maximas)
 from scilpy.io.image import get_data_as_mask
-from scilpy.io.utils import (add_overwrite_arg, add_sphere_arg,
-                             add_verbose_arg, assert_inputs_exist,
-                             assert_outputs_exist, verify_compression_th)
+from scilpy.io.utils import (add_sphere_arg, add_verbose_arg,
+                             assert_inputs_exist, assert_outputs_exist,
+                             verify_compression_th)
 from scilpy.tracking.tools import get_theta
 from scilpy.tracking.utils import (add_mandatory_options_tracking,
-                                   add_seeding_options, add_tracking_options,
+                                   add_out_options, add_seeding_options,
+                                   add_tracking_options,
                                    verify_streamline_length_options,
                                    verify_seed_options)
 
@@ -64,18 +62,10 @@ def _build_arg_parser():
     add_sphere_arg(track_g, symmetric_only=True)
 
     add_seeding_options(p)
+    out_g = add_out_options(p)
 
-    out_g = p.add_argument_group('  Output options')
-    out_g.add_argument('--compress', type=float,
-                       help='If set, will compress streamlines.\n'
-                            'The parameter value is the distance threshold.')
     out_g.add_argument('--seed', type=int,
                        help='Random number generator seed.')
-    add_overwrite_arg(out_g)
-
-    out_g.add_argument('--save_seeds', action='store_true',
-                       help='If set, save the seeds used for the tracking \n '
-                            'in the data_per_streamline property.')
 
     log_g = p.add_argument_group('Logging options')
     add_verbose_arg(log_g)

--- a/scripts/scil_compute_local_tracking_2.py
+++ b/scripts/scil_compute_local_tracking_2.py
@@ -46,9 +46,9 @@ from scilpy.image.datasets import DataVolume
 from scilpy.tracking.seed import SeedGenerator
 
 from scilpy.tracking.tracker import Tracker
-from scilpy.tracking.propagator import (ProbabilisticSHPropagator,
-                                        DeterministicMaximaSHPropagator)
-from scilpy.tracking.tracking_field import SphericalHarmonicField
+from scilpy.tracking.propagator import (ProbabilisticODFPropagator,
+                                        DeterministicODFPropagator)
+from scilpy.tracking.tracking_field import ODFField
 from scilpy.tracking.tools import get_theta
 from scilpy.tracking.utils import (add_mandatory_options_tracking,
                                    add_out_options, add_seeding_options,
@@ -175,18 +175,18 @@ def main():
     logging.debug("Loading SH data.")
     fodf_sh_img = nib.load(args.in_sh)
     dataset = DataVolume(fodf_sh_img, args.sh_interp)
-    sh_field = SphericalHarmonicField(dataset, args.sh_basis,
-                                      args.sf_threshold,
-                                      args.sf_threshold_init, theta,
-                                      dipy_sphere=args.sphere)
+    sh_field = ODFField(dataset, args.sh_basis,
+                        args.sf_threshold,
+                        args.sf_threshold_init, theta,
+                        dipy_sphere=args.sphere)
 
     logging.debug("Instantiating tracker.")
     if args.algo == 'det':
-        propagator = DeterministicMaximaSHPropagator(sh_field, args.step_size,
-                                                     args.rk_order)
+        propagator = DeterministicODFPropagator(sh_field, args.step_size,
+                                                args.rk_order)
     else:
-        propagator = ProbabilisticSHPropagator(sh_field, args.step_size,
-                                               args.rk_order)
+        propagator = ProbabilisticODFPropagator(sh_field, args.step_size,
+                                                args.rk_order)
 
     tracker = Tracker(propagator, mask, seed_generator, nbr_seeds, min_nbr_pts,
                       max_nbr_pts, max_invalid_dirs, args.compress,

--- a/scripts/scil_compute_local_tracking_2.py
+++ b/scripts/scil_compute_local_tracking_2.py
@@ -132,7 +132,7 @@ def main():
         parser.error('Invalid output streamline file format (must be trk or ' +
                      'tck): {0}'.format(args.out_tractogram))
 
-    inputs = [args.in_sh, args.in_seed, args.in_mask]
+    inputs = [args.in_odf, args.in_seed, args.in_mask]
     assert_inputs_exist(parser, inputs)
     assert_outputs_exist(parser, args, args.out_tractogram)
 
@@ -172,20 +172,19 @@ def main():
         parser.error('Seed mask "{}" does not have any voxel with value > 0.'
                      .format(args.in_seed))
 
-    logging.debug("Loading SH data.")
-    fodf_sh_img = nib.load(args.in_sh)
-    dataset = DataVolume(fodf_sh_img, args.sh_interp)
-    sh_field = ODFField(dataset, args.sh_basis,
-                        args.sf_threshold,
-                        args.sf_threshold_init, theta,
-                        dipy_sphere=args.sphere)
+    logging.debug("Loading ODF SH data.")
+    odf_sh_img = nib.load(args.in_odf)
+    dataset = DataVolume(odf_sh_img, args.sh_interp)
+    odf_field = ODFField(dataset, args.sh_basis, args.sf_threshold,
+                         args.sf_threshold_init, theta,
+                         dipy_sphere=args.sphere)
 
     logging.debug("Instantiating tracker.")
     if args.algo == 'det':
-        propagator = DeterministicODFPropagator(sh_field, args.step_size,
+        propagator = DeterministicODFPropagator(odf_field, args.step_size,
                                                 args.rk_order)
     else:
-        propagator = ProbabilisticODFPropagator(sh_field, args.step_size,
+        propagator = ProbabilisticODFPropagator(odf_field, args.step_size,
                                                 args.rk_order)
 
     tracker = Tracker(propagator, mask, seed_generator, nbr_seeds, min_nbr_pts,

--- a/scripts/scil_compute_local_tracking_2.py
+++ b/scripts/scil_compute_local_tracking_2.py
@@ -156,11 +156,15 @@ def main():
 
     logging.debug("Loading tracking mask.")
     mask_img = nib.load(args.in_mask)
-    mask = DataVolume(mask_img, args.mask_interp)
+    mask_data = mask_img.get_fdata(caching='unchanged', dtype=float)
+    mask_res = mask_img.header.get_zooms()[:3]
+    mask = DataVolume(mask_data, mask_res, args.mask_interp)
 
     logging.debug("Loading seeding mask.")
     seed_img = nib.load(args.in_seed)
-    seed_generator = SeedGenerator(seed_img)
+    seed_data = seed_img.get_fdata(caching='unchanged', dtype=float)
+    seed_res = seed_img.header.get_zooms()[:3]
+    seed_generator = SeedGenerator(seed_data, seed_res)
     if args.npv:
         nbr_seeds = len(seed_generator.seeds) * args.npv
     elif args.nt:

--- a/scripts/scil_compute_local_tracking_dev.py
+++ b/scripts/scil_compute_local_tracking_dev.py
@@ -98,7 +98,7 @@ def _build_arg_parser():
     add_seeding_options(p)
 
     r_g = p.add_argument_group('Random seeding options')
-    r_g.add_argument('--rng_seed', type=int,
+    r_g.add_argument('--rng_seed', type=int, default=0,
                      help='Initial value for the random number generator. '
                           '[%(default)s]')
     r_g.add_argument('--skip', type=int, default=0,

--- a/scripts/scil_compute_local_tracking_dev.py
+++ b/scripts/scil_compute_local_tracking_dev.py
@@ -156,6 +156,8 @@ def main():
     seed_res = seed_img.header.get_zooms()[:3]
     seed_generator = SeedGenerator(seed_data, seed_res)
     if args.npv:
+        # toDo. This will not really produce n seeds per voxel, only true
+        #  in average.
         nbr_seeds = len(seed_generator.seeds) * args.npv
     elif args.nt:
         nbr_seeds = args.nt

--- a/scripts/tests/test_compute_local_tracking_dev.py
+++ b/scripts/tests/test_compute_local_tracking_dev.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import os
+import tempfile
+
+from scilpy.io.fetcher import get_testing_files_dict, fetch_data, get_home
+
+
+# If they already exist, this only takes 5 seconds (check md5sum)
+fetch_data(get_testing_files_dict(), keys=['tracking.zip'])
+tmp_dir = tempfile.TemporaryDirectory()
+
+
+def test_help_option(script_runner):
+    ret = script_runner.run('scil_compute_local_tracking_dev.py',
+                            '--help')
+    assert ret.success
+
+
+def test_execution_tracking_fodf(script_runner):
+    os.chdir(os.path.expanduser(tmp_dir.name))
+    in_fodf = os.path.join(get_home(), 'tracking',
+                           'fodf.nii.gz')
+    in_mask = os.path.join(get_home(), 'tracking',
+                           'seeding_mask.nii.gz')
+    ret = script_runner.run('scil_compute_local_tracking_dev.py', in_fodf,
+                            in_mask, in_mask, 'local_prob.trk', '--nt', '1000',
+                            '--compress', '0.1', '--sh_basis', 'descoteaux07',
+                            '--min_length', '20', '--max_length', '200')
+    assert ret.success


### PR DESCRIPTION
**Bigger changes:** 

- **Merging the tracker and the propagator** into propagator to avoid circular reference. Old file tracker.py (containing the two classes) becomes propagator.py
- Adding a main **script** scil_compute_local_tracking_2.py (other names suggested?)
- New "Tracker" class
    - Englobes the track() function that was previously alone in local_tracking.py. This will allow creating a child version in dwi_ml.     File renamed tracker.py
    - Now the main script is: 1) Initialize the tracker. 2)  Tracker.track(). 
    - So to be clear, this new "Tracker" is absolutely not the same as the old, it is one step above. See new diagram:

https://docs.google.com/presentation/d/1mvvBYjKZ-IVmkl1EYWBTQ_8T8H0R3_Y-/edit?usp=sharing&ouid=101323301275554058305&rtpof=true&sd=true 

**Smaller changes:** 

- Encapsulating parts in the scil_compute_local_tracking that are common in scilpy.tracking.utils
    - Similiar to functions like add_processes_arg in scilpy.io.utils.
    - It makes the proof-reading a bit less natural but at least the args are the same in both scripts. Do we like that? Separated in a few sub-functions so I can use only some of them in dwi_ml. If we prefer, I can copy all of this back into each script.
- Now the seedGenerator and DataVolume take receive the data instead of the img. In dwi_ml, we have the data and affine, not the image, it would be a little weird to create the image back just to re-divide it.
- In the DataVolume: renaming methods as in the SFT nomenclature. Ex: using "voxmm"  instead of "position", to clarify. Adding "origin" option (center or corner)
- AbstractTrackingField created above the ODFTrackingField.
