### PR TITLE
Fixing doc in io.utils

### DIFF
--- a/scilpy/io/utils.py
+++ b/scilpy/io/utils.py
@@ -330,7 +330,7 @@ def assert_outputs_exist(parser, args, required, optional=None,
     ----------
     parser: argparse.ArgumentParser object
         Parser.
-    args: list
+    args: argparse namespace
         Argument list.
     required: string or list of paths to files
         Required paths to be checked.
@@ -376,8 +376,12 @@ def assert_output_dirs_exist_and_empty(parser, args, required,
         Parser.
     args: argparse namespace
         Argument list.
-    dirs: list
-        Required directory paths to be checked.
+    required: string or list of paths to files
+        Required paths to be checked.
+    optional: string or list of paths to files
+        Optional paths to be checked.
+    create_dir: bool
+        If true, create the directory if it does not exist.
     """
     def check(path):
         if not os.path.isdir(path):


### PR DESCRIPTION
Fixing some doc:

1) `args: list` raises a warning in editors such as pycharm, as it is actually a Namespace.
2) missing parameters
