### PR TITLE
ENH: Remove unused default process count parameter

### DIFF
--- a/scilpy/io/utils.py
+++ b/scilpy/io/utils.py
@@ -206,9 +206,12 @@ def add_sh_basis_args(parser, mandatory=False):
                         help=help_msg)
 
 
-def validate_nbr_processes(parser, args, default_nbr_cpu=None):
+def validate_nbr_processes(parser, args):
     """ Check if the passed number of processes arg is valid.
-    If not valid (0 < nbr_cpu_to_use <= cpu_count), raise parser.error.
+    Valid values are considered to be in the [0, CPU count] range:
+        - Raises a parser.error if an invalid value is provided.
+        - Returns the maximum number of cores retrieved if no value (or a value
+        of 0) is provided.
 
     Parameters
     ----------
@@ -216,12 +219,10 @@ def validate_nbr_processes(parser, args, default_nbr_cpu=None):
         Parser as created by argparse.
     args: argparse namespace
         Args as created by argparse.
-    default_nbr_cpu: int (or None)
-        Number of cpu to use, default is cpu_count (all).
 
-    Results
-    ------
-    nbr_cpu
+    Returns
+    -------
+    nbr_cpu: int
         The number of CPU to be used.
     """
 
@@ -230,7 +231,7 @@ def validate_nbr_processes(parser, args, default_nbr_cpu=None):
     else:
         nbr_cpu = multiprocessing.cpu_count()
 
-    if nbr_cpu <= 0:
+    if nbr_cpu < 0:
         parser.error('Number of processes must be > 0.')
     elif nbr_cpu > multiprocessing.cpu_count():
         parser.error('Max number of processes is {}. Got {}.'.format(

--- a/scripts/scil_compute_connectivity.py
+++ b/scripts/scil_compute_connectivity.py
@@ -369,7 +369,7 @@ def main():
     if not args.no_self_connection:
         comb_list.extend(zip(labels_list, labels_list))
 
-    nbr_cpu = validate_nbr_processes(parser, args, args.nbr_processes)
+    nbr_cpu = validate_nbr_processes(parser, args)
     measures_dict_list = []
     if nbr_cpu == 1:
         for comb in comb_list:

--- a/scripts/scil_compute_hdf5_average_density_map.py
+++ b/scripts/scil_compute_hdf5_average_density_map.py
@@ -101,7 +101,7 @@ def main():
             keys.extend(curr_file.keys())
 
     keys = set(keys)
-    nbr_cpu = validate_nbr_processes(parser, args, args.nbr_processes)
+    nbr_cpu = validate_nbr_processes(parser, args)
     if nbr_cpu == 1:
         for key in keys:
             _average_wrapper([args.in_hdf5, key, args.binary, args.out_dir])

--- a/scripts/scil_compute_mean_fixel_afd_from_hdf5.py
+++ b/scripts/scil_compute_mean_fixel_afd_from_hdf5.py
@@ -96,7 +96,7 @@ def main():
     assert_inputs_exist(parser, [args.in_hdf5, args.in_fodf])
     assert_outputs_exist(parser, args, [args.out_hdf5])
 
-    nbr_cpu = validate_nbr_processes(parser, args, args.nbr_processes)
+    nbr_cpu = validate_nbr_processes(parser, args)
 
     # HDF5 will not overwrite the file
     if os.path.isfile(args.out_hdf5):

--- a/scripts/scil_remove_similar_streamlines.py
+++ b/scripts/scil_remove_similar_streamlines.py
@@ -111,12 +111,12 @@ def main():
     original_length = len(streamlines)
     logging.debug('Loaded {} streamlines...'.format(original_length))
 
-    nbr_cpu = validate_nbr_processes(parser, args, args.nbr_processes)
+    nbr_cpu = validate_nbr_processes(parser, args)
     pool = multiprocessing.Pool(nbr_cpu)
     timer = time()
 
     logging.debug(
-        'Lauching subsampling on {} processes.'.format(args.nbr_processes))
+        'Lauching subsampling on {} processes.'.format(nbr_cpu))
     last_iteration = False
     iter_count = 0
     while True:


### PR DESCRIPTION
Remove unused default process count parameter from the process count
validation method.

Take advantage of the commit to:
- Document the method behavior if the process count is not contained in
the arguments.
- Fix the returned value docstring.
- Fix the logged process count in script.