### PR TITLE
Modifying scil_score tractogram

### DIFF
--- a/scilpy/tractanalysis/scoring.py
+++ b/scilpy/tractanalysis/scoring.py
@@ -123,6 +123,7 @@ def compute_masks(gt_files, parser, args):
     mask_2: numpy.ndarray
         "Tail" of the mask.
     """
+    save_ref = args.reference
 
     gt_bundle_masks = []
     gt_bundle_inv_masks = []
@@ -145,6 +146,13 @@ def compute_masks(gt_files, parser, args):
                 affine = gt_img.affine
                 dimensions = gt_mask.shape
             else:
+                # Cheating ref because it may send a lot of warning if loading
+                # many trk with ref (reference was maybe added only for some
+                # of these files)
+                if ext == '.trk':
+                    args.reference = None
+                else:
+                    args.reference = save_ref
                 gt_sft = load_tractogram_with_reference(
                     parser, args, gt_bundle, bbox_check=False)
                 gt_sft.to_vox()

--- a/scilpy/tractanalysis/scoring.py
+++ b/scilpy/tractanalysis/scoring.py
@@ -100,7 +100,7 @@ def compute_gt_masks(gt_bundles, parser, args):
 
                 if affine is not None:
                     # compare affines.
-                    #todO
+                    # todO
                     logging.debug('Previous affine discarded. (todo)')
                 affine = gt_img.affine
                 dimensions = gt_mask.shape
@@ -112,7 +112,7 @@ def compute_gt_masks(gt_bundles, parser, args):
                 _affine, _dimensions, _, _ = gt_sft.space_attributes
                 if affine is not None:
                     # compare affines.
-                    #todO
+                    # todO
                     logging.debug('Previous affine discarded. (todo)')
                 affine = _affine
                 dimensions = _dimensions
@@ -214,7 +214,7 @@ def compute_endpoint_masks(roi_options, affine, dimensions, out_dir):
         if 'gt_endpoints' in bundle_options:
             tail, head, _affine, _dimensions = \
                 extract_tails_heads_from_endpoints(
-                    bundle_options['endpoints'], out_dir)
+                    bundle_options['gt_endpoints'], out_dir)
             if affine is not None:
                 # Compare affine
                 # todo
@@ -311,11 +311,13 @@ def extract_true_connections(
         valid_length_ids_mask_from_tc = np.logical_and(lengths > min_len,
                                                        lengths < max_len)
 
-        logging.info("Bundle {}:    Classifying {}/{} invalid length "
-                     "streamlines as wpc."
-                      .format(bundle_prefix,
-                              sum(~valid_length_ids_mask_from_tc),
-                              len(tc_ids)))
+        nb_invalid = sum(~valid_length_ids_mask_from_tc)
+        if nb_invalid > 0:
+            logging.info("Bundle {}:    Classifying {}/{} invalid length "
+                         "streamlines as wpc."
+                         .format(bundle_prefix,
+                                 sum(~valid_length_ids_mask_from_tc),
+                                 len(tc_ids)))
 
         # Update ids
         wpc_ids.extend(tc_ids[~valid_length_ids_mask_from_tc])
@@ -331,10 +333,12 @@ def extract_true_connections(
         valid_angle_ids = tc_ids[valid_angle_ids_from_tc]
         invalid_angle_ids = np.setdiff1d(tc_ids, valid_angle_ids)
 
-        logging.info("Bundle {}:    Classifying {}/{} invalid angle "
-                     "streamlines as wpc."
-                      .format(bundle_prefix, len(invalid_angle_ids),
-                              len(tc_ids)))
+        nb_invalid = len(invalid_angle_ids)
+        if nb_invalid > 0:
+            logging.info("Bundle {}:    Classifying {}/{} invalid angle "
+                         "streamlines as wpc."
+                         .format(bundle_prefix, len(invalid_angle_ids),
+                                 len(tc_ids)))
 
         wpc_ids.extend(invalid_angle_ids)
         tc_ids = valid_angle_ids
@@ -348,10 +352,12 @@ def extract_true_connections(
             tmp_sft, gt_bundle_inv_mask, 'any', False)
         out_of_mask_ids = tc_ids[out_of_mask_ids_from_tc]
 
-        logging.info("Bundle {}:    Classifying {}/{} streamlines out of "
-                     "ground truth mask as wpc."
-                      .format(bundle_prefix, len(out_of_mask_ids),
-                              len(tc_ids)))
+        nb_invalid = len(out_of_mask_ids)
+        if nb_invalid > 0:
+            logging.info("Bundle {}:    Classifying {}/{} streamlines out of "
+                         "ground truth mask as wpc."
+                         .format(bundle_prefix, len(out_of_mask_ids),
+                                 len(tc_ids)))
 
         # Update ids
         wpc_ids.extend(out_of_mask_ids)

--- a/scilpy/tractanalysis/scoring.py
+++ b/scilpy/tractanalysis/scoring.py
@@ -20,6 +20,14 @@ from scilpy.tractanalysis.streamlines_metrics import compute_tract_counts_map
 from scilpy.utils.filenames import split_name_with_nii
 
 
+def compute_f1_score(overlap, overreach):
+    # https://en.wikipedia.org/wiki/F1_score
+    recall = overlap
+    precision = 1 - overreach
+    f1_score = 2 * (precision * recall) / (precision + recall)
+    return f1_score
+
+
 def get_binary_maps(streamlines, sft):
     """
     Extract a mask from a bundle

--- a/scilpy/tractanalysis/scoring.py
+++ b/scilpy/tractanalysis/scoring.py
@@ -298,7 +298,6 @@ def extract_true_connections(
     sft: StatefulTractogram
         SFT of remaining streamlines.
     """
-
     mask_1_img = nib.load(head_filename)
     mask_2_img = nib.load(tail_filename)
     mask_1 = get_data_as_mask(mask_1_img)
@@ -311,9 +310,7 @@ def extract_true_connections(
     _, tc_ids = filter_grid_roi_both(sft, mask_1, mask_2)
 
     wpc_ids = []
-    bundle_stats = {"Head": head_filename,
-                    "Tail": tail_filename,
-                    "Initial TC head to tail": len(tc_ids)}
+    bundle_stats = {"Initial TC head to tail": len(tc_ids)}
 
     # Remove invalid lengths from tc
     if limits_length is not None:
@@ -340,6 +337,7 @@ def extract_true_connections(
     if orientation_length is not None:
         # Compute valid lengths
         limits_x, limits_y, limits_z = orientation_length
+
         _, valid_orientation_ids_from_tc, _ = \
             filter_streamlines_by_total_length_per_dim(
                 make_sft_from_ids(tc_ids, sft), limits_x, limits_y, limits_z,
@@ -350,7 +348,7 @@ def extract_true_connections(
         invalid_orientation_ids = np.setdiff1d(tc_ids, valid_orientation_ids)
 
         bundle_stats.update({
-            "WPC_invalid_length": len(invalid_orientation_ids)})
+            "WPC_invalid_orientation": len(invalid_orientation_ids)})
 
         wpc_ids.extend(invalid_orientation_ids)
         tc_ids = valid_orientation_ids
@@ -385,7 +383,7 @@ def extract_true_connections(
         wpc_ids.extend(out_of_mask_ids)
         tc_ids = np.setdiff1d(tc_ids, wpc_ids)
 
-        bundle_stats.update({"TC": len(tc_ids)})
+    bundle_stats.update({"TC": len(tc_ids)})
 
     return list(tc_ids), list(wpc_ids), bundle_stats
 

--- a/scilpy/tractanalysis/scoring.py
+++ b/scilpy/tractanalysis/scoring.py
@@ -291,11 +291,9 @@ def extract_true_connections(
         mask_1 = binary_dilation(mask_1, iterations=dilate_endpoints)
         mask_2 = binary_dilation(mask_2, iterations=dilate_endpoints)
 
-    nb_streamlines = len(sft)
-
     _, tc_ids = filter_grid_roi_both(sft, mask_1, mask_2)
-    logging.info("Bundle {}: Found {}/{} streamlines with correct endpoints."
-                 .format(bundle_prefix, len(tc_ids), nb_streamlines))
+    logging.info("Bundle {}: Found {} streamlines with correct endpoints."
+                 .format(bundle_prefix, len(tc_ids)))
 
     wpc_ids = []
 
@@ -313,7 +311,7 @@ def extract_true_connections(
         valid_length_ids_mask_from_tc = np.logical_and(lengths > min_len,
                                                        lengths < max_len)
 
-        logging.info("Bundle {}: Classifying {}/{} invalid length "
+        logging.info("Bundle {}:    Classifying {}/{} invalid length "
                      "streamlines as wpc."
                       .format(bundle_prefix,
                               sum(~valid_length_ids_mask_from_tc),
@@ -333,8 +331,8 @@ def extract_true_connections(
         valid_angle_ids = tc_ids[valid_angle_ids_from_tc]
         invalid_angle_ids = np.setdiff1d(tc_ids, valid_angle_ids)
 
-        logging.info("Bundle {}: Classifying {}/{} invalid angle streamlines "
-                     "as wpc."
+        logging.info("Bundle {}:    Classifying {}/{} invalid angle "
+                     "streamlines as wpc."
                       .format(bundle_prefix, len(invalid_angle_ids),
                               len(tc_ids)))
 
@@ -350,8 +348,8 @@ def extract_true_connections(
             tmp_sft, gt_bundle_inv_mask, 'any', False)
         out_of_mask_ids = tc_ids[out_of_mask_ids_from_tc]
 
-        logging.info("Bundle {}: Classifying {}/{} streamlines out of ground "
-                     "truth mask as wpc."
+        logging.info("Bundle {}:    Classifying {}/{} streamlines out of "
+                     "ground truth mask as wpc."
                       .format(bundle_prefix, len(out_of_mask_ids),
                               len(tc_ids)))
 
@@ -362,7 +360,7 @@ def extract_true_connections(
     tc_sft = make_sft_from_ids(tc_ids, sft)
     wpc_sft = make_sft_from_ids(wpc_ids, sft)
 
-    return tc_sft, wpc_sft, tc_ids, wpc_ids
+    return tc_sft, wpc_sft, list(tc_ids), list(wpc_ids)
 
 
 def extract_false_connections(sft, mask_1_filename, mask_2_filename,

--- a/scilpy/tractanalysis/scoring.py
+++ b/scilpy/tractanalysis/scoring.py
@@ -360,7 +360,7 @@ def extract_vb_vs(
     bundle_stats = {"Initial count head to tail": len(vs_ids)}
 
     # Remove out of inclusion mask (limits_mask)
-    if inclusion_inv_mask is not None:
+    if len(vs_ids) > 0 and inclusion_inv_mask is not None:
         tmp_sft = StatefulTractogram.from_sft(sft.streamlines[vs_ids], sft)
         _, out_of_mask_ids_from_vs = filter_grid_roi(
             tmp_sft, inclusion_inv_mask, 'any', False)
@@ -373,7 +373,7 @@ def extract_vb_vs(
         vs_ids = np.setdiff1d(vs_ids, wpc_ids)
 
     # Remove invalid lengths
-    if limits_length is not None:
+    if len(vs_ids) > 0 and limits_length is not None:
         min_len, max_len = limits_length
 
         # Bring streamlines to world coordinates so proper length
@@ -394,7 +394,7 @@ def extract_vb_vs(
         vs_ids = vs_ids[valid_length_ids_mask_from_vs]
 
     # Remove invalid lengths per orientation
-    if orientation_length is not None:
+    if len(vs_ids) > 0 and orientation_length is not None:
         # Compute valid lengths
         limits_x, limits_y, limits_z = orientation_length
 
@@ -414,7 +414,7 @@ def extract_vb_vs(
         vs_ids = valid_orientation_ids
 
     # Idem in abs
-    if abs_orientation_length is not None:
+    if len(vs_ids) > 0 and abs_orientation_length is not None:
         # Compute valid lengths
         limits_x, limits_y, limits_z = abs_orientation_length
 
@@ -436,7 +436,7 @@ def extract_vb_vs(
         vs_ids = valid_orientation_ids
 
     # Remove loops from tc
-    if angle is not None:
+    if len(vs_ids) > 0 and angle is not None:
         # Compute valid angles
         valid_angle_ids_from_vs = remove_loops_and_sharp_turns(
             sft.streamlines[vs_ids], angle)

--- a/scilpy/tractanalysis/scoring.py
+++ b/scilpy/tractanalysis/scoring.py
@@ -229,9 +229,14 @@ def compute_endpoint_masks(roi_options, affine, dimensions, out_dir):
 
 
 def make_sft_from_ids(ids, sft):
-    streamlines = sft.streamlines[ids]
-    data_per_streamline = sft.data_per_streamline[ids]
-    data_per_point = sft.data_per_point[ids]
+    if len(ids) > 0:
+        streamlines = sft.streamlines[ids]
+        data_per_streamline = sft.data_per_streamline[ids]
+        data_per_point = sft.data_per_point[ids]
+    else:
+        streamlines = []
+        data_per_streamline = None
+        data_per_point = None
 
     new_sft = StatefulTractogram.from_sft(
         streamlines, sft,

--- a/scilpy/tractanalysis/scoring.py
+++ b/scilpy/tractanalysis/scoring.py
@@ -25,6 +25,15 @@ def compute_f1_score(overlap, overreach):
     Compute the F1 score between overlap and overreach (they must be
     percentages).
 
+    Params
+    ------
+    overlap: float, The overlap value.
+    overreach: float, The overreach value.
+
+    Returns
+    -------
+    f1_score: float, The f1 score.
+
     Ref: https://en.wikipedia.org/wiki/F1_score
     """
     recall = overlap
@@ -37,7 +46,25 @@ def compute_dice_overlap_overreach(current_vb_voxels, gt_mask, dimensions):
     """
     Compute dice, OL and OR based on a ground truth mask.
 
-    Results are returned in number of voxels, not as percentages.
+    Params
+    ------
+    current_vb_voxels: 3D array
+        The voxels touched by at least one streamlines for a given bundle.
+    gt_mask: 3D array
+        The ground truth mask.
+    dimensions: array
+        The nibabel dimensions of the data (3D).
+
+    Returns
+    -------
+    dice: float
+        The dice score
+    overlap: int
+        The overlap (in number of voxels, not as percentages).
+    overreach: int
+        The overreach (in number of voxels).
+    lacking: int
+        The number of voxels from the gt_mask that have not been recovered.
     """
     # Dice
     dice = compute_dice_voxel(gt_mask, current_vb_voxels)[0]

--- a/scilpy/tractanalysis/scoring.py
+++ b/scilpy/tractanalysis/scoring.py
@@ -294,8 +294,8 @@ def extract_true_connections(
     nb_streamlines = len(sft)
 
     _, tc_ids = filter_grid_roi_both(sft, mask_1, mask_2)
-    logging.debug("Bundle {}: Found {}/{} streamlines with correct endpoints."
-                  .format(bundle_prefix, len(tc_ids), nb_streamlines))
+    logging.info("Bundle {}: Found {}/{} streamlines with correct endpoints."
+                 .format(bundle_prefix, len(tc_ids), nb_streamlines))
 
     wpc_ids = []
 
@@ -313,8 +313,8 @@ def extract_true_connections(
         valid_length_ids_mask_from_tc = np.logical_and(lengths > min_len,
                                                        lengths < max_len)
 
-        logging.debug("Bundle {}: Classifying {}/{} invalid length "
-                      "streamlines as wpc."
+        logging.info("Bundle {}: Classifying {}/{} invalid length "
+                     "streamlines as wpc."
                       .format(bundle_prefix,
                               sum(~valid_length_ids_mask_from_tc),
                               len(tc_ids)))
@@ -333,8 +333,8 @@ def extract_true_connections(
         valid_angle_ids = tc_ids[valid_angle_ids_from_tc]
         invalid_angle_ids = np.setdiff1d(tc_ids, valid_angle_ids)
 
-        logging.debug("Bundle {}: Classifying {}/{} invalid angle streamlines "
-                      "as wpc."
+        logging.info("Bundle {}: Classifying {}/{} invalid angle streamlines "
+                     "as wpc."
                       .format(bundle_prefix, len(invalid_angle_ids),
                               len(tc_ids)))
 
@@ -350,8 +350,8 @@ def extract_true_connections(
             tmp_sft, gt_bundle_inv_mask, 'any', False)
         out_of_mask_ids = tc_ids[out_of_mask_ids_from_tc]
 
-        logging.debug("Bundle {}: Classifying {}/{} streamlines out of ground "
-                      "truth mask as wpc."
+        logging.info("Bundle {}: Classifying {}/{} streamlines out of ground "
+                     "truth mask as wpc."
                       .format(bundle_prefix, len(out_of_mask_ids),
                               len(tc_ids)))
 

--- a/scilpy/tractanalysis/scoring.py
+++ b/scilpy/tractanalysis/scoring.py
@@ -25,7 +25,7 @@ def compute_f1_score(overlap, overreach):
     Compute the F1 score between overlap and overreach (they must be
     percentages).
 
-    Params
+    Parameters
     ------
     overlap: float, The overlap value.
     overreach: float, The overreach value.
@@ -46,7 +46,7 @@ def compute_dice_overlap_overreach(current_vb_voxels, gt_mask, dimensions):
     """
     Compute dice, OL and OR based on a ground truth mask.
 
-    Params
+    Parameters
     ------
     current_vb_voxels: 3D array
         The voxels touched by at least one streamlines for a given bundle.
@@ -281,7 +281,7 @@ def compute_endpoint_masks(roi_options, affine, dimensions, out_dir):
     If endpoints without heads/tails are loaded, split them and continue
     normally after. Q/C of the output is important.
 
-    Params
+    Parameters
     ------
     roi_options: dict
         Keys are the bundle names. For each bundle, the value is itself a

--- a/scilpy/tractanalysis/scoring.py
+++ b/scilpy/tractanalysis/scoring.py
@@ -398,13 +398,7 @@ def extract_false_connections(sft, mask_1_filename, mask_2_filename,
         mask_1 = binary_dilation(mask_1, iterations=dilate_endpoints)
         mask_2 = binary_dilation(mask_2, iterations=dilate_endpoints)
 
-    if len(sft.streamlines) > 0:
-        tmp_sft, sft = extract_tc_streamlines_ids(mask_1, mask_2, sft)
+    _, fc_ids = filter_grid_roi_both(sft, mask_1, mask_2)
 
-        streamlines = tmp_sft.streamlines
-        fc_streamlines = streamlines
-
-        fc_sft = StatefulTractogram.from_sft(fc_streamlines, sft)
-        return fc_sft, sft
-    else:
-        return sft, sft
+    fc_sft = make_sft_from_ids(fc_ids, sft)
+    return fc_sft, fc_ids

--- a/scilpy/tractanalysis/scoring.py
+++ b/scilpy/tractanalysis/scoring.py
@@ -6,7 +6,6 @@ import os
 
 from dipy.io.stateful_tractogram import StatefulTractogram
 from dipy.tracking.utils import length
-from nibabel.streamlines import ArraySequence
 from scipy.ndimage import binary_dilation
 from sklearn.cluster import KMeans
 
@@ -295,6 +294,8 @@ def extract_true_connections(
 
     wpc_ids = []
     bundle_stats = {"Bundle": bundle_prefix,
+                    "Head": head_filename,
+                    "Tail": tail_filename,
                     "Initial tc head to tail": len(tc_ids)}
 
     # Remove invalid lengths from tc
@@ -350,10 +351,7 @@ def extract_true_connections(
 
         bundle_stats.update({"TC": len(tc_ids)})
 
-    tc_sft = make_sft_from_ids(tc_ids, sft)
-    wpc_sft = make_sft_from_ids(wpc_ids, sft)
-
-    return tc_sft, wpc_sft, list(tc_ids), list(wpc_ids), bundle_stats
+    return list(tc_ids), list(wpc_ids), bundle_stats
 
 
 def extract_false_connections(sft, mask_1_filename, mask_2_filename,

--- a/scripts/scil_score_tractogram.py
+++ b/scripts/scil_score_tractogram.py
@@ -125,8 +125,8 @@ def _build_arg_parser():
                         "as 'limits_mask' for each bundle. Note that this "
                         "means the OR will necessarily be 0.")
     p.add_argument("--dilate_endpoints",
-                   metavar="NB_PASS", default=1, type=int,
-                   help="Dilate inclusion masks n-times.")
+                   metavar="NB_PASS", default=0, type=int,
+                   help="Dilate inclusion masks n-times. Default: 0.")
     p.add_argument("--compute_fc", action='store_true',
                    help="If set, false connections will be separated in sub-"
                         "bundles, one for each pair of ROI not belonging to "

--- a/scripts/scil_score_tractogram.py
+++ b/scripts/scil_score_tractogram.py
@@ -53,11 +53,11 @@ Config file:
         - angle: angle criteria. Streamlines containing loops and sharp turns
             above given angle will be rejected from the bundle.
         - length: maximum and minimum lengths per bundle.
-        - length_x / length_x_abs: maximum and mimimum total distance in the x
+        - length_x / length_x_abs: maximum and minimum total distance in the x
             direction (i.e. first coordinate).**
-        - length_y / length_y_abs: maximum and mimimum total distance in the y
+        - length_y / length_y_abs: maximum and minimum total distance in the y
             direction (i.e. second coordinate).**
-        - length_z / length_z_abs: maximum and mimimum total distance in the z
+        - length_z / length_z_abs: maximum and minimum total distance in the z
             direction (i.e. third coordinate).**
 
 * Files must be .tck, .trk, .nii or .nii.gz. If it is a tractogram, a mask will

--- a/scripts/scil_score_tractogram.py
+++ b/scripts/scil_score_tractogram.py
@@ -9,37 +9,46 @@ tractogram : *_tc.tck, *_fc.tck, nc.tck and *_wpc.tck,
 where * is the current bundle.
 
 Definitions:
+    In terms of number of streamlines:
     - tc: true connections, streamlines joining a correct combination
         of ROIs.
     - fc: false connections, streamlines joining an incorrect combination of
         ROIs.
     - nc: no connections, streamlines not joining two ROIs.
     - wpc: wrong path connections, streamlines that go outside of the ground
-        truth mask, joining a correct combination of ROIs.
-    - Bundle overlap : ground truth voxels containing tc streamline(s).
+        truth mask, joining a correct combination of ROIs. One wpc file per
+        bundle will be saved. They could contain duplicated if your ROIs
+        overlap. The final total wpc file, however, will not contain
+        duplicates.
 
-Masks can be dilated with --dilate_endpoints for bundle recognition.
+    In terms of number of voxels:
+    - Bundle overlap : ground truth voxels containing tc streamline(s).
 
 Config dictionnary needs to be a json containing a dict of the ground-truth
 bundles as keys and the value being a dictionnary with
     - endpoints OR head/tail: filename for the endpoints ROI.
         If 'enpoints' is used, we will automatically separate the mask into
         two ROIs, acting as head and tail. QC is strongly recommended.
-    - bundle_mask (optional): if set, streamlines outside this ground truth
-        path will be defined as wpc. Files must be .tck, .trk, .nii or .nii.gz
-        filenames. If it is is a tractogram, a mask will be created. If it is a
-        nifti file, it will be considered as a mask.
+    - gt_mask: Expected result. Overreach and overlap metrics (OR, OL) will be
+        computed from this mask.*
+    - limits_mask (optional): if set, streamlines outside this path will be
+        defined as wrong path connections (wpc) if they are not included in
+        any other bundle as tc. This is thus the equivalent of 'include' 'all'
+        in our typical filtering scripts.*
     - angle (optional): if set, we will remove loops and sharp turns (up to
-        given angle) for the bundle.**
+        given angle) for the bundle. Removed streamlines will be classified as
+        wpc.**
     - length (optional): maximum and minimum lengths per bundle. Streamlines
-        outside this range will be classified as false connections even if they
-        do connect the right ROIs.**
+        outside this range will be classified as wpc.**
 
-**Rejected streamlines will be classified as wrong path connections.
+* Files must be .tck, .trk, .nii or .nii.gz. If it is is a tractogram, a mask
+will be created. If it is a nifti file, it will be considered as a mask.
+** Rejected streamlines will be classified as wrong path connections.
 
 Ex 1:
 {
   "Ground_truth_bundle_0": {
+    "gt_mask": "PATH/bundle0.nii.gz",
     "angle": 300,
     "length": [140, 150],
     "endpoints": PATH/'file1'
@@ -49,9 +58,10 @@ Ex 1:
 Ex 2:
 {
   "Ground_truth_bundle_1": {
+    "gt_mask": "bundle1.trk"
     "head": 'file2',
     "tail": 'file3',
-    "bundle_mask": ground_truth_bundle_1.nii.gz
+    "limits_mask": big_bundle_1.nii.gz
   }
 }
 (used with options --bundle_masks_dir PATH1 --rois_dir PATH2)
@@ -76,7 +86,7 @@ from scilpy.io.utils import (add_overwrite_arg,
                              assert_inputs_exist,
                              assert_output_dirs_exist_and_empty)
 from scilpy.tractanalysis.reproducibility_measures import compute_dice_voxel
-from scilpy.tractanalysis.scoring import (compute_gt_masks,
+from scilpy.tractanalysis.scoring import (compute_masks,
                                           extract_false_connections,
                                           extract_true_connections,
                                           get_binary_maps,
@@ -98,17 +108,25 @@ def _build_arg_parser():
     p.add_argument("out_dir",
                    help="Output directory")
 
-    p.add_argument("--bundle_masks_dir", default='',
-                   help="Path of the bundle paths listed in the gt_config.\n "
+    p.add_argument("--gt_masks_dir", default='',
+                   help="Path of the gt_masks listed in the gt_config.\n "
                         "If not set, filenames in the config file are "
                         "considered as complete paths.")
+    p.add_argument("--limits_masks_dir", default='',
+                   help="Path of the limits_masks listed in the "
+                        "gt_config.\n If not set, filenames in the config "
+                        "file are considered as complete paths.")
     p.add_argument("--rois_dir", default='',
-                   help="Path of the ROI files listed in the gt_config.\n If "
-                        "not set, filenames in the config file are considered "
-                        "as complete paths.")
+                   help="Path of the ROI files listed in the gt_config (head, "
+                        "tail of endpoints).\n If not set, filenames in the "
+                        "config file are considered as complete paths.")
+    p.add_argument("--use_gt_masks_as_limits_masks", action='store_true',
+                   help="If set, the gt_config's 'gt_mask' will also be used "
+                        "as 'limits_mask' for each bundle. Note that this "
+                        "means the OR will necessarily be 0.")
     p.add_argument("--dilate_endpoints",
                    metavar="NB_PASS", default=1, type=int,
-                   help="Dilate masks n-times.")
+                   help="Dilate inclusion masks n-times.")
     p.add_argument("--remove_invalid", action="store_true",
                    help="Remove invalid streamlines before scoring.")
     p.add_argument("--no_empty", action='store_true',
@@ -129,20 +147,25 @@ def extract_prefix(filename):
     return prefix
 
 
-def read_config_file(gt_config, bundle_masks_dir, rois_dir):
-    # Create
-    # roi_options = {
-    #      'bundle1': {
-    #              'gt_endpoints': path + file,  # OR
-    #              'gt_head': path + file
-    #              'gt_tail': path + file}}
+def read_config_file(args):
+    """
+    Read the gt_config file and returns:
+
+    angles: the list of maximum angles per bundle (None if not set)
+    lengths: the list of [min max] lengths per bundle (None if not set)
+    gt_masks: the list of gt_mask filenames per bundle (None if not set)
+    limits_masks: the list of limits_masks filenames per bundles (None if not
+          set)
+    roi_options: a dict with, for each bundle, the keys 'gt_head', 'gt_tail' if
+          they are set, else the key 'gt_endpoints'.
+    """
     angles = []
     lengths = []
-    masks = []
+    gt_masks = []
+    limits_masks = []
     roi_options = {}
-    roi_files = []
 
-    with open(gt_config, "r") as json_file:
+    with open(args.gt_config, "r") as json_file:
         config = json.load(json_file)
 
         bundles = list(config.keys())
@@ -158,39 +181,71 @@ def read_config_file(gt_config, bundle_masks_dir, rois_dir):
             else:
                 lengths.append(None)
 
-            if 'bundle_mask' in bundle_config:
-                masks.append(os.path.join(bundle_masks_dir,
-                                          bundle_config['bundle_mask']))
+            if 'gt_mask' in bundle_config:
+                gt_masks.append(os.path.join(args.gt_masks_dir,
+                                             bundle_config['gt_mask']))
             else:
-                masks.append(None)
+                logging.warning(
+                    "No gt_mask set for bundle {}. Some tractometry metrics "
+                    "won't be computed (OR, OL).".format(bundle))
+                gt_masks.append(None)
+
+            if 'limits_mask' in bundle_config:
+                if args.use_gt_masks_as_limits_masks:
+                    raise ValueError(
+                        "With the option --use_gt_masks_as_limits_masks, "
+                        "you should not add any limits_mask in the config "
+                        "file.")
+                limits_masks.append(os.path.join(args.limits_masks_dir,
+                                                 bundle_config['limits_mask']))
+            else:
+                if args.use_gt_masks_as_limits_masks:
+                    limits_masks.append(gt_masks[-1])
+                else:
+                    limits_masks.append(None)
 
             if 'endpoints' in bundle_config:
                 if 'head' in bundle_config or 'tail' in bundle_config:
-                    raise ValueError("Bundle {} has confusion keywords in the "
-                                     "config file. Please choose either "
-                                     "endpoints OR head/tail.".format(bundle))
-                endpoints = os.path.join(rois_dir, bundle_config['endpoints'])
-                roi_options.update({
-                    bundle: {'gt_endpoints': endpoints}})
-                roi_files.append(endpoints)
+                    raise ValueError(
+                        "Bundle {} has confusion keywords in the config file. "
+                        "Please choose either endpoints OR head/tail."
+                        .format(bundle))
+                endpoints = os.path.join(args.rois_dir,
+                                         bundle_config['endpoints'])
+                roi_options.update({bundle: {'gt_endpoints': endpoints}})
             elif 'head' in bundle_config:
                 if 'tail' not in bundle_config:
-                    raise ValueError("You have provided the head for bundle "
-                                     "{}, but not the tail".format(bundle))
-                head = os.path.join(rois_dir, bundle_config['head'])
-                tail = os.path.join(rois_dir, bundle_config['tail'])
-                roi_options.update({
-                    bundle: {
-                        'gt_head': head,
-                        'gt_tail': tail
-                    }})
-                roi_files.append(head)
-                roi_files.append(tail)
+                    raise ValueError(
+                        "You have provided the head for bundle {}, but not "
+                        "the tail".format(bundle))
+                head = os.path.join(args.rois_dir, bundle_config['head'])
+                tail = os.path.join(args.rois_dir, bundle_config['tail'])
+                roi_options.update({bundle: {'gt_head': head,
+                                             'gt_tail': tail
+                                             }})
             else:
-                raise ValueError("Bundle configuration for bundle {} misses "
-                                 "'endpoints' or 'head'/'tail'".format(bundle))
+                raise ValueError(
+                    "Bundle configuration for bundle {} misses 'endpoints' or "
+                    "'head'/'tail'".format(bundle))
 
-    return bundles, masks, roi_options, roi_files, lengths, angles
+    return bundles, gt_masks, limits_masks, roi_options, lengths, angles
+
+
+def _verify_compatibility_with_bundles(sft, masks_files, parser, args):
+    """
+    Verifies the compatibility of the main sft with the bundle masks, which can
+    be either tractograms or nifti files.
+    """
+    for file in masks_files:
+        _, ext = os.path.splitext(file)
+        if ext in ['.trk', '.tck']:
+            mask = load_tractogram_with_reference(parser, args, file,
+                                                  bbox_check=False)
+        else:
+            mask = file
+        compatible = is_header_compatible(sft, mask)
+        if not compatible:
+            parser.error("Input tractogram incompatible with {}".format(file))
 
 
 def main():
@@ -208,16 +263,18 @@ def main():
     # Preparation
     # -----------
     # Read the config file
-    bundles_names, masks, roi_options, all_rois, lengths, angles = \
-        read_config_file(args.gt_config, args.bundle_masks_dir, args.rois_dir)
+    (bundles_names, gt_masks_files, limits_masks_files, roi_options,
+     lengths, angles) = read_config_file(args)
     nb_bundles = len(bundles_names)
 
-    # Remove duplicates
-    # (in case a same roi file is used for more than one bundle)
-    all_rois = list(dict.fromkeys(all_rois))
+    # Find all masks to be loaded.
+    all_rois = list(itertools.chain(
+        *[list(roi_options[b].values()) for b in roi_options]))
+    all_rois = list(dict.fromkeys(all_rois))  # Remove duplicates
 
     # Verify options
-    assert_inputs_exist(parser, masks + all_rois)
+    assert_inputs_exist(parser, gt_masks_files + limits_masks_files +
+                        all_rois + [args.in_tractogram])
 
     if args.verbose:
         logging.basicConfig(level=logging.INFO)
@@ -232,22 +289,18 @@ def main():
 
     initial_count = len(sft)
 
-    logging.info("Verifying compatibility of tractogram with bundle masks.")
-    for gt in masks:
-        _, gt_ext = os.path.splitext(gt)
-        if gt_ext in ['.trk', '.tck']:
-            gt_bundle = load_tractogram_with_reference(
-                parser, args, gt, bbox_check=False)
-        else:
-            gt_bundle = gt
-        compatible = is_header_compatible(sft, gt_bundle)
-        if not compatible:
-            parser.error("Input tractogram incompatible with"
-                         " {}".format(gt))
+    logging.info("Verifying compatibility of tractogram with gt_masks and "
+                 "limits_masks.")
+    all_masks = gt_masks_files + limits_masks_files
+    all_masks = list(dict.fromkeys(all_masks))  # Removes duplicates
+    _verify_compatibility_with_bundles(sft, all_masks, parser, args)
 
-    logging.info("Loading and/or computing ground-truth masks.")
-    gt_bundle_masks, gt_bundle_inv_masks, affine, dimensions, = \
-        compute_gt_masks(masks, parser, args)
+    logging.info("Loading and/or computing ground-truth masks and limits "
+                 "masks.")
+    gt_masks, _, affine, dimensions, = \
+        compute_masks(gt_masks_files, parser, args)
+    limits_masks, limits_inv_masks, _, _, = \
+        compute_masks(limits_masks_files, parser, args)
 
     logging.info("Extracting ground-truth head and tail masks.")
     gt_tails, gt_heads = compute_endpoint_masks(
@@ -255,16 +308,22 @@ def main():
 
     # Update all_rois, remove duplicates
     all_rois = gt_tails + gt_heads
-    all_rois = list(dict.fromkeys(all_rois))
+    all_rois = list(dict.fromkeys(all_rois))  # Removes duplicates
 
     logging.info("Verifying tractogram compatibility with endpoint ROIs.")
-    for gt in gt_tails + gt_heads:
-        compatible = is_header_compatible(sft, gt)
+    for file in all_rois:
+        compatible = is_header_compatible(sft, file)
         if not compatible:
-            parser.error("Input tractogram incompatible with {}".format(gt))
+            parser.error("Input tractogram incompatible with {}".format(file))
 
     # -----------
-    # True connections
+    # True connections:
+    #    1) Connect the head and tail
+    #    2) Are completely included in the limits_mask (if any)
+    #    3) Have acceptable angle and length.
+    # +
+    # WPC connections (connect the head and tail but criteria 2 and 3 are
+    #   not respected)
     # -----------
     logging.info("Scoring true connections (and wpc)")
 
@@ -275,17 +334,18 @@ def main():
     tc_ids_list = []
     wpc_sft_list = []
     wpc_ids_list = []
-    for i, (mask_1_filename, mask_2_filename) in enumerate(tc_filenames):
+    for i, (head_filename, tail_filename) in enumerate(tc_filenames):
 
         # Automatically generate filename for Q/C
-        prefix_1 = extract_prefix(mask_1_filename)
-        prefix_2 = extract_prefix(mask_2_filename)
+        prefix_1 = extract_prefix(head_filename)
+        prefix_2 = extract_prefix(tail_filename)
 
         # Extract true connection
-        tc_sft, wpc_sft, tc_ids, wpc_ids = extract_true_connections(
-            sft, mask_1_filename, mask_2_filename, lengths[i], angles[i],
-            bundles_names[i], gt_bundle_inv_masks[i],
-            args.dilate_endpoints)
+        tc_sft, wpc_sft, tc_ids, wpc_ids, bundle_stats = \
+            extract_true_connections(sft, head_filename, tail_filename,
+                                     lengths[i], angles[i], bundles_names[i],
+                                     limits_inv_masks[i],
+                                     args.dilate_endpoints)
 
         # Save results
         if len(tc_sft) > 0 or not args.no_empty:
@@ -305,73 +365,80 @@ def main():
         wpc_sft_list.append(wpc_sft)
         wpc_ids_list.append(wpc_ids)
 
+        logging.info(json.dumps(bundle_stats, indent=4))
+
     # Duplicates?
-    tc_and_wpc = [tc_ids_list[i] + wpc_ids_list[i] for i in
-                  range(len(tc_ids_list))]
     for i in range(nb_bundles):
         for j in range(i + 1, nb_bundles):
-            duplicate_ids = np.intersect1d(tc_and_wpc[i], tc_and_wpc[j])
+            duplicate_ids = np.intersect1d(tc_ids_list[i], tc_ids_list[j])
             if len(duplicate_ids) > 0:
                 logging.warning(
-                    "{} streamlines belong both to bundle {} and {}. Please "
-                    "verify your criteria!"
+                    "{} streamlines belong both to true connections of both "
+                    "bundles {} and {}. Please verify your criteria!"
                     .format(len(duplicate_ids), bundles_names[i],
                             bundles_names[j]))
 
     # -----------
     # False connections
     # -----------
-    logging.info("Scoring false connections")
+    if args.compute_fc:
+        logging.info("Scoring false connections")
 
-    # Keep all possible combinations
-    all_rois = sorted(all_rois)
-    comb_filename = list(itertools.combinations(all_rois, r=2))
+        # Keep all possible combinations
+        all_rois = sorted(all_rois)
+        comb_filename = list(itertools.combinations(all_rois, r=2))
 
-    # Remove the true connections from all combinations, leaving only
-    # false connections
-    for tc_f in tc_filenames:
-        tc_f = tuple(sorted(tc_f))
-        comb_filename.remove(tc_f)
+        # Remove the true connections from all combinations, leaving only
+        # false connections
+        for tc_f in tc_filenames:
+            tc_f = tuple(sorted(tc_f))
+            comb_filename.remove(tc_f)
 
-    # Go through all the possible combinations of endpoints masks
-    fc_sft_list = []
-    fc_ids_list = []
-    for i, roi in enumerate(comb_filename):
-        mask_1_filename, mask_2_filename = roi
+        # Go through all the possible combinations of endpoints masks
+        fc_sft_list = []
+        fc_ids_list = []
+        for i, roi in enumerate(comb_filename):
+            head_filename, tail_filename = roi
 
-        # Automatically generate filename for Q/C
-        prefix_1 = extract_prefix(mask_1_filename)
-        prefix_2 = extract_prefix(mask_2_filename)
-        _, ext = os.path.splitext(args.in_tractogram)
+            # Automatically generate filename for Q/C
+            prefix_1 = extract_prefix(head_filename)
+            prefix_2 = extract_prefix(tail_filename)
+            _, ext = os.path.splitext(args.in_tractogram)
 
-        fc_sft, fc_ids = extract_false_connections(
-            sft, mask_1_filename, mask_2_filename, args.dilate_endpoints)
+            fc_sft, fc_ids = extract_false_connections(
+                sft, head_filename, tail_filename, args.dilate_endpoints)
 
-        if len(fc_sft) > 0 or not args.no_empty:
-            save_tractogram(fc_sft, os.path.join(
-                args.out_dir,
-                "segmented_IB/{}_{}_fc{}".format(prefix_1, prefix_2, ext)),
-                            bbox_valid_check=False)
+            if len(fc_sft) > 0 or not args.no_empty:
+                save_tractogram(fc_sft, os.path.join(
+                    args.out_dir,
+                    "segmented_IB/{}_{}_fc{}".format(prefix_1, prefix_2, ext)),
+                                bbox_valid_check=False)
 
-        if len(fc_sft.streamlines) > 0:
-            logging.info("Recognized {} streamlines between {} and {}"
-                         .format(len(fc_sft.streamlines), prefix_1, prefix_2))
+            if len(fc_sft.streamlines) > 0:
+                logging.info("Recognized {} streamlines between {} and {}"
+                             .format(len(fc_sft.streamlines), prefix_1, prefix_2))
 
-        fc_sft_list.append(fc_sft)
-        fc_ids_list.append(fc_ids)
+            fc_sft_list.append(fc_sft)
+            fc_ids_list.append(fc_ids)
 
-    # Duplicates?
-    nb_pairs = len(fc_ids_list)
-    for i in range(nb_pairs):
-        for j in range(i + 1, nb_pairs):
-            duplicate_ids = np.intersect1d(fc_ids_list[i], fc_ids_list[j])
-            if len(duplicate_ids) > 0:
-                logging.warning(
-                    "{} streamlines are scored twice as invalid connections \n"
-                    "(between pair {}\n and between pair {}).\n You probably "
-                    "have overlapping ROIs!"
-                    .format(len(duplicate_ids), comb_filename[i],
-                            comb_filename[j]))
+        # Duplicates?
+        nb_pairs = len(fc_ids_list)
+        for i in range(nb_pairs):
+            for j in range(i + 1, nb_pairs):
+                duplicate_ids = np.intersect1d(fc_ids_list[i], fc_ids_list[j])
+                if len(duplicate_ids) > 0:
+                    logging.warning(
+                        "{} streamlines are scored twice as invalid "
+                        "connections \n (between pair {}\n and between pair "
+                        "{}).\n You probably have overlapping ROIs!"
+                        .format(len(duplicate_ids), comb_filename[i],
+                                comb_filename[j]))
+
+        all_fc_ids = np.unique(list(itertools.chain(*fc_ids_list)))
+    else:
+        fc_ids_list = []
+        fc_sft_list = []
+        all_fc_ids = []
 
     # -----------
     # No connections
@@ -409,7 +476,9 @@ def main():
     if total_count != initial_count:
         logging.warning("Total count tc + fc + wpc + nc is not the same as "
                         "the number of streamlines in the input tractogram.\n"
-                        "Verify your ROIs, or this script.")
+                        "Verify your ROIs, or this script.\n"
+                        "Total: {}. SFT: {}"
+                        .format(total_count, initial_count))
 
     final_results = {
         "tractogram_filename": str(args.in_tractogram),
@@ -444,43 +513,52 @@ def main():
             current_tc_streamlines, sft)
         current_wpc_voxels, _ = get_binary_maps(current_wpc_streamlines, sft)
 
-        # Dice
-        tc_dice = compute_dice_voxel(gt_bundle_masks[i], current_tc_voxels)
-        wpc_dice = compute_dice_voxel(gt_bundle_masks[i], current_wpc_voxels)
+        if gt_masks[i] is not None:
+            # Dice
+            tc_dice = compute_dice_voxel(gt_masks[i], current_tc_voxels)[0]
+            wpc_dice = compute_dice_voxel(gt_masks[i], current_wpc_voxels)[0]
 
-        # Overlap and overreach
-        bundle_overlap = gt_bundle_masks[i] * current_tc_voxels
-        bundle_overreach = np.zeros(dimensions)
-        # If no ground truth bundle was given (only the endpoints ROIs),
-        # overreach can be computed as usual
-        bundle_overreach[np.where(
-            (gt_bundle_masks[i] == 0) & (current_tc_voxels >= 1))] = 1
-        # If a ground truth bundle has been given, all streamlines contributing
-        # to the overreach are now classified as wpc.
-        bundle_overreach[np.where(
-            (gt_bundle_masks[i] == 0) & (current_wpc_voxels >= 1))] = 1
+            # Overlap and overreach
+            bundle_overlap = gt_masks[i] * current_tc_voxels
+            bundle_overreach = np.zeros(dimensions)
+            # If no ground truth bundle was given (only the endpoints ROIs),
+            # overreach can be computed as usual
+            bundle_overreach[np.where(
+                (gt_masks[i] == 0) & (current_tc_voxels >= 1))] = 1
+            # If a ground truth bundle has been given, all streamlines
+            # contributing to the overreach are now classified as wpc.
+            bundle_overreach[np.where(
+                (gt_masks[i] == 0) & (current_wpc_voxels >= 1))] = 1
 
-        bundle_lacking = np.zeros(dimensions)
-        bundle_lacking[np.where(
-            (gt_bundle_masks[i] == 1) & (current_tc_voxels == 0))] = 1
+            bundle_lacking = np.zeros(dimensions)
+            bundle_lacking[np.where(
+                (gt_masks[i] == 1) & (current_tc_voxels == 0))] = 1
 
-        overlap = np.count_nonzero(bundle_overlap)
-        overreach = np.count_nonzero(bundle_overreach)
-        lacking = np.count_nonzero(bundle_lacking)
+            overlap = np.count_nonzero(bundle_overlap)
+            overreach = np.count_nonzero(bundle_overreach)
+            lacking = np.count_nonzero(bundle_lacking)
 
-        # Endpoints coverage
-        endpoints_overlap = gt_bundle_masks[i] * current_tc_endpoints_voxels
-        endpoints_overreach = np.zeros(dimensions)
-        endpoints_overreach[np.where(
-            (gt_bundle_masks[i] == 0) &
-            (current_tc_endpoints_voxels >= 1))] = 1
+            # Endpoints coverage
+            endpoints_overlap = gt_masks[i] * current_tc_endpoints_voxels
+            endpoints_overreach = np.zeros(dimensions)
+            endpoints_overreach[np.where(
+                (gt_masks[i] == 0) &
+                (current_tc_endpoints_voxels >= 1))] = 1
+        else:
+            tc_dice = None
+            wpc_dice = None
+            overlap = None
+            overreach = None
+            lacking = None
+            endpoints_overlap = None
+            endpoints_overreach = None
 
         tmp_dict = {
             "bundle": bundles_names[i],
             "tc_streamlines": len(current_tc_streamlines),
             "wpc_streamlines": len(current_wpc_streamlines),
-            "tc_dice": tc_dice[0],
-            "wpc_dice": wpc_dice[0],
+            "tc_dice": tc_dice,
+            "wpc_dice": wpc_dice,
             "tc_bundle_overlap": overlap,
             "tc_bundle_overreach": overreach,
             "tc_bundle_lacking": lacking,
@@ -517,7 +595,7 @@ def main():
 
     final_results.update({
         "bundle_wise": bundle_wise_dict,
-        "tractogram_overlap": tractogram_overlap / len(gt_bundle_masks)
+        "tractogram_overlap": tractogram_overlap / nb_bundles
     })
 
     logging.info("Final results saved in {}".format(args.out_dir))

--- a/scripts/scil_score_tractogram.py
+++ b/scripts/scil_score_tractogram.py
@@ -108,7 +108,6 @@ from scilpy.tractanalysis.scoring import (compute_masks,
                                           extract_false_connections,
                                           get_binary_maps,
                                           compute_endpoint_masks,
-                                          make_sft_from_ids,
                                           extract_vb_vs, compute_f1_score,
                                           compute_dice_overlap_overreach)
 from scilpy.utils.filenames import split_name_with_nii
@@ -458,7 +457,7 @@ def compute_vb_vs_all_bundles(
                 orientation_lengths[i], abs_orientation_lengths[i],
                 limits_inv_masks[i], args.dilate_endpoints)
 
-        vb_sft = make_sft_from_ids(vs_ids, sft)
+        vb_sft = sft[vs_ids]
 
         # Save results
         if len(vb_sft) > 0 or not args.no_empty:
@@ -520,7 +519,7 @@ def save_wpc_all_bundles(wpc_ids_list, sft, bundles_names, args, vs_ids_list,
                 {"Belonging to another bundle": nb_rejected})
             wpc_ids = new_wpc_ids
 
-        wpc_sft = make_sft_from_ids(wpc_ids, sft)
+        wpc_sft = sft[wpc_ids]
         wpc_sft_list.append(wpc_sft)
 
         if len(wpc_ids) > 0 or not args.no_empty:
@@ -804,7 +803,7 @@ def main():
                      .format(len(all_nc_ids), len(sft)))
         filename = "IS.trk"
 
-    nc_sft = make_sft_from_ids(all_nc_ids, sft)
+    nc_sft = sft[all_nc_ids]
     if len(nc_sft) > 0 or not args.no_empty:
         save_tractogram(nc_sft, os.path.join(
             args.out_dir, filename), bbox_valid_check=False)

--- a/scripts/tests/test_score_tractogram.py
+++ b/scripts/tests/test_score_tractogram.py
@@ -1,3 +1,4 @@
+import json
 import os
 import tempfile
 
@@ -17,11 +18,22 @@ def test_help_option(script_runner):
 
 def test_score_bundles(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
-    in_tractogram = os.path.join(get_home(), 'tracking',
-                                 'pft.trk')
-    models = os.path.join(get_home(), 'tracking', 'seeding_mask.nii.gz')
-    endpoints = os.path.join(get_home(), 'tracking', 'interface.nii.gz')
+    in_tractogram = os.path.join(get_home(), 'tracking', 'pft.trk')
+
+    json_contents = {
+        "example_bundle": {
+            "angle": 300,
+            "length": [30, 190],
+            "bundle_mask": os.path.join(get_home(), 'tracking',
+                                        'seeding_mask.nii.gz'),
+            "endpoints": os.path.join(get_home(), 'tracking',
+                                      'interface.nii.gz')
+        }
+    }
+    with open(os.path.join("config_file.json"), "w") as f:
+        json.dump(json_contents, f)
+
     ret = script_runner.run('scil_score_tractogram.py',
-                            in_tractogram, models,
-                            '--gt_endpoints', endpoints)
+                            in_tractogram, "config_file.json",
+                            'scoring_results/', '--no_empty')
     assert ret.success

--- a/scripts/tests/test_score_tractogram.py
+++ b/scripts/tests/test_score_tractogram.py
@@ -24,8 +24,8 @@ def test_score_bundles(script_runner):
         "example_bundle": {
             "angle": 300,
             "length": [30, 190],
-            "bundle_mask": os.path.join(get_home(), 'tracking',
-                                        'seeding_mask.nii.gz'),
+            "gt_mask": os.path.join(get_home(), 'tracking',
+                                    'seeding_mask.nii.gz'),
             "endpoints": os.path.join(get_home(), 'tracking',
                                       'interface.nii.gz')
         }
@@ -35,5 +35,6 @@ def test_score_bundles(script_runner):
 
     ret = script_runner.run('scil_score_tractogram.py',
                             in_tractogram, "config_file.json",
-                            'scoring_results/', '--no_empty')
+                            'scoring_results/', '--no_empty',
+                            '--use_gt_masks_as_limits_masks')
     assert ret.success


### PR DESCRIPTION
Mainly two changes (although that makes a lot of changed lines, sorry!)

- Including the options `--gt_heads, --gt_tails`, and the grount truth bundle directly into the json config file. This way:
       -  Options can vary per bundle
                  (ex: use only the head/tail ROI for one, but include a ground truth mask for another)
       -  Same ROIs can be used for many bundles
        (ex: a ROI named 'occipital' could be used to define many bundle without having to copy it locally as bundle1_head and bundle2_head)
       - A lot less dangerous to mix up the order of the bundles
       (compared, say, to using `--gt_head *_heads --gt_tails *_tails`)
       
- Changed the code to deal with streamline ids instead of streamlines themselves (as per the #todo that was left).

Also, I now compute each bundle from the whole tractogram instead of from the remaining streamlines after each. This way, it is possible to discover if some ROIs have overlapping voxels, leading to streamlines accepted in more than one (valid or invalid) bundle. 


Should be ready but I will test it more and modify the test file.