### PR TITLE
Fix wrong condition for is_voxel_in_bound used in dev tracking

### DIFF
--- a/scilpy/image/datasets.py
+++ b/scilpy/image/datasets.py
@@ -83,9 +83,9 @@ class DataVolume(object):
         out: bool
             True if voxel is in dataset range, False otherwise.
         """
-        return (0 <= i <= (self.dim[0] - 1) and
-                0 <= j <= (self.dim[1] - 1) and
-                0 <= k <= (self.dim[2] - 1))
+        return (0 <= i < (self.dim[0]) and
+                0 <= j < (self.dim[1]) and
+                0 <= k < (self.dim[2]))
 
     def voxmm_to_idx(self, x, y, z, origin):
         """


### PR DESCRIPTION
The condition for `is_voxel_in_bound` is wrong in the `DataVolume` class.

Because we are in `voxmm` space with origin `corner`, the volume bounds should be `[0, dims[0][`, `[0, dims[1][`, `[0, dims[2][`.

Take for example a volume 1mm-iso with a length of 2 along some axis. The first voxel is contained between indices `[0, 1[` mm and the second voxel is contained between indices `[1, 2[` mm. The previous condition would have placed the upper bound at `1`, and therefore ignored the last slice completely.

Do you agree @EmmaRenauld ?