### PR TITLE
Warn user for rk > 1 with prob tracking in dev tracking

### DIFF
--- a/scilpy/tracking/propagator.py
+++ b/scilpy/tracking/propagator.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from enum import Enum
+import logging
 
 import dipy
 import numpy as np
@@ -352,6 +353,12 @@ class ODFPropagator(PropagatorOnSphere):
             candidate direction.
         """
         super().__init__(dataset, step_size, rk_order, dipy_sphere)
+
+        # Warn user if the rk order does not match the algo
+        if rk_order != 1 and algo == 'prob':
+            logging.warning('Probabilistic tracking with RK order != 1 is '
+                            'not recommended! Use deterministic tracking '
+                            'or set rk_order to 1 instead.')
 
         # Propagation params
         self.theta = theta

--- a/scripts/scil_compute_local_tracking_dev.py
+++ b/scripts/scil_compute_local_tracking_dev.py
@@ -20,6 +20,21 @@ As in scil_compute_local_tracking:
 
 Contrary to scil_compute_local_tracking:
     - Input nifti files do not necessarily need to be in isotropic resolution.
+    - The script works with asymmetric input ODF.
+    - The interpolation for the tracking mask and spherical function can be
+      one of 'nearest' or 'trilinear'.
+    - Runge-Kutta integration is supported for the step function.
+
+A few notes on Runge-Kutta integration.
+    1. Runge-Kutta integration is used to approximate the next tracking
+       direction by estimating directions from future tracking steps. This
+       works well for deterministic tracking. However, in the context of
+       probabilistic tracking, the next tracking directions cannot be estimated
+       in advance, because they are picked randomly from a distribution. It is
+       therefore recommanded to keep the rk_order to 1 for probabilistic
+       tracking.
+    2. As a rule of thumb, doubling the rk_order will double the computation
+       time in the worst case.
 
 References: [1] Girard, G., Whittingstall K., Deriche, R., and
             Descoteaux, M. (2014). Towards quantitative connectivity analysis:
@@ -73,9 +88,9 @@ def _build_arg_parser():
     track_g.add_argument('--rk_order', metavar="K", type=int, default=1,
                          choices=[1, 2, 4],
                          help="The order of the Runge-Kutta integration used "
-                              "for the \nstep function [%(default)s]. As a "
-                              "rule of thumb, doubling the rk_order \nwill "
-                              "double the computation time in the worst case.")
+                              "for the step function.\n"
+                              "For more information, refer to the note in the"
+                              " script description. [%(default)s]")
     track_g.add_argument('--max_invalid_length', metavar='MAX', type=float,
                          default=1,
                          help="Maximum length without valid direction, in mm. "

--- a/scripts/scil_compute_local_tracking_dev.py
+++ b/scripts/scil_compute_local_tracking_dev.py
@@ -70,7 +70,7 @@ def _build_arg_parser():
                          default=0.5, dest='sf_threshold_init',
                          help="Spherical function relative threshold value "
                               "for the \ninitial direction. [%(default)s]")
-    track_g.add_argument('--rk_order', metavar="K", type=int, default=2,
+    track_g.add_argument('--rk_order', metavar="K", type=int, default=1,
                          choices=[1, 2, 4],
                          help="The order of the Runge-Kutta integration used "
                               "for the \nstep function [%(default)s]. As a "


### PR DESCRIPTION
Add a warning when using rk_order > 1 with probabilistic tracking in `_dev` tracking. Set default `rk` order to 1.

Might close #560, or should we keep the issue opened until we reimplement our rk integration correctly for prob tracking?
@EmmaRenauld @StongeEtienne