### PR TITLE
Small fixes and improvements in tractogram filtering scripts

### DIFF
--- a/scilpy/image/operations.py
+++ b/scilpy/image/operations.py
@@ -577,7 +577,7 @@ def dilation(input_list, ref_img):
     """
     dilation: IMG, VALUE
         Binary morphological operation to spatially extend the values of an
-        image to their neighbors.
+        image to their neighbors. VALUE is in voxels.
     """
     _validate_length(input_list, 2)
     _validate_type(input_list[0], nib.Nifti1Image)
@@ -591,7 +591,7 @@ def erosion(input_list, ref_img):
     """
     erosion: IMG, VALUE
         Binary morphological operation to spatially shrink the volume contained
-        in a binary image.
+        in a binary image. VALUE is in voxels.
     """
     _validate_length(input_list, 2)
     _validate_type(input_list[0], nib.Nifti1Image)

--- a/scilpy/segment/streamlines.py
+++ b/scilpy/segment/streamlines.py
@@ -65,17 +65,16 @@ def filter_grid_roi_both(sft, mask_1, mask_2):
         Binary mask in which the streamlines should start or end.
     Returns
     -------
-    ids : tuple
+    new_sft: StatefulTractogram
         Filtered sft.
+    ids: list
         Ids of the streamlines passing through the mask.
     """
-    line_based_indices = []
     sft.to_vox()
     sft.to_corner()
     streamline_vox = sft.streamlines
     # For endpoint filtering, we need to keep 2 separately
     # Could be faster for either end, but the code look cleaner like this
-    line_based_indices = []
     voxel_beg = np.asarray([s[0] for s in streamline_vox],
                            dtype=np.int16).transpose(1, 0)
     voxel_end = np.asarray([s[-1] for s in streamline_vox],
@@ -111,7 +110,7 @@ def filter_grid_roi(sft, mask, filter_type, is_exclude):
     ----------
     sft : StatefulTractogram
         StatefulTractogram containing the streamlines to segment.
-    target_mask : numpy.ndarray
+    mask : numpy.ndarray
         Binary mask in which the streamlines should pass.
     filter_type: str
         One of the 3 following choices, 'any', 'all', 'either_end', 'both_ends'.
@@ -119,8 +118,9 @@ def filter_grid_roi(sft, mask, filter_type, is_exclude):
         Value to indicate if the ROI is an AND (false) or a NOT (true).
     Returns
     -------
-    ids : tuple
+    new_sft: StatefulTractogram
         Filtered sft.
+    ids: list
         Ids of the streamlines passing through the mask.
     """
     line_based_indices = []

--- a/scripts/scil_compute_endpoints_map.py
+++ b/scripts/scil_compute_endpoints_map.py
@@ -45,6 +45,8 @@ def _build_arg_parser():
     p.add_argument('--swap', action='store_true',
                    help='Swap head<->tail convention. '
                         'Can be useful when the reference is not in RAS.')
+    p.add_argument('--binary', action='store_true',
+                   help="Save outputs as a binary mask instead of a heat map.")
 
     add_json_args(p)
     add_reference_arg(p)
@@ -80,6 +82,10 @@ def main():
 
     endpoints_map_head, endpoints_map_tail = \
         get_head_tail_density_maps(sft.streamlines, dim)
+
+    if args.binary:
+        endpoints_map_head = (endpoints_map_head > 0).astype(np.int16)
+        endpoints_map_tail = (endpoints_map_tail > 0).astype(np.int16)
 
     nib.save(nib.Nifti1Image(endpoints_map_head, transfo), head_name)
     nib.save(nib.Nifti1Image(endpoints_map_tail, transfo), tail_name)

--- a/scripts/scil_compute_qbx.py
+++ b/scripts/scil_compute_qbx.py
@@ -19,7 +19,8 @@ from scilpy.io.utils import (add_overwrite_arg,
                              add_reference_arg,
                              assert_inputs_exist,
                              assert_outputs_exist,
-                             assert_output_dirs_exist_and_empty)
+                             assert_output_dirs_exist_and_empty,
+                             add_verbose_arg)
 
 
 def _build_arg_parser():
@@ -44,6 +45,7 @@ def _build_arg_parser():
 
     add_reference_arg(p)
     add_overwrite_arg(p)
+    add_verbose_arg(p)
 
     return p
 
@@ -63,6 +65,10 @@ def main():
     thresholds = [40, 30, 20, args.dist_thresh]
     clusters = qbx_and_merge(streamlines, thresholds,
                              nb_pts=args.nb_points, verbose=False)
+
+    if args.verbose:
+        print("Tractogram was separated into {} clusters. Saving..."
+              .format(len(clusters)))
 
     for i, cluster in enumerate(clusters):
         if len(cluster.indices) > 1:

--- a/scripts/scil_compute_qbx.py
+++ b/scripts/scil_compute_qbx.py
@@ -7,6 +7,7 @@
 """
 
 import argparse
+import logging
 from operator import itemgetter
 import os
 
@@ -60,6 +61,9 @@ def main():
                                        args.out_clusters_dir,
                                        create_dir=True)
 
+    if args.verbose:
+        logging.basicConfig(level=logging.INFO)
+
     sft = load_tractogram_with_reference(parser, args, args.in_tractogram)
     streamlines = sft.streamlines
     thresholds = [40, 30, 20, args.dist_thresh]
@@ -67,8 +71,8 @@ def main():
                              nb_pts=args.nb_points, verbose=False)
 
     if args.verbose:
-        print("Tractogram was separated into {} clusters. Saving..."
-              .format(len(clusters)))
+        logging.info("Tractogram was separated into {} clusters. Saving..."
+                     .format(len(clusters)))
 
     for i, cluster in enumerate(clusters):
         if len(cluster.indices) > 1:

--- a/scripts/tests/test_compute_endpoints_map.py
+++ b/scripts/tests/test_compute_endpoints_map.py
@@ -22,6 +22,6 @@ def test_execution_tractometry(script_runner):
     in_bundle = os.path.join(get_home(), 'tractometry',
                              'IFGWM_uni.trk')
     ret = script_runner.run('scil_compute_endpoints_map.py', in_bundle,
-                            'head.nii.gz', 'tail.nii.gz')
+                            'head.nii.gz', 'tail.nii.gz', '--binary')
 
     assert ret.success

--- a/scripts/tests/test_filter_tractogram.py
+++ b/scripts/tests/test_filter_tractogram.py
@@ -28,5 +28,6 @@ def test_execution_filtering(script_runner):
     ret = script_runner.run('scil_filter_tractogram.py', in_tractogram,
                             'bundle_4.trk', '--display_counts',
                             '--drawn_roi', in_roi, 'any', 'include',
-                            '--bdo', in_bdo, 'any', 'include')
+                            '--bdo', in_bdo, 'any', 'include',
+                            '--save_rejected', 'bundle_4_rejected.trk')
     assert ret.success


### PR DESCRIPTION
I worked a bit with tractogram filtering scripts this week, and here is a list of very small changes.

- My pycharm was sometimes confused by the datatypes. Clarifying docstrings.
- Adding --binary option to scil_compute_endpoints maps.
- Adding verbose option to scil_compute_qbx.
- Adding option to save rejected streamlines in scil_filter_tractogram