### PR TITLE
Fix vf stuff

### DIFF
--- a/scilpy/viz/scene_utils.py
+++ b/scilpy/viz/scene_utils.py
@@ -154,6 +154,11 @@ def create_texture_slicer(texture, mask, slice_index, value_range=None,
     else:
         masked_texture = texture
 
+    if value_range:
+        masked_texture = (masked_texture - value_range[0])
+                         / value_range[1] * 255
+        masked_texture = np.clip(masked_texture, 0 , 255)
+
     slicer_actor = actor.slicer(masked_texture, affine=affine,
                                 value_range=value_range,
                                 opacity=opacity,

--- a/scilpy/viz/scene_utils.py
+++ b/scilpy/viz/scene_utils.py
@@ -28,8 +28,6 @@ def initialize_camera(orientation, slice_index, volume_shape):
 
     Parameters
     ----------
-    slicer_actor : actor
-        Slicer actor from Fury
     orientation : str
         Name of the axis to visualize. Choices are axial, coronal and sagittal.
     slice_index : int
@@ -131,9 +129,8 @@ def create_odf_slicer(sh_fodf, orientation, slice_index, mask, sphere,
 
     Parameters
     ----------
-    texture : np.ndarray (3d or 4d)
-        Texture image. Can be 3d for scalar data of 4d for RGB data, in which
-        case the values must be between 0 and 255.
+    sh_fodf : np.ndarray
+        Spherical harmonics of fODF data.
     orientation : str
         Name of the axis to visualize. Choices are axial, coronal and sagittal.
     slice_index : int

--- a/scilpy/viz/scene_utils.py
+++ b/scilpy/viz/scene_utils.py
@@ -252,7 +252,7 @@ def create_texture_slicer(texture, orientation, slice_index, mask=None,
     affine = _get_affine_for_texture(orientation, offset)
 
     if mask is not None:
-        texture *= mask
+        texture[np.where(mask == 0)] = 0
 
     if value_range:
         texture = np.clip((texture - value_range[0]) / value_range[1] * 255,

--- a/scilpy/viz/scene_utils.py
+++ b/scilpy/viz/scene_utils.py
@@ -155,14 +155,11 @@ def create_texture_slicer(texture, mask, slice_index, value_range=None,
         masked_texture = texture
 
     if value_range:
-        masked_texture = (masked_texture - value_range[0])
-                         / value_range[1] * 255
-        masked_texture = np.clip(masked_texture, 0 , 255)
+        masked_texture = (masked_texture - value_range[0]) / value_range[1]
+        masked_texture = np.clip(masked_texture * 255, 0, 255)
 
     slicer_actor = actor.slicer(masked_texture, affine=affine,
-                                value_range=value_range,
-                                opacity=opacity,
-                                interpolation=interpolation)
+                                opacity=opacity, interpolation=interpolation)
     set_display_extent(slicer_actor, orientation, texture.shape, slice_index)
     return slicer_actor
 

--- a/scripts/scil_compute_msmt_fodf.py
+++ b/scripts/scil_compute_msmt_fodf.py
@@ -198,6 +198,9 @@ def main():
 
     shm_coeff = np.where(np.isnan(shm_coeff), 0, shm_coeff)
 
+    vf = msmt_fit.volume_fractions
+    vf = np.where(np.isnan(vf), 0, vf)
+
     # Saving results
     if args.wm_out_fODF:
         wm_coeff = shm_coeff[..., 2:]
@@ -226,11 +229,10 @@ def main():
                                  vol.affine), args.csf_out_fODF)
 
     if args.vf:
-        nib.save(nib.Nifti1Image(msmt_fit.volume_fractions.astype(np.float32),
+        nib.save(nib.Nifti1Image(vf.astype(np.float32),
                                  vol.affine), args.vf)
 
     if args.vf_rgb:
-        vf = msmt_fit.volume_fractions
         vf_rgb = vf / np.max(vf) * 255
         vf_rgb = np.clip(vf_rgb, 0, 255)
         nib.save(nib.Nifti1Image(vf_rgb.astype(np.uint8),

--- a/scripts/scil_visualize_fodf.py
+++ b/scripts/scil_visualize_fodf.py
@@ -229,7 +229,7 @@ def main():
         mask = None
 
     # Instantiate the ODF slicer actor
-    odf_actor = create_odf_slicer(data['fodf'], args.axis_name, 
+    odf_actor = create_odf_slicer(data['fodf'], args.axis_name,
                                   args.slice_index, mask, sph,
                                   args.sph_subdivide, sh_order,
                                   args.sh_basis, full_basis,

--- a/scripts/scil_visualize_fodf.py
+++ b/scripts/scil_visualize_fodf.py
@@ -118,7 +118,7 @@ def _build_arg_parser():
                    help='Peaks image file.')
 
     p.add_argument('--peaks_color', nargs=3, type=float,
-                   help='Color used for peaks. if None, '
+                   help='Color used for peaks. If None, '
                         'then a RGB colormap is used. [%(default)s]')
 
     p.add_argument('--peaks_width', default=1.0, type=float,
@@ -229,21 +229,22 @@ def main():
         mask = None
 
     # Instantiate the ODF slicer actor
-    odf_actor = create_odf_slicer(data['fodf'], mask, sph,
+    odf_actor = create_odf_slicer(data['fodf'], args.axis_name, 
+                                  args.slice_index, mask, sph,
                                   args.sph_subdivide, sh_order,
                                   args.sh_basis, full_basis,
-                                  args.axis_name, args.scale,
+                                  args.scale,
                                   not args.radial_scale_off,
-                                  not args.norm_off, args.colormap,
-                                  args.slice_index)
+                                  not args.norm_off, args.colormap)
     actors.append(odf_actor)
 
     # Instantiate a texture slicer actor if a background image is supplied
     if 'bg' in data:
-        bg_actor = create_texture_slicer(data['bg'], mask,
-                                         args.slice_index,
-                                         args.bg_range,
+        bg_actor = create_texture_slicer(data['bg'],
                                          args.axis_name,
+                                         args.slice_index,
+                                         mask,
+                                         args.bg_range,
                                          args.bg_opacity,
                                          args.bg_offset,
                                          args.bg_interpolation)


### PR DESCRIPTION
There was a minor bug with the `vf_rgb` when nan values occured in `shm_coeff`. In the script `scil_compute_msmt_fodf.py`, we changed any nan for 0 in `shm_coeff`, but forgot to do so in `vf`, so that when calculating `vf_rgb`, we were dividing by nan, resulting in a `vf_rgb` full of nan. This has been fixed by a simple 2 lines change.

Also, the parameter `bg_range` in `scil_visualize_fodf.py` was not working for rgb background. The value_range parameter was removed when calling `actor.slice` and instead, we now apply the value_range manually on the texture before sending it to `actor.slice`. This works for both scalar and rgb data.