### PR TITLE
Color by p-value script

### DIFF
--- a/scripts/scil_color_bundle_by_pvalue.py
+++ b/scripts/scil_color_bundle_by_pvalue.py
@@ -2,28 +2,31 @@
 # -*- coding: utf-8 -*-
 """
 Assign a color to each streamline point based on its p-value. The p-values
-are assumed to be in the same order as the streamline points.
+are assumed to be in the same order as the streamline points. If a streamline
+has less points than the number of p-values, the streamline is resampled
+to have the same number of points. The number of points can also be set
+by the user with --resample.
 
 The p-values input format is a whitespace-separated list of values saved
 in a .txt file.
-"""
 
+The resulting tractogram can be visualized with MI-Brain. A PNG of the colormap
+is also saved.
+"""
 import argparse
 import nibabel as nib
 import numpy as np
+import os
 
 from dipy.tracking.streamline import set_number_of_points
-from fury import window, actor, colormap
+from fury import colormap
 
 from scilpy.io.utils import (add_overwrite_arg, assert_inputs_exist,
-                             assert_outputs_exist, parser_color_type)
+                             assert_outputs_exist)
 from dipy.io.stateful_tractogram import StatefulTractogram, Space
 from dipy.io.streamline import save_tractogram
 from scipy.interpolate import interp1d
 from matplotlib import pyplot as plt
-
-streamline_actor = {'tube': actor.streamtube,
-                    'line': actor.line}
 
 
 def _build_arg_parser():
@@ -37,41 +40,61 @@ def _build_arg_parser():
     p.add_argument('out_tractogram',
                    help='Output tractogram file (.trk).')
     p.add_argument('out_colormap',
-                   help='Output colormap image.')
+                   help='Output colormap image (.png).')
 
     p.add_argument('--colormap', default='plasma',
                    help='Colormap to use for coloring the streamlines.')
     p.add_argument('--resample', type=int,
                    help='Optionally resample the streamlines.')
 
-    p.add_argument('--interactive', action='store_true',
-                   help='If true, fibers will be rendered to a FURY window.')
-    p.add_argument('--shape', type=str,
-                   choices=['line', 'tube'], default='line',
-                   help='Display streamlines either as lines or tubes.'
-                   '\n[Default: %(default)s]')
-    p.add_argument('--width', type=float,
-                   help='Width of tubes or lines representing streamlines'
-                   '\n[Default: 2.0 for lines,]')
-    p.add_argument('--background', metavar=('R', 'G', 'B'), nargs=3,
-                   default=[0, 0, 0], type=parser_color_type,
-                   help='RBG values [0, 255] of the color of the background.'
-                   '\n[Default: %(default)s]')
-
     add_overwrite_arg(p)
     return p
 
 
-def get_width(args):
-    if args.width is None:
-        if args.shape == 'line':
-            return 2.0
-        elif args.shape == 'tube':
-            return 0.25
-        else:
-            raise ValueError('Unknown shape: {}'.format(args.shape))
-    else:
-        return args.width
+def resample_streamlines_from_pvalues(streamlines, pvalues,
+                                      override_resample=None):
+    """
+    Resample each streamline so that it has at least the same
+    number of points as the p-values vector. If override_resample
+    is set, the number of points is set to this value.
+
+    Parameters
+    ----------
+    streamlines : list of ndarray
+        List of streamlines.
+    pvalues : ndarray
+        Array of p-values.
+    override_resample : int, optional
+        If set, the number of points is set to this value.
+
+    Returns
+    -------
+    resampled_streamlines: list of ndarray
+        List of resampled streamlines.
+    mapped_pvalues: ndarray
+        Array of p-values mapped to the resampled streamlines.
+    """
+    n_timepoints = len(pvalues)
+    f_interp = interp1d(np.linspace(0.0, 1.0, n_timepoints), pvalues)
+
+    mapped_pvals = []
+    resampled_strl = []
+    for strl in streamlines:
+        if len(strl) < n_timepoints or override_resample is not None:
+            new_n_points = override_resample if override_resample is not None\
+                 else n_timepoints
+            strl = set_number_of_points(strl, new_n_points)
+
+        # compute interpolation timepoints
+        distances = np.sqrt(np.sum((strl[1:] - strl[:-1])**2, axis=-1))
+        distances = np.append([0], distances)
+        weights = np.cumsum(distances)
+        weights /= weights[-1]
+        pvals = f_interp(weights)
+        mapped_pvals.append(pvals)
+        resampled_strl.append(strl)
+
+    return resampled_strl, mapped_pvals
 
 
 def main():
@@ -82,69 +105,41 @@ def main():
     assert_outputs_exist(parser, args,
                          [args.out_tractogram, args.out_colormap])
 
+    # Assert that the output tractogram is in .trk format
+    _, ext = os.path.splitext(args.out_tractogram)
+    if ext != '.trk':
+        parser.error("Output tractogram file must have .trk extension.")
+
     pvalues = np.loadtxt(args.in_pvalues)
-    n_timepoints = len(pvalues)
-
     tractogram = nib.streamlines.load(args.in_bundle)
-    streamlines = tractogram.streamlines
 
-    # create interpolation function
-    f_interp = interp1d(np.linspace(0.0, 1.0, n_timepoints), pvalues)
-
-    # interpolation weights [0, 1) for p-values
-    mapped_pvals = []
-    resampled_strl = []
-    for strl in streamlines:
-        if len(strl) < n_timepoints or args.resample is not None:
-            resample = args.resample if args.resample is not None\
-                 else n_timepoints
-            strl = set_number_of_points(strl, resample)
-        resampled_strl.append(strl)
-
-        # compute interpolation weights
-        distances = np.sqrt(np.sum((strl[1:] - strl[:-1])**2, axis=-1))
-        distances = np.append([0], distances)
-        weights = np.cumsum(distances)
-        weights /= weights[-1]
-        pvals = f_interp(weights)
-        mapped_pvals.append(pvals)
+    # resample streamlines if necessary
+    streamlines, pvals =\
+        resample_streamlines_from_pvalues(tractogram.streamlines,
+                                          pvalues,
+                                          args.resample)
 
     # assign colors to streamlines
-    color = colormap.create_colormap(np.ravel(mapped_pvals),
+    color = colormap.create_colormap(np.ravel(pvals),
                                      args.colormap, auto=False)
-    sft = StatefulTractogram(resampled_strl, tractogram, Space.RASMM)
+    sft = StatefulTractogram(streamlines, tractogram, Space.RASMM)
     sft.data_per_point['color'] = sft.streamlines
     sft.data_per_point['color']._data = color * 255
     save_tractogram(sft, args.out_tractogram)
 
     # output colormap to png file
-    xticks = np.linspace(0, 1, 256)
+    n_steps_cmap = 256
+    xticks = np.linspace(0, 1, n_steps_cmap)
     gradient = colormap.create_colormap(xticks,
                                         args.colormap,
                                         auto=False)
     gradient = gradient[None, ...]  # 2D RGB image
     _, ax = plt.subplots(1, 1, figsize=(10, 1), dpi=100)
     ax.imshow(gradient, aspect=10)
-    ax.set_xticks([0, 255])
+    ax.set_xticks([0, n_steps_cmap - 1])
     ax.set_xticklabels(['0.0', '1.0'])
     ax.set_yticks([])
     plt.savefig(args.out_colormap)
-
-    if args.interactive:
-        width = get_width(args)
-        scene = window.Scene()
-        scene.background(np.asarray(args.background)/255.0)
-        line_actor = streamline_actor[args.shape](resampled_strl, colors=color,
-                                                  linewidth=width)
-        start_pos = np.array([s[0] for s in resampled_strl])
-        dot_actor = actor.dots(start_pos)
-        scene.add(line_actor)
-        scene.add(dot_actor)
-
-        # Showtime !
-        showm = window.ShowManager(scene)
-        showm.initialize()
-        showm.start()
 
 
 if __name__ == '__main__':

--- a/scripts/scil_color_bundle_by_pvalue.py
+++ b/scripts/scil_color_bundle_by_pvalue.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Assign a color to each streamline point based on its p-value. The p-values
+are assumed to be in the same order as the streamline points.
+
+The p-values input format is a whitespace-separated list of values saved
+in a .txt file.
+"""
+
+import argparse
+import nibabel as nib
+import numpy as np
+
+from dipy.tracking.streamline import set_number_of_points
+from fury import window, actor, colormap
+
+from scilpy.io.utils import assert_inputs_exist, parser_color_type
+from dipy.io.stateful_tractogram import StatefulTractogram, Space
+from dipy.io.streamline import save_tractogram
+
+streamline_actor = {'tube': actor.streamtube,
+                    'line': actor.line}
+
+
+def _build_arg_parser():
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+    p.add_argument('in_bundle',
+                   help='Input bundle file.')
+    p.add_argument('in_metric',
+                   help='Input metric vector as text file of'
+                        ' whitespace-separated values.')
+    p.add_argument('out_tractogram',
+                   help='Output tractogram file.')
+
+    p.add_argument('--colormap', default='plasma',
+                   help='Colormap to use for coloring the streamlines.')
+
+    p.add_argument('--interactive', action='store_true',
+                   help='If true, fibers will be rendered to a FURY window.')
+    p.add_argument('--shape', type=str,
+                   choices=['line', 'tube'], default='line',
+                   help='Display streamlines either as lines or tubes.'
+                   '\n[Default: %(default)s]')
+    p.add_argument('--width', type=float,
+                   help='Width of tubes or lines representing streamlines'
+                   '\n[Default: 2.0 for lines,]')
+    p.add_argument('--background', metavar=('R', 'G', 'B'), nargs=3,
+                   default=[0, 0, 0], type=parser_color_type,
+                   help='RBG values [0, 255] of the color of the background.'
+                   '\n[Default: %(default)s]')
+    return p
+
+
+def get_width(args):
+    if args.width is None:
+        if args.shape == 'line':
+            return 2.0
+        elif args.shape == 'tube':
+            return 0.25
+        else:
+            raise ValueError('Unknown shape: {}'.format(args.shape))
+    else:
+        return args.width
+
+
+def main():
+    parser = _build_arg_parser()
+    args = parser.parse_args()
+
+    assert_inputs_exist(parser, [args.in_bundle, args.in_metric])
+
+    pvalues = np.loadtxt(args.in_metric)
+    n_timepoints = len(pvalues)
+
+    tractogram = nib.streamlines.load(args.in_bundle)
+    streamlines = tractogram.streamlines
+
+    # TODO: For each streamline, do not resample. Keep original number of
+    # points and interpolate the p-values instead.
+    # Or maybe resample only when the number of points is smaller than the
+    # number of p-values.
+    streamlines = set_number_of_points(streamlines, n_timepoints)
+
+    color = np.tile(pvalues, len(streamlines))
+    color = colormap.create_colormap(color, args.colormap, auto=False)
+
+    width = get_width(args)
+
+    sft = StatefulTractogram(streamlines, tractogram, Space.RASMM)
+    sft.data_per_point['color'] = sft.streamlines
+    sft.data_per_point['color']._data = color * 255
+    save_tractogram(sft, args.out_tractogram)
+
+    if args.interactive:
+        scene = window.Scene()
+        scene.background(np.asarray(args.background)/255.0)
+        line_actor = streamline_actor[args.shape](streamlines, colors=color,
+                                                  linewidth=width)
+        scene.add(line_actor)
+
+        # Showtime !
+        showm = window.ShowManager(scene)
+        showm.initialize()
+        showm.start()
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/scil_color_bundle_by_pvalue.py
+++ b/scripts/scil_color_bundle_by_pvalue.py
@@ -110,7 +110,7 @@ def main():
     if ext != '.trk':
         parser.error("Output tractogram file must have .trk extension.")
 
-    pvalues = np.loadtxt(args.in_pvalues)
+    pvalues = np.loadtxt(args.in_pvalues).reshape((-1,))
     tractogram = nib.streamlines.load(args.in_bundle)
 
     # resample streamlines if necessary

--- a/scripts/tests/test_color_bundle_by_pvalue.py
+++ b/scripts/tests/test_color_bundle_by_pvalue.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import os
+import tempfile
+import numpy as np
+
+from scilpy.io.fetcher import get_testing_files_dict, fetch_data, get_home
+
+fetch_data(get_testing_files_dict(), keys=['tractometry.zip'])
+tmp_dir = tempfile.TemporaryDirectory()
+
+
+def test_help_option(script_runner):
+    ret = script_runner.run('scil_color_bundle_by_pvalue.py', '--help')
+    assert ret.success
+
+
+def test_execution_base(script_runner):
+    os.chdir(os.path.expanduser(tmp_dir.name))
+
+    # dummy p-values file
+    pvalues = np.linspace(0.0, 1.0, 100)
+    np.savetxt('pvalues.txt', pvalues, delimiter=' ')
+
+    in_bundle = os.path.join(get_home(), 'tractometry',
+                             'IFGWM.trk')
+
+    ret = script_runner.run('scil_color_bundle_by_pvalue.py',
+                            in_bundle, 'pvalues.txt',
+                            'out.trk', 'out.png', '--colormap', 'plasma')
+    assert ret.success
+
+
+def test_execution_resample(script_runner):
+    os.chdir(os.path.expanduser(tmp_dir.name))
+
+    # dummy p-values file
+    pvalues = np.linspace(0.0, 1.0, 100)
+    np.savetxt('pvalues.txt', pvalues, delimiter=' ')
+
+    in_bundle = os.path.join(get_home(), 'tractometry',
+                             'IFGWM.trk')
+
+    ret = script_runner.run('scil_color_bundle_by_pvalue.py',
+                            in_bundle, 'pvalues.txt',
+                            'out.trk', 'out.png', '--colormap', 'plasma',
+                            '--resample', '8', '-f')
+    assert ret.success


### PR DESCRIPTION
Script to assign colors to each point of a bundle given some vector saved in txt file as a list of whitespace-separated values. Colored tractogram can be visualized in MI-Brain ~~or directly in the script with `--interactive`~~.

- [x] For the moment, each streamline is resampled to match the number of values in the text file. But I want to improve this. 
- [x] Also I need to support tck file format as input.
- [x] ~~Actually, maybe the content of the script can be included in `scil_assign_color_to_tractogram.py`.~~

@mdesco Anyway, it should be usable right away.
