### PR TITLE
Adding new filtering script by orientation

### DIFF
--- a/scilpy/tracking/tools.py
+++ b/scilpy/tracking/tools.py
@@ -117,19 +117,19 @@ def filter_streamlines_by_total_length_per_dim(
         total_per_orientation = np.abs(np.asarray(
             [np.sum(d, axis=0) for d in all_dirs]))
 
-    logging.info("Total length per orientation is:\n"
-                 "Average: x: {:.2f}, y: {:.2f}, z: {:.2f} \n"
-                 "Min: x: {:.2f}, y: {:.2f}, z: {:.2f} \n"
-                 "Max: x: {:.2f}, y: {:.2f}, z: {:.2f} \n"
-                 .format(np.mean(total_per_orientation[:, 0]),
-                         np.mean(total_per_orientation[:, 1]),
-                         np.mean(total_per_orientation[:, 2]),
-                         np.min(total_per_orientation[:, 0]),
-                         np.min(total_per_orientation[:, 1]),
-                         np.min(total_per_orientation[:, 2]),
-                         np.max(total_per_orientation[:, 0]),
-                         np.max(total_per_orientation[:, 1]),
-                         np.max(total_per_orientation[:, 2])))
+    logging.debug("Total length per orientation is:\n"
+                  "Average: x: {:.2f}, y: {:.2f}, z: {:.2f} \n"
+                  "Min: x: {:.2f}, y: {:.2f}, z: {:.2f} \n"
+                  "Max: x: {:.2f}, y: {:.2f}, z: {:.2f} \n"
+                  .format(np.mean(total_per_orientation[:, 0]),
+                          np.mean(total_per_orientation[:, 1]),
+                          np.mean(total_per_orientation[:, 2]),
+                          np.min(total_per_orientation[:, 0]),
+                          np.min(total_per_orientation[:, 1]),
+                          np.min(total_per_orientation[:, 2]),
+                          np.max(total_per_orientation[:, 0]),
+                          np.max(total_per_orientation[:, 1]),
+                          np.max(total_per_orientation[:, 2])))
 
     # Find good ids
     mask_good_x = np.logical_and(limits_x[0] < total_per_orientation[:, 0],

--- a/scilpy/tracking/tools.py
+++ b/scilpy/tracking/tools.py
@@ -9,6 +9,24 @@ from scipy.interpolate import splev, splprep
 from scipy.ndimage.filters import gaussian_filter1d
 
 
+def _filter_sft_by_mask(sft, mask_of_ids_to_keep):
+    """
+    Keep only the streamlines for which the associated value is True in mask.
+    """
+    filtered_streamlines = list(np.asarray(sft.streamlines,
+                                           dtype=object)[mask_of_ids_to_keep])
+    filtered_data_per_point = sft.data_per_point[mask_of_ids_to_keep]
+    filtered_data_per_streamline = sft.data_per_streamline[mask_of_ids_to_keep]
+
+    # Create final sft
+    filtered_sft = StatefulTractogram.from_sft(
+        filtered_streamlines, sft,
+        data_per_point=filtered_data_per_point,
+        data_per_streamline=filtered_data_per_streamline)
+
+    return filtered_sft
+
+
 def filter_streamlines_by_length(sft, min_length=0., max_length=np.inf):
     """
     Filter streamlines using minimum and max length.
@@ -42,21 +60,97 @@ def filter_streamlines_by_length(sft, min_length=0., max_length=np.inf):
     else:
         filter_stream = []
 
-    filtered_streamlines = list(np.asarray(sft.streamlines,
-                                           dtype=object)[filter_stream])
-    filtered_data_per_point = sft.data_per_point[filter_stream]
-    filtered_data_per_streamline = sft.data_per_streamline[filter_stream]
-
-    # Create final sft
-    filtered_sft = StatefulTractogram.from_sft(
-        filtered_streamlines, sft,
-        data_per_point=filtered_data_per_point,
-        data_per_streamline=filtered_data_per_streamline)
+    filtered_sft = _filter_sft_by_mask(sft, filter_stream)
 
     # Return to original space
     filtered_sft.to_space(orig_space)
 
     return filtered_sft
+
+
+def filter_streamlines_by_total_length_per_dim(
+        sft, limits_x, limits_y, limits_z, use_abs, save_rejected):
+    """
+    Filter streamlines using sum of abs length per dimension.
+
+    Note: we consider that x, y, z are the coordinates of the streamlines; we
+    do not verify if they are aligned with the brain's orientation.
+
+    Parameters
+    ----------
+    sft: StatefulTractogram
+        SFT containing the streamlines to filter.
+    limits_x: [float float]
+        The list of [min, max] for the x coordinates.
+    limits_y: [float float]
+        The list of [min, max] for the y coordinates.
+    limits_z: [float float]
+        The list of [min, max] for the z coordinates.
+    use_abs: bool
+        If True, will use the total of distances in absolute value (ex,
+        coming back on yourself will contribute to the total distance
+        instead of cancelling it).
+    save_rejected: bool
+        If true, also returns the SFT of rejected streamlines. Else, returns
+        None.
+
+    Return
+    ------
+    filtered_sft : StatefulTractogram
+        A tractogram of accepted streamlines.
+    ids: list
+        The list of good ids.
+    rejected_sft: StatefulTractogram or None
+        A tractogram of rejected streamlines.
+    """
+    # Make sure we are in world space
+    orig_space = sft.space
+    sft.to_rasmm()
+
+    # Compute directions
+    all_dirs = [np.diff(s, axis=0) for s in sft.streamlines]
+    if use_abs:
+        total_per_orientation = np.asarray(
+            [np.sum(np.abs(d), axis=0) for d in all_dirs])
+    else:
+        # We add the abs on the total length, not on each small movement.
+        total_per_orientation = np.abs(np.asarray(
+            [np.sum(d, axis=0) for d in all_dirs]))
+
+    logging.info("Total length per orientation is:\n"
+                 "Average: x: {:.2f}, y: {:.2f}, z: {:.2f} \n"
+                 "Min: x: {:.2f}, y: {:.2f}, z: {:.2f} \n"
+                 "Max: x: {:.2f}, y: {:.2f}, z: {:.2f} \n"
+                 .format(np.mean(total_per_orientation[:, 0]),
+                         np.mean(total_per_orientation[:, 1]),
+                         np.mean(total_per_orientation[:, 2]),
+                         np.min(total_per_orientation[:, 0]),
+                         np.min(total_per_orientation[:, 1]),
+                         np.min(total_per_orientation[:, 2]),
+                         np.max(total_per_orientation[:, 0]),
+                         np.max(total_per_orientation[:, 1]),
+                         np.max(total_per_orientation[:, 2])))
+
+    # Find good ids
+    mask_good_x = np.logical_and(limits_x[0] < total_per_orientation[:, 0],
+                                 total_per_orientation[:, 0] < limits_x[1])
+    mask_good_y = np.logical_and(limits_y[0] < total_per_orientation[:, 1],
+                                 total_per_orientation[:, 1] < limits_y[1])
+    mask_good_z = np.logical_and(limits_z[0] < total_per_orientation[:, 2],
+                                 total_per_orientation[:, 2] < limits_z[1])
+    mask_good_ids = np.logical_and(mask_good_x, mask_good_y)
+    mask_good_ids = np.logical_and(mask_good_ids, mask_good_z)
+
+    filtered_sft = _filter_sft_by_mask(sft, mask_good_ids)
+
+    rejected_sft = None
+    if save_rejected:
+        rejected_sft = _filter_sft_by_mask(sft, ~mask_good_ids)
+
+    # Return to original space
+    filtered_sft.to_space(orig_space)
+
+    return filtered_sft, np.nonzero(mask_good_ids), rejected_sft
 
 
 def get_subset_streamlines(sft, max_streamlines, rng_seed=None):

--- a/scilpy/tracking/tools.py
+++ b/scilpy/tracking/tools.py
@@ -9,35 +9,6 @@ from scipy.interpolate import splev, splprep
 from scipy.ndimage.filters import gaussian_filter1d
 
 
-def _filter_sft_by_id(sft, ids_to_keep):
-    """
-    Keep only the streamlines for which the associated value is True in mask.
-
-    Params
-    ------
-    sft: Stateful Tractogram
-    mask_of_ids_to_keep: list[bool]
-        List of length len(sft), with one bool per streamline indicating if it
-        should be kept.
-
-    Returns
-    -------
-    filtered_sft: StatefulTractogram
-    """
-    filtered_streamlines = list(np.asarray(sft.streamlines,
-                                           dtype=object)[ids_to_keep])
-    filtered_data_per_point = sft.data_per_point[ids_to_keep]
-    filtered_data_per_streamline = sft.data_per_streamline[ids_to_keep]
-
-    # Create final sft
-    filtered_sft = StatefulTractogram.from_sft(
-        filtered_streamlines, sft,
-        data_per_point=filtered_data_per_point,
-        data_per_streamline=filtered_data_per_streamline)
-
-    return filtered_sft
-
-
 def filter_streamlines_by_length(sft, min_length=0., max_length=np.inf):
     """
     Filter streamlines using minimum and max length.
@@ -71,7 +42,7 @@ def filter_streamlines_by_length(sft, min_length=0., max_length=np.inf):
     else:
         filter_stream = []
 
-    filtered_sft = _filter_sft_by_id(sft, filter_stream)
+    filtered_sft = sft[filter_stream]
 
     # Return to original space
     filtered_sft.to_space(orig_space)
@@ -152,11 +123,11 @@ def filter_streamlines_by_total_length_per_dim(
     mask_good_ids = np.logical_and(mask_good_x, mask_good_y)
     mask_good_ids = np.logical_and(mask_good_ids, mask_good_z)
 
-    filtered_sft = _filter_sft_by_id(sft, mask_good_ids)
+    filtered_sft = sft[mask_good_ids]
 
     rejected_sft = None
     if save_rejected:
-        rejected_sft = _filter_sft_by_id(sft, ~mask_good_ids)
+        rejected_sft = sft[~mask_good_ids]
 
     # Return to original space
     filtered_sft.to_space(orig_space)

--- a/scilpy/tracking/tools.py
+++ b/scilpy/tracking/tools.py
@@ -9,14 +9,25 @@ from scipy.interpolate import splev, splprep
 from scipy.ndimage.filters import gaussian_filter1d
 
 
-def _filter_sft_by_mask(sft, mask_of_ids_to_keep):
+def _filter_sft_by_id(sft, ids_to_keep):
     """
     Keep only the streamlines for which the associated value is True in mask.
+
+    Params
+    ------
+    sft: Stateful Tractogram
+    mask_of_ids_to_keep: list[bool]
+        List of length len(sft), with one bool per streamline indicating if it
+        should be kept.
+
+    Returns
+    -------
+    filtered_sft: StatefulTractogram
     """
     filtered_streamlines = list(np.asarray(sft.streamlines,
-                                           dtype=object)[mask_of_ids_to_keep])
-    filtered_data_per_point = sft.data_per_point[mask_of_ids_to_keep]
-    filtered_data_per_streamline = sft.data_per_streamline[mask_of_ids_to_keep]
+                                           dtype=object)[ids_to_keep])
+    filtered_data_per_point = sft.data_per_point[ids_to_keep]
+    filtered_data_per_streamline = sft.data_per_streamline[ids_to_keep]
 
     # Create final sft
     filtered_sft = StatefulTractogram.from_sft(
@@ -60,7 +71,7 @@ def filter_streamlines_by_length(sft, min_length=0., max_length=np.inf):
     else:
         filter_stream = []
 
-    filtered_sft = _filter_sft_by_mask(sft, filter_stream)
+    filtered_sft = _filter_sft_by_id(sft, filter_stream)
 
     # Return to original space
     filtered_sft.to_space(orig_space)
@@ -141,11 +152,11 @@ def filter_streamlines_by_total_length_per_dim(
     mask_good_ids = np.logical_and(mask_good_x, mask_good_y)
     mask_good_ids = np.logical_and(mask_good_ids, mask_good_z)
 
-    filtered_sft = _filter_sft_by_mask(sft, mask_good_ids)
+    filtered_sft = _filter_sft_by_id(sft, mask_good_ids)
 
     rejected_sft = None
     if save_rejected:
-        rejected_sft = _filter_sft_by_mask(sft, ~mask_good_ids)
+        rejected_sft = _filter_sft_by_id(sft, ~mask_good_ids)
 
     # Return to original space
     filtered_sft.to_space(orig_space)

--- a/scripts/scil_filter_streamlines_by_orientation.py
+++ b/scripts/scil_filter_streamlines_by_orientation.py
@@ -69,7 +69,7 @@ def _build_arg_parser():
     p.add_argument('--no_empty', action='store_true',
                    help='Do not write file if there is no streamline.')
     p.add_argument('--display_counts', action='store_true',
-                   help='Print streamline count before and after filtering')
+                   help='Print streamline count before and after filtering.')
     p.add_argument('--save_rejected', metavar='filename',
                    help="Save the SFT of rejected streamlines.")
 

--- a/scripts/scil_filter_streamlines_by_orientation.py
+++ b/scripts/scil_filter_streamlines_by_orientation.py
@@ -13,6 +13,7 @@ import argparse
 import json
 import logging
 
+from dipy.io.stateful_tractogram import set_sft_logger_level
 from dipy.io.streamline import save_tractogram
 import numpy as np
 
@@ -82,7 +83,10 @@ def main():
     assert_outputs_exist(parser, args, args.out_tractogram, args.save_rejected)
 
     if args.verbose:
-        logging.basicConfig(level=logging.INFO)
+        logging.basicConfig(level=logging.DEBUG)
+        # Silencing SFT's logger if our logging is in DEBUG mode, because it
+        # typically produces a lot of outputs!
+        set_sft_logger_level('WARNING')
 
     if args.min_x == 0 and np.isinf(args.max_x) and \
        args.min_y == 0 and np.isinf(args.max_y) and \

--- a/scripts/scil_filter_streamlines_by_orientation.py
+++ b/scripts/scil_filter_streamlines_by_orientation.py
@@ -2,8 +2,15 @@
 # -*- coding: utf-8 -*-
 
 """
-Script to filter streamlines based on their orientation (total length per
-dimension).
+Script to filter streamlines based on their distance traveled in a specific
+dimension (x, y, or z).
+
+Useful to help differentiate bundles.
+
+Examples: In a brain aligned with x coordinates in left - right axis and y
+coordinates in anterior-posterior axis, a streamline from the ...
+    - corpus callosum will likely travel a very short distance in the y axis.
+    - cingulum will likely travel a very short distance in the x axis.
 
 Note: we consider that x, y, z are the coordinates of the streamlines; we
 do not verify if they are aligned with the brain's orientation.

--- a/scripts/scil_filter_streamlines_by_orientation.py
+++ b/scripts/scil_filter_streamlines_by_orientation.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Script to filter streamlines based on their orientation (total length per
+dimension).
+
+Note: we consider that x, y, z are the coordinates of the streamlines; we
+do not verify if they are aligned with the brain's orientation.
+"""
+
+import argparse
+import json
+import logging
+
+from dipy.io.streamline import save_tractogram
+import numpy as np
+
+from scilpy.tracking.tools import filter_streamlines_by_total_length_per_dim
+from scilpy.io.streamlines import load_tractogram_with_reference
+from scilpy.io.utils import (add_json_args,
+                             add_overwrite_arg,
+                             add_reference_arg,
+                             add_verbose_arg,
+                             assert_inputs_exist,
+                             assert_outputs_exist)
+
+
+def _build_arg_parser():
+    p = argparse.ArgumentParser(
+        formatter_class=argparse.RawTextHelpFormatter, description=__doc__)
+
+    p.add_argument('in_tractogram',
+                   help='Streamlines input file name.')
+    p.add_argument('out_tractogram',
+                   help='Streamlines output file name.')
+
+    p.add_argument('--min_x', default=0., type=float,
+                   help='Minimum distance in the first dimension, in mm.'
+                        '[%(default)s]')
+    p.add_argument('--max_x', default=np.inf, type=float,
+                   help='Maximum distance in the first dimension, in mm.'
+                        '[%(default)s]')
+    p.add_argument('--min_y', default=0., type=float,
+                   help='Minimum distance in the second dimension, in mm.'
+                        '[%(default)s]')
+    p.add_argument('--max_y', default=np.inf, type=float,
+                   help='Maximum distance in the second dimension, in mm.'
+                        '[%(default)s]')
+    p.add_argument('--min_z', default=0., type=float,
+                   help='Minimum distance in the third dimension, in mm.'
+                        '[%(default)s]')
+    p.add_argument('--max_z', default=np.inf, type=float,
+                   help='Maximum distance in the third dimension, in mm.'
+                        '[%(default)s]')
+    p.add_argument('--use_abs', action='store_true',
+                   help="If set, will use the total of distances in absolute "
+                        "value (ex, coming back on yourself will contribute "
+                        "to the total distance instead of cancelling it).")
+
+    p.add_argument('--no_empty', action='store_true',
+                   help='Do not write file if there is no streamline.')
+    p.add_argument('--display_counts', action='store_true',
+                   help='Print streamline count before and after filtering')
+    p.add_argument('--save_rejected', metavar='filename',
+                   help="Save the SFT of rejected streamlines.")
+
+    add_reference_arg(p)
+    add_overwrite_arg(p)
+    add_verbose_arg(p)
+    add_json_args(p)
+
+    return p
+
+
+def main():
+
+    parser = _build_arg_parser()
+    args = parser.parse_args()
+
+    assert_inputs_exist(parser, args.in_tractogram)
+    assert_outputs_exist(parser, args, args.out_tractogram, args.save_rejected)
+
+    if args.verbose:
+        logging.basicConfig(level=logging.INFO)
+
+    if args.min_x == 0 and np.isinf(args.max_x) and \
+       args.min_y == 0 and np.isinf(args.max_y) and \
+       args.min_z == 0 and np.isinf(args.max_z):
+        logging.warning("You have not specified min or max in any direction. "
+                        "Output will simply be a copy of your input!")
+
+    sft = load_tractogram_with_reference(parser, args, args.in_tractogram)
+    computed_rejected_sft = args.save_rejected is not None
+    new_sft, indices, rejected_sft = \
+        filter_streamlines_by_total_length_per_dim(
+            sft, [args.min_x, args.max_x], [args.min_y, args.max_y],
+            [args.min_z, args.max_z], args.use_abs, computed_rejected_sft)
+
+    if args.display_counts:
+        sc_bf = len(sft.streamlines)
+        sc_af = len(new_sft.streamlines)
+        print(json.dumps({'streamline_count_before_filtering': int(sc_bf),
+                         'streamline_count_after_filtering': int(sc_af)},
+                         indent=args.indent))
+
+    if len(new_sft.streamlines) == 0:
+        if args.no_empty:
+            logging.debug("The file {} won't be written "
+                          "(0 streamline).".format(args.out_tractogram))
+        else:
+            logging.debug('The file {} contains 0 streamline'.format(
+                args.out_tractogram))
+
+    save_tractogram(new_sft, args.out_tractogram)
+
+    if computed_rejected_sft:
+        save_tractogram(rejected_sft, args.save_rejected)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_filter_streamlines_by_orientation.py
+++ b/scripts/tests/test_filter_streamlines_by_orientation.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import os
+import tempfile
+
+from scilpy.io.fetcher import get_testing_files_dict, fetch_data, get_home
+
+
+# If they already exist, this only takes 5 seconds (check md5sum)
+fetch_data(get_testing_files_dict(), keys=['filtering.zip'])
+tmp_dir = tempfile.TemporaryDirectory()
+
+
+def test_help_option(script_runner):
+    ret = script_runner.run('scil_filter_streamlines_by_orientation.py',
+                            '--help')
+    assert ret.success
+
+
+def test_execution_filtering(script_runner):
+    os.chdir(os.path.expanduser(tmp_dir.name))
+    in_bundle = os.path.join(get_home(), 'filtering',
+                             'bundle_4.trk')
+    ret = script_runner.run('scil_filter_streamlines_by_orientation.py',
+                            in_bundle,  'bundle_4_filtered.trk',
+                            '--min_x', '20', '--max_y', '230', '--min_z', '30',
+                            '--use_abs')
+    assert ret.success


### PR DESCRIPTION
New script to filter a tractogram based on total changes in x, y or z directions. There is a note explaining that x, y, z mean the x,y,z coordinates of the sft streamlines, not necessarily aligned with the real x,y,z coordinates of the brain.

This will be useful to separate cingulum streamlines from the CC in our new tractometer based on ROI, using scil_score_tractogram (upcoming).