### PR TITLE
Fixing coordinate type + decreasing test size in dev tracking

### DIFF
--- a/scilpy/tracking/tracker.py
+++ b/scilpy/tracking/tracker.py
@@ -270,7 +270,7 @@ class Tracker(object):
         np.random.seed(np.uint32(hash((seeding_pos, self.rng_seed))))
 
         # Forward
-        line = [seeding_pos]
+        line = [np.asarray(seeding_pos)]
         tracking_info = self.propagator.prepare_forward(seeding_pos)
         if tracking_info == PropagationStatus.ERROR:
             # No good tracking direction can be found at seeding position.
@@ -303,8 +303,9 @@ class Tracker(object):
 
         Parameters
         ----------
-        line: List
-            Beginning of the line to propagate.
+        line: List[np.ndarrays]
+            Beginning of the line to propagate: list of 3D coordinates
+            formatted as arrays.
         tracking_info: Any
             Information necessary to know how to propagate. Type: as understood
             by the propagator. Example, with the typical fODF propagator: the

--- a/scripts/tests/test_compute_local_tracking_dev.py
+++ b/scripts/tests/test_compute_local_tracking_dev.py
@@ -25,7 +25,7 @@ def test_execution_tracking_fodf(script_runner):
     in_mask = os.path.join(get_home(), 'tracking',
                            'seeding_mask.nii.gz')
     ret = script_runner.run('scil_compute_local_tracking_dev.py', in_fodf,
-                            in_mask, in_mask, 'local_prob.trk', '--nt', '1000',
+                            in_mask, in_mask, 'local_prob.trk', '--nt', '10',
                             '--compress', '0.1', '--sh_basis', 'descoteaux07',
                             '--min_length', '20', '--max_length', '200')
     assert ret.success


### PR DESCRIPTION
Small fix: coordinate type was a tuple when expected to be an array. Script was still running, but streamline contained one tuple and n-1 arrays. 


Also changing test from --nt 1000 to --nt 10. Decreasing this test time from 46 seconds to 2 seconds on my computer.