### PR TITLE
Bug fix: Multi-tissue fODF convergence error

### DIFF
--- a/scripts/scil_compute_msmt_fodf.py
+++ b/scripts/scil_compute_msmt_fodf.py
@@ -39,7 +39,7 @@ from scilpy.utils.bvec_bval_tools import (check_b0_threshold, normalize_bvecs,
 def _build_arg_parser():
 
     p = argparse.ArgumentParser(description=__doc__,
-                                formatter_class=argparse.RawDescriptionHelpFormatter)
+                                formatter_class=argparse.RawTextHelpFormatter)
 
     p.add_argument('in_dwi',
                    help='Path of the input diffusion volume.')
@@ -188,7 +188,7 @@ def main():
         to it. Proceeding to fill the problematic voxels by 0.
         """
         logging.warning(msg.format(nan_count, voxel_count))
-    elif nan_count  > 0:
+    elif nan_count > 0:
         msg = """There are {} voxels out of {} that could not be solved by
         the solver. Make sure to tune the response functions properly, as the
         solving process is very sensitive to it. Proceeding to fill the
@@ -203,7 +203,7 @@ def main():
         wm_coeff = shm_coeff[..., 2:]
         if args.sh_basis == 'tournier07':
             wm_coeff = convert_sh_basis(wm_coeff, reg_sphere, mask=mask,
-                                         nbr_processes=args.nbr_processes)
+                                        nbr_processes=args.nbr_processes)
         nib.save(nib.Nifti1Image(wm_coeff.astype(np.float32),
                                  vol.affine), args.wm_out_fODF)
 
@@ -212,7 +212,7 @@ def main():
         if args.sh_basis == 'tournier07':
             gm_coeff = gm_coeff.reshape(gm_coeff.shape + (1,))
             gm_coeff = convert_sh_basis(gm_coeff, reg_sphere, mask=mask,
-                                         nbr_processes=args.nbr_processes)
+                                        nbr_processes=args.nbr_processes)
         nib.save(nib.Nifti1Image(gm_coeff.astype(np.float32),
                                  vol.affine), args.gm_out_fODF)
 

--- a/scripts/tests/test_compute_msmt_fodf.py
+++ b/scripts/tests/test_compute_msmt_fodf.py
@@ -17,25 +17,21 @@ def test_help_option(script_runner):
 
 def test_execution_processing(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
-    in_dwi = os.path.join(get_home(), 'commit_amico',
-                          'dwi.nii.gz')
-    in_bval = os.path.join(get_home(), 'commit_amico',
-                           'dwi.bval')
-    in_bvec = os.path.join(get_home(), 'commit_amico',
-                           'dwi.bvec')
-    in_wm_frf = os.path.join(get_home(), 'commit_amico',
-                          'wm_frf.txt')
-    in_gm_frf = os.path.join(get_home(), 'commit_amico',
-                          'gm_frf.txt')
-    in_csf_frf = os.path.join(get_home(), 'commit_amico',
-                          'csf_frf.txt')
-    mask = os.path.join(get_home(), 'commit_amico',
-                           'mask.nii.gz')
+    in_dwi = os.path.join(get_home(), 'commit_amico', 'dwi.nii.gz')
+    in_bval = os.path.join(get_home(), 'commit_amico', 'dwi.bval')
+    in_bvec = os.path.join(get_home(), 'commit_amico', 'dwi.bvec')
+    in_wm_frf = os.path.join(get_home(), 'commit_amico', 'wm_frf.txt')
+    in_gm_frf = os.path.join(get_home(), 'commit_amico', 'gm_frf.txt')
+    in_csf_frf = os.path.join(get_home(), 'commit_amico', 'csf_frf.txt')
+    mask = os.path.join(get_home(), 'commit_amico', 'mask.nii.gz')
+
     ret = script_runner.run('scil_compute_msmt_fodf.py', in_dwi, in_bval,
                             in_bvec, in_wm_frf, in_gm_frf, in_csf_frf,
-                            '--mask', mask, '--wm_out_fODF', 'wm_fodf.nii.gz',
-                            '--gm_out_fODF', 'gm_fodf.nii.gz', '--csf_out_fODF',
-                            'csf_fodf.nii.gz', '--vf', 'vf.nii.gz',
-                            '--sh_order', '4', '--sh_basis', 'tournier07',
+                            '--mask', mask,
+                            '--wm_out_fODF', 'wm_fodf.nii.gz',
+                            '--gm_out_fODF', 'gm_fodf.nii.gz',
+                            '--csf_out_fODF', 'csf_fodf.nii.gz',
+                            '--vf', 'vf.nii.gz', '--sh_order', '4',
+                            '--sh_basis', 'tournier07',
                             '--processes', '1', '-f')
     assert ret.success


### PR DESCRIPTION
Multi-tissue fODF estimation can throw `ArpackNoConvergence` error when the solution does not converge inside a voxel for some `cvxpy/numpy/scipy` version combinations. The problem occurs when using `cvxpy >= 1.1.15` but I didn't find where it comes from specifically.  It is one possible workaround, we could also just force the cvxpy version if you prefer.

I also used the opportunity to solve PEP8 style issues.

It is also unclear to me why it crashes when running it locally from the command line but not through pytest (also local).

@karanphil @arnaudbore