### PR TITLE
[BF] Remove exception for non-symmetric sphere for dev tracking

### DIFF
--- a/scilpy/tracking/propagator.py
+++ b/scilpy/tracking/propagator.py
@@ -89,9 +89,9 @@ class AbstractPropagator(object):
         Returns
         -------
         v_in: ndarray (3,)
-            Last direction of the streamline, of if it contains only the
-            seeding point (forward tracking failed), simply inverse the
-            forward direction.
+            Last direction of the streamline. If the streamline contains
+            only the seeding point (forward tracking failed), simply inverse
+            the forward direction.
         """
         if len(line) > 1:
             v = line[-1] - line[-2]
@@ -122,8 +122,8 @@ class AbstractPropagator(object):
         # interpolation of a new direction). Ex of use: if stopped because it
         # exited the (WM) tracking mask, reaching GM a little more.
 
-        # In this abstract class, tracking_information only contains the last
-        # tracking direction.
+        # In this abstract class, tracking information only consists of the
+        # last tracking direction.
         final_pos = last_pos + self.step_size * np.array(v_in)
         return final_pos
 
@@ -252,9 +252,6 @@ class PropagatorOnSphere(AbstractPropagator):
         """
         super().__init__(dataset, step_size, rk_order)
 
-        if 'symmetric' not in dipy_sphere:
-            raise ValueError('Sphere must be symmetric. Call to '
-                             'get_opposite_direction will fail.')
         self.sphere = dipy.data.get_sphere(dipy_sphere)
         self.dirs = np.zeros(len(self.sphere.vertices), dtype=np.ndarray)
         for i in range(len(self.sphere.vertices)):

--- a/scilpy/tracking/propagator.py
+++ b/scilpy/tracking/propagator.py
@@ -121,9 +121,6 @@ class AbstractPropagator(object):
         # Make a last step straight in the last direction (no sampling or
         # interpolation of a new direction). Ex of use: if stopped because it
         # exited the (WM) tracking mask, reaching GM a little more.
-
-        # In this abstract class, tracking information only consists of the
-        # last tracking direction.
         final_pos = last_pos + self.step_size * np.array(v_in)
         return final_pos
 

--- a/scilpy/tracking/tracker.py
+++ b/scilpy/tracking/tracker.py
@@ -37,7 +37,9 @@ class Tracker(object):
         nbr_seeds: int
             Number of seeds to create via the seed generator.
         min_nbr_pts: int
+            Minimum number of points for streamlines.
         max_nbr_pts: int
+            Maximum number of points for streamlines.
         max_invalid_dirs: int
             Number of consecutives invalid directions allowed during tracking.
         compression_th : float,
@@ -49,8 +51,8 @@ class Tracker(object):
             Whether to save the seeds associated to their respective
             streamlines.
         mmap_mode: str
-            Memory-mapping mode. One of {None, 'r+', 'c'}. This value is passed to
-            np.load() when loading the raw tracking data from a subprocess.
+            Memory-mapping mode. One of {None, 'r+', 'c'}. This value is passed
+            to np.load() when loading the raw tracking data from a subprocess.
         rng_seed: int
             The random "seed" for the random generator.
         track_forward_only: bool
@@ -100,7 +102,10 @@ class Tracker(object):
         Return
         ------
         streamlines: list of numpy.array
+            List of streamlines, represented as an array of positions.
         seeds: list of numpy.array
+            List of seeding positions, one 3-dimensional position per
+            streamline.
         """
         if self.nbr_processes < 2:
             chunk_id = 1
@@ -165,11 +170,13 @@ class Tracker(object):
 
         Parameters
         ----------
-        chunk_id: int, This processes's id.
+        chunk_id: int
+            This processes's id.
 
         Return
         -------
-        lines: list, list of list of 3D positions (streamlines).
+        lines: list
+            List of list of 3D positions (streamlines).
         """
         global data_file_info
 
@@ -253,6 +260,7 @@ class Tracker(object):
         Returns
         -------
         line: list of 3D positions
+            The generated streamline for seeding_pos.
         """
 
         # toDo See numpy's doc: np.random.seed:


### PR DESCRIPTION
For the `dev` tracking scripts.
We  don't use `get_opposite_direction` for backward tracking anymore so supplying a non-symmetric sphere should not be a problem, right? @EmmaRenauld  could you confirm this is ok?

I removed the `ValueError` which is raised in the `PropagatorOnSphere` constructor when a `repulsion` sphere is supplied. Also fixed some docstrings.