### PR TITLE
Upgrading dipy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ bz2file==0.98.*
 coloredlogs==10.0.*
 cycler==0.10.*
 Cython==0.29.*
-dipy==1.4.*,>=1.4.1
+dipy==1.5.*
 fury==0.7.*
 future==0.17.*
 h5py==2.10.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ bz2file==0.98.*
 coloredlogs==10.0.*
 cycler==0.10.*
 Cython==0.29.*
-dipy==1.3.*
+dipy==1.4.*,>=1.4.1
 fury==0.7.*
 future==0.17.*
 h5py==2.10.*

--- a/scilpy/tractanalysis/features.py
+++ b/scilpy/tractanalysis/features.py
@@ -4,7 +4,7 @@ from itertools import count, takewhile
 import logging
 
 from dipy.segment.clustering import QuickBundles, qbx_and_merge
-from dipy.segment.metric import ResampleFeature
+from dipy.segment.featurespeed import ResampleFeature
 from dipy.segment.metric import AveragePointwiseEuclideanMetric
 from dipy.tracking import metrics as tm
 from scilpy.tracking.tools import resample_streamlines_num_points


### PR DESCRIPTION
A warning was fixed in dipy 1.4.1 in file bundles_distances_mdf (used in Recobundles), where a warning was printed erroneously in previous versions. It made me want to verify if we could upgrade dipy a little.

Changed requirements.

I created a clean environment, pip installed requirements successfully, pip installed scilpy successfully. 


Tests seem to pass.