### PR TITLE
Add option to scale SF by the b0 in scil_compute_sf_from_sh.py

### DIFF
--- a/scripts/scil_compute_sf_from_sh.py
+++ b/scripts/scil_compute_sf_from_sh.py
@@ -144,7 +144,8 @@ def main():
 
         # Scale SF by b0
         if args.b0_scaling:
-            sf = sf * data_b0
+            scale_b0 = np.mean(data_b0, axis=-1, keepdims=True)
+            sf = sf * scale_b0
 
         # Append b0 images to SF
         sf = np.concatenate((data_b0, sf), axis=-1)

--- a/scripts/scil_compute_sf_from_sh.py
+++ b/scripts/scil_compute_sf_from_sh.py
@@ -61,6 +61,9 @@ def _build_arg_parser():
     p.add_argument('--out_bvec',
                    help="Optional output bvec file.")
 
+    p.add_argument('--b0_scaling', action="store_true",
+                   help="Scale resulting SF by the b0 image.")
+
     add_sh_basis_args(p)
     p.add_argument('--full_basis', action="store_true",
                    help="If true, use a full basis for the input SH "
@@ -87,6 +90,9 @@ def main():
             args.out_bval and not args.in_bval):
         parser.error("--out_bval is required if --in_bval is provided, "
                      "and vice-versa.")
+
+    if args.b0_scaling and not args.in_b0:
+            parser.error("--in_b0 is required when using --b0_scaling.")
 
     nbr_processes = validate_nbr_processes(parser, args)
 
@@ -135,6 +141,10 @@ def main():
         # Append zeros to bvecs
         new_bvecs = np.concatenate(
             (np.zeros((data_b0.shape[-1], 3)), new_bvecs), axis=0)
+
+        # Scale SF by b0
+        if args.b0_scaling:
+            sf = sf * data_b0
 
         # Append b0 images to SF
         sf = np.concatenate((data_b0, sf), axis=-1)

--- a/scripts/scil_compute_sf_from_sh.py
+++ b/scripts/scil_compute_sf_from_sh.py
@@ -19,7 +19,6 @@ from dipy.core.sphere import Sphere
 from dipy.data import SPHERE_FILES, get_sphere
 from dipy.io import read_bvals_bvecs
 
-from scilpy.image.operations import lower_clip, upper_clip
 from scilpy.io.utils import (add_force_b0_arg, add_overwrite_arg,
                              add_processes_arg, add_sh_basis_args,
                              assert_inputs_exist,

--- a/scripts/scil_compute_sf_from_sh.py
+++ b/scripts/scil_compute_sf_from_sh.py
@@ -19,6 +19,7 @@ from dipy.core.sphere import Sphere
 from dipy.data import SPHERE_FILES, get_sphere
 from dipy.io import read_bvals_bvecs
 
+from scilpy.image.operations import lower_clip, upper_clip
 from scilpy.io.utils import (add_force_b0_arg, add_overwrite_arg,
                              add_processes_arg, add_sh_basis_args,
                              assert_inputs_exist,
@@ -153,6 +154,8 @@ def main():
 
         # Scale SF by b0
         if args.b0_scaling:
+            # Clip SF signal between 0. and 1., then scale using mean b0
+            sf = np.clip(sf, 0., 1.)
             scale_b0 = np.mean(data_b0, axis=-1, keepdims=True)
             sf = sf * scale_b0
 


### PR DESCRIPTION
Add option to scale SF by the given b0, to be symmetrical with `scil_compute_sh_from_signal.py` when using `--use_attenuation`
- Requires a b0 to be given as input
- Fixes a bug where bvecs corresponding to b0 images are not removed before building the sphere, causing additional bvecs to be created when normalizing the "b0-bvecs"