### PR TITLE
Bug fix for fake metadata in streamlines math

### DIFF
--- a/scilpy/utils/streamlines.py
+++ b/scilpy/utils/streamlines.py
@@ -332,8 +332,8 @@ def concatenate_sft(sft_list, erase_metadata=False, metadata_fake_init=False):
 
             for dps_key in sft_list[0].data_per_streamline.keys():
                 if dps_key not in sft.data_per_streamline:
-                    arr_shape = sft_list[0].data_per_streamline[dps_key].shape
-                    arr_shape[0] = len(sft)
+                    arr_shape = (len(sft),) +\
+                        sft_list[0].data_per_streamline[dps_key].shape[1:]
                     sft.data_per_streamline[dps_key] = np.zeros(arr_shape)
             for dpp_key in sft_list[0].data_per_point.keys():
                 if dpp_key not in sft.data_per_point:

--- a/scilpy/utils/streamlines.py
+++ b/scilpy/utils/streamlines.py
@@ -332,8 +332,9 @@ def concatenate_sft(sft_list, erase_metadata=False, metadata_fake_init=False):
 
             for dps_key in sft_list[0].data_per_streamline.keys():
                 if dps_key not in sft.data_per_streamline:
-                    arr_shape = (len(sft),) +\
-                        sft_list[0].data_per_streamline[dps_key].shape[1:]
+                    arr_shape =\
+                        list(sft_list[0].data_per_streamline[dps_key].shape)
+                    arr_shape[0] = len(sft)
                     sft.data_per_streamline[dps_key] = np.zeros(arr_shape)
             for dpp_key in sft_list[0].data_per_point.keys():
                 if dpp_key not in sft.data_per_point:


### PR DESCRIPTION
When using dummy metadata with `scil_streamlines_math.py` I get an error because it tries to modify a `tuple` object.
This should fix the issue.

I'll test more extensively soon and then I'll remove the WIP.