### PR TITLE
Add split image script

### DIFF
--- a/scripts/scil_split_image.py
+++ b/scripts/scil_split_image.py
@@ -115,6 +115,9 @@ def main():
                      'number of direcitons.')
     if np.min(args.split_indices) <= 0:
         parser.error('split_indices values must be higher than 0.')
+    # Check if the indices are in increasing order
+    if not np.all(np.diff(args.split_indices) > 0):
+        parser.error('split_indices values must be in increasing order.')
 
     indices = np.concatenate(([0], args.split_indices, [data.shape[-1]]))
 

--- a/scripts/scil_split_image.py
+++ b/scripts/scil_split_image.py
@@ -108,10 +108,9 @@ def main():
     bvals, bvecs = read_bvals_bvecs(args.in_bval, args.in_bvec)
 
     img = nib.load(args.in_dwi)
-    data = img.get_fdata(dtype=np.float32)
 
     # Check if the indices fit inside the range of possible values
-    if np.max(args.split_indices) > data.shape[-1]:
+    if np.max(args.split_indices) > img.shape[-1]:
         parser.error('split_indices values must be lower than the total '
                      'number of direcitons.')
     if np.min(args.split_indices) <= 0:
@@ -120,10 +119,10 @@ def main():
     if not np.all(np.diff(args.split_indices) > 0):
         parser.error('split_indices values must be in increasing order.')
 
-    indices = np.concatenate(([0], args.split_indices, [data.shape[-1]]))
+    indices = np.concatenate(([0], args.split_indices, [img.shape[-1]]))
 
     for i in range(len(indices)-1):
-        data_split = data[..., indices[i]:indices[i+1]]
+        data_split = img.dataobj[..., indices[i]:indices[i+1]]
         bvals_split = bvals[indices[i]:indices[i+1]]
         bvecs_split = bvecs[indices[i]:indices[i+1]]
         # Saving the dwi file

--- a/scripts/scil_split_image.py
+++ b/scripts/scil_split_image.py
@@ -2,18 +2,14 @@
 # -*- coding: utf-8 -*-
 
 """
-Extracts the DWI volumes that are on specific b-value shells. Many shells
-can be extracted at once by specifying multiple b-values. The extracted
-volumes are in the same order as in the original file.
+Splits the DWI image at certain indices along the last dimension (b-values).
+Many indices can be given at once by specifying multiple values. The splited
+volumes are in the same order as in the original file. Also outputs the
+corresponding .bval and .bvec files.
 
-If the b-values of a shell are not all identical, use the --tolerance
-argument to adjust the accepted interval. For example, a b-value of 2000
-and a tolerance of 20 will extract all volumes with a b-values from 1980 to
-2020.
-
-Files that are too large to be loaded in memory can still be processed by
-setting the --block-size argument. A block size of X means that X DWI volumes
-are loaded at a time for processing.
+This script can be useful for splitting images at places where a b-value
+extraction does not work. For instance, if one wants to split the x first
+b-1500s from the rest of the b-1500s in an image, simply put x as an index.
 
 """
 

--- a/scripts/scil_split_image.py
+++ b/scripts/scil_split_image.py
@@ -74,7 +74,7 @@ def main():
     # Check if the indices fit inside the range of possible values
     if np.max(args.split_indices) >= img.shape[-1]:
         parser.error('split_indices values must be lower than the total '
-                     'number of direcitons.')
+                     'number of directions.')
     if np.min(args.split_indices) <= 0:
         parser.error('split_indices values must be higher than 0.')
     # Check if the indices are in increasing order

--- a/scripts/scil_split_image.py
+++ b/scripts/scil_split_image.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Extracts the DWI volumes that are on specific b-value shells. Many shells
+can be extracted at once by specifying multiple b-values. The extracted
+volumes are in the same order as in the original file.
+
+If the b-values of a shell are not all identical, use the --tolerance
+argument to adjust the accepted interval. For example, a b-value of 2000
+and a tolerance of 20 will extract all volumes with a b-values from 1980 to
+2020.
+
+Files that are too large to be loaded in memory can still be processed by
+setting the --block-size argument. A block size of X means that X DWI volumes
+are loaded at a time for processing.
+
+"""
+
+import argparse
+import logging
+from pathlib import Path
+
+from dipy.io import read_bvals_bvecs
+import nibabel as nib
+import numpy as np
+
+from scilpy.io.utils import (add_overwrite_arg, add_verbose_arg,
+                             assert_inputs_exist, assert_outputs_exist)
+
+
+def _build_arg_parser():
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawTextHelpFormatter)
+
+    p.add_argument('in_dwi',
+                   help='The DW image file to split.')
+
+    p.add_argument('in_bval',
+                   help='The b-values file in FSL format (.bval).')
+
+    p.add_argument('in_bvec',
+                   help='The b-vectors file in FSL format (.bvec).')
+
+    p.add_argument('split_indices', nargs='+', type=int,
+                   help='The list of indices where to split the image. For '
+                        'example 3 10. This would split the image in three '
+                        'parts, such as [:3], [3:10], [10:].')
+
+    p.add_argument('--out_dwi', nargs='+', default='',
+                   help='The names of the output DWI files. There must be '
+                        'one more name than indices in split_indices. By '
+                        'default, indices number will be appended to in_dwi, '
+                        'such as in_dwi_0_3, in_dwi_3_10, in_dwi_10_end.')
+
+    p.add_argument('--out_bval', nargs='+', default='',
+                   help='The names of the output b-value files (.bval). There '
+                        'must be one more name than indices in split_indices. '
+                        'By default, indices number will be appended to '
+                        'in_dwi, such as in_dwi_0_3, in_dwi_3_10, '
+                        'in_dwi_10_end.')
+
+    p.add_argument('--out_bvec', nargs='+', default='',
+                   help='The names of the output b-vector files (.bvec).There '
+                        'must be one more name than indices in split_indices. '
+                        'By default, indices number will be appended to '
+                        'in_dwi, such as in_dwi_0_3, in_dwi_3_10, '
+                        'in_dwi_10_end.')
+
+    add_verbose_arg(p)
+    add_overwrite_arg(p)
+
+    return p
+
+
+def create_name_from_indices(indices, input):
+    input_path = Path(input)
+    parent_dir = input_path.parent
+    input_name = Path(input_path.stem).stem
+    index_name = "_" + str(indices[0]) + "_" + str(indices[1])
+    suffix = ""
+    for suff in input_path.suffixes:
+        suffix += suff
+    output_name = Path(parent_dir, input_name + index_name + suffix)
+
+    return str(output_name)
+
+
+def main():
+    parser = _build_arg_parser()
+    args = parser.parse_args()
+
+    if args.verbose:
+        logging.basicConfig(level=logging.INFO)
+
+    assert_inputs_exist(parser, [args.in_dwi, args.in_bval, args.in_bvec])
+    assert_outputs_exist(parser, args, [],
+                         optional=list(np.concatenate((args.out_dwi,
+                                                       args.out_bval,
+                                                       args.out_bvec))))
+
+    if args.out_dwi and len(args.out_dwi) != len(args.split_indices) + 1:
+        parser.error('--out_dwi must contain len(split_indices) + 1 names.')
+    if args.out_bval and len(args.out_bval) != len(args.split_indices) + 1:
+        parser.error('--out_bval must contain len(split_indices) + 1 names.')
+    if args.out_bvec and len(args.out_bvec) != len(args.split_indices) + 1:
+        parser.error('--out_bvec must contain len(split_indices) + 1 names.')
+
+    bvals, bvecs = read_bvals_bvecs(args.in_bval, args.in_bvec)
+
+    img = nib.load(args.in_dwi)
+    data = img.get_fdata(dtype=np.float32)
+
+    indices = np.concatenate(([0], args.split_indices, [data.shape[-1]]))
+
+    for i in range(len(indices)-1):
+        data_split = data[..., indices[i]:indices[i+1]]
+        bvals_split = bvals[indices[i]:indices[i+1]]
+        bvecs_split = bvecs[indices[i]:indices[i+1]]
+
+        if args.out_dwi:
+            data_name = args.out_dwi[i]
+        else:
+            data_name = create_name_from_indices(indices[i:i+2], args.in_dwi)
+        nib.save(nib.Nifti1Image(data_split, img.affine, header=img.header),
+                 data_name)
+
+        if args.out_bval:
+            bval_name = args.out_bval[i]
+        else:
+            bval_name = create_name_from_indices(indices[i:i+2], args.in_bval)
+        np.savetxt(bval_name, bvals_split, '%d')
+
+        if args.out_bvec:
+            bvec_name = args.out_bvec[i]
+        else:
+            bvec_name = create_name_from_indices(indices[i:i+2], args.in_bvec)
+        np.savetxt(bvec_name, bvecs_split, '%0.15f')
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/scil_split_image.py
+++ b/scripts/scil_split_image.py
@@ -69,8 +69,8 @@ def main():
                          optional=list((args.out_basename)))
 
     # Check if the number of names given is equal to the number of indices + 1
-    if (args.out_basename and 
-        len(args.out_basename) != len(args.split_indices) + 1):
+    if (args.out_basename and
+            len(args.out_basename) != len(args.split_indices) + 1):
         parser.error('--out_basename must contain len(split_indices) + 1 '
                      'names.')
 

--- a/scripts/scil_split_image.py
+++ b/scripts/scil_split_image.py
@@ -42,7 +42,8 @@ def _build_arg_parser():
     p.add_argument('split_indices', nargs='+', type=int,
                    help='The list of indices where to split the image. For '
                         'example 3 10. This would split the image in three '
-                        'parts, such as [:3], [3:10], [10:].')
+                        'parts, such as [:3], [3:10], [10:]. Indices must be '
+                        'in increasing order.')
 
     p.add_argument('--out_dwi', nargs='+', default=[],
                    help='The names of the output DWI files. There must be '

--- a/scripts/scil_split_image.py
+++ b/scripts/scil_split_image.py
@@ -15,8 +15,6 @@ b-1500s from the rest of the b-1500s in an image, simply put x as an index.
 
 import argparse
 import logging
-from operator import index
-from pathlib import Path
 
 from dipy.io import read_bvals_bvecs
 import nibabel as nib
@@ -40,19 +38,19 @@ def _build_arg_parser():
     p.add_argument('in_bvec',
                    help='The b-vectors file in FSL format (.bvec).')
 
+    p.add_argument('out_basename',
+                   help='The basename of the output files. Indices number '
+                        'will be appended to out_basename. For example, if '
+                        'split_indices were 3 10, the files would be saved as '
+                        'out_basename_0_2, out_basename_3_10, '
+                        'out_basename_11_20, where the size of the last '
+                        'dimension is 21 in this example.')
+
     p.add_argument('split_indices', nargs='+', type=int,
                    help='The list of indices where to split the image. For '
                         'example 3 10. This would split the image in three '
                         'parts, such as [:3], [3:10], [10:]. Indices must be '
                         'in increasing order.')
-
-    p.add_argument('--out_basename',
-                   help='The basename of the output files. Indices number '
-                        'will be appended to out_basename, such as '
-                        'out_basename_0_3, out_basename_3_10, '
-                        'out_basename_10_end. By default, indices number'
-                        'will be appended to in_dwi, '
-                        'such as in_dwi_0_3, in_dwi_3_10, in_dwi_10_end.')
 
     add_verbose_arg(p)
     add_overwrite_arg(p)
@@ -68,43 +66,42 @@ def main():
         logging.basicConfig(level=logging.INFO)
 
     assert_inputs_exist(parser, [args.in_dwi, args.in_bval, args.in_bvec])
-    assert_outputs_exist(parser, args, [],
-                         optional=args.out_basename)
 
     bvals, bvecs = read_bvals_bvecs(args.in_bval, args.in_bvec)
 
     img = nib.load(args.in_dwi)
 
     # Check if the indices fit inside the range of possible values
-    if np.max(args.split_indices) > img.shape[-1]:
+    if np.max(args.split_indices) >= img.shape[-1]:
         parser.error('split_indices values must be lower than the total '
                      'number of direcitons.')
     if np.min(args.split_indices) <= 0:
         parser.error('split_indices values must be higher than 0.')
     # Check if the indices are in increasing order
     if not np.all(np.diff(args.split_indices) > 0):
-        parser.error('split_indices values must be in increasing order.')
+        logging.warning('split_indices values were not in increasing order.'
+                        'Proceeding to reorder them.')
+        split_indices = np.sort(args.split_indices)
+    else:
+        split_indices = args.split_indices
 
-    indices = np.concatenate(([0], args.split_indices, [img.shape[-1]]))
+    indices = np.concatenate(([0], split_indices, [img.shape[-1]]))
+
+    out_names = np.ndarray((len(split_indices) + 1), dtype=object)
+    for i in range(len(indices)-1):
+        index_name = "_" + str(indices[i]) + "_" + str(indices[i+1] - 1)
+        out_names[i] = args.out_basename + index_name
+    assert_outputs_exist(parser, args, out_names)
 
     for i in range(len(indices)-1):
         data_split = img.dataobj[..., indices[i]:indices[i+1]]
         bvals_split = bvals[indices[i]:indices[i+1]]
         bvecs_split = bvecs[indices[i]:indices[i+1]]
         # Saving the output files
-        index_name = "_" + str(indices[i]) + "_" + str(indices[i+1])
-        if args.out_basename:
-            data_name = args.out_basename + index_name
-            bval_name = args.out_basename + index_name
-            bvec_name = args.out_basename + index_name
-        else:
-            data_name = str(Path(Path(args.in_dwi).stem).stem) + index_name
-            bval_name = str(Path(Path(args.in_bval).stem).stem) + index_name
-            bvec_name = str(Path(Path(args.in_bvec).stem).stem) + index_name
         nib.save(nib.Nifti1Image(data_split, img.affine, header=img.header),
-                 data_name + ".nii.gz")
-        np.savetxt(bval_name + ".bval", bvals_split, '%d')
-        np.savetxt(bvec_name + ".bvec", bvecs_split, '%0.15f')
+                 out_names[i] + ".nii.gz")
+        np.savetxt(out_names[i] + ".bval", bvals_split, '%d')
+        np.savetxt(out_names[i] + ".bvec", bvecs_split, '%0.15f')
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_split_image.py
+++ b/scripts/tests/test_split_image.py
@@ -29,7 +29,7 @@ def test_execution_processing_no_output_given(script_runner):
     assert ret.success
 
 
-def test_execution_processing_good_output_given(script_runner):
+def test_execution_processing_output_given(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi = os.path.join(get_home(), 'processing',
                           'dwi_crop.nii.gz')
@@ -39,29 +39,8 @@ def test_execution_processing_good_output_given(script_runner):
                            'dwi.bvec')
     ret = script_runner.run('scil_split_image.py', in_dwi,
                             in_bval, in_bvec, '5', '15',
-                            '--out_basename', 'dwi0', 'dwi1',
-                            'dwi2')
+                            '--out_basename', 'dwi')
     assert ret.success
-
-
-def test_execution_processing_wrong_output(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
-    in_dwi = os.path.join(get_home(), 'processing',
-                          'dwi_crop.nii.gz')
-    in_bval = os.path.join(get_home(), 'processing',
-                           'dwi.bval')
-    in_bvec = os.path.join(get_home(), 'processing',
-                           'dwi.bvec')
-    ret = script_runner.run('scil_split_image.py', in_dwi,
-                            in_bval, in_bvec, '5', '15',
-                            '--out_basename', 'dwi0', 'dwi1')
-    assert (not ret.success)
-
-    ret = script_runner.run('scil_split_image.py', in_dwi,
-                            in_bval, in_bvec, '5', '15',
-                            '--out_basename', 'dwi0', 'dwi1',
-                            'dwi2', 'dwi3')
-    assert (not ret.success)
 
 
 def test_execution_processing_wrong_indices_given(script_runner):

--- a/scripts/tests/test_split_image.py
+++ b/scripts/tests/test_split_image.py
@@ -39,10 +39,8 @@ def test_execution_processing_good_output_given(script_runner):
                            'dwi.bvec')
     ret = script_runner.run('scil_split_image.py', in_dwi,
                             in_bval, in_bvec, '5', '15',
-                            '--out_dwi', 'dwi0.nii.gz', 'dwi1.nii.gz',
-                            'dwi2.nii.gz', '--out_bval', 'dwi0.bval',
-                            'dwi1.bval', 'dwi2.bval', '--out_bvec',
-                            'dwi0.bvec', 'dwi1.bvec', 'dwi2.bvec')
+                            '--out_basename', 'dwi0', 'dwi1',
+                            'dwi2')
     assert ret.success
 
 
@@ -56,26 +54,13 @@ def test_execution_processing_wrong_output(script_runner):
                            'dwi.bvec')
     ret = script_runner.run('scil_split_image.py', in_dwi,
                             in_bval, in_bvec, '5', '15',
-                            '--out_dwi', 'dwi0.nii.gz', 'dwi1.nii.gz',
-                            '--out_bval', 'dwi0.bval',
-                            'dwi1.bval', 'dwi2.bval', '--out_bvec',
-                            'dwi0.bvec', 'dwi1.bvec', 'dwi2.bvec')
+                            '--out_basename', 'dwi0', 'dwi1')
     assert (not ret.success)
 
     ret = script_runner.run('scil_split_image.py', in_dwi,
                             in_bval, in_bvec, '5', '15',
-                            '--out_dwi', 'dwi0.nii.gz', 'dwi1.nii.gz',
-                            'dwi2.nii.gz', '--out_bval', 'dwi0.bval',
-                            'dwi1.bval', '--out_bvec',
-                            'dwi0.bvec', 'dwi1.bvec', 'dwi2.bvec')
-    assert (not ret.success)
-
-    ret = script_runner.run('scil_split_image.py', in_dwi,
-                            in_bval, in_bvec, '5', '15',
-                            '--out_dwi', 'dwi0.nii.gz', 'dwi1.nii.gz',
-                            'dwi2.nii.gz', '--out_bval', 'dwi0.bval',
-                            'dwi1.bval', 'dwi2.bval', '--out_bvec',
-                            'dwi0.bvec', 'dwi1.bvec')
+                            '--out_basename', 'dwi0', 'dwi1',
+                            'dwi2', 'dwi3')
     assert (not ret.success)
 
 

--- a/scripts/tests/test_split_image.py
+++ b/scripts/tests/test_split_image.py
@@ -78,6 +78,7 @@ def test_execution_processing_wrong_output(script_runner):
                             'dwi0.bvec', 'dwi1.bvec')
     assert (not ret.success)
 
+
 def test_execution_processing_wrong_indices_given(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi = os.path.join(get_home(), 'processing',

--- a/scripts/tests/test_split_image.py
+++ b/scripts/tests/test_split_image.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import os
+import tempfile
+
+from scilpy.io.fetcher import fetch_data, get_home, get_testing_files_dict
+
+# If they already exist, this only takes 5 seconds (check md5sum)
+fetch_data(get_testing_files_dict(), keys=['processing.zip'])
+tmp_dir = tempfile.TemporaryDirectory()
+
+
+def test_help_option(script_runner):
+    ret = script_runner.run('scil_split_image.py', '--help')
+    assert ret.success
+
+
+def test_execution_processing_no_output_given(script_runner):
+    os.chdir(os.path.expanduser(tmp_dir.name))
+    in_dwi = os.path.join(get_home(), 'processing',
+                          'dwi_crop.nii.gz')
+    in_bval = os.path.join(get_home(), 'processing',
+                           'dwi.bval')
+    in_bvec = os.path.join(get_home(), 'processing',
+                           'dwi.bvec')
+    ret = script_runner.run('scil_split_image.py', in_dwi,
+                            in_bval, in_bvec, '5 15 25')
+    assert ret.success
+
+
+def test_execution_processing_good_output_given(script_runner):
+    os.chdir(os.path.expanduser(tmp_dir.name))
+    in_dwi = os.path.join(get_home(), 'processing',
+                          'dwi_crop.nii.gz')
+    in_bval = os.path.join(get_home(), 'processing',
+                           'dwi.bval')
+    in_bvec = os.path.join(get_home(), 'processing',
+                           'dwi.bvec')
+    ret = script_runner.run('scil_split_image.py', in_dwi,
+                            in_bval, in_bvec, '5 15',
+                            '--out_dwi dwi0.nii.gz dwi1.nii.gz dwi2.nii.gz',
+                            '--out_bval dwi0.bval dwi1.bval dwi2.bval',
+                            '--out_bvec dwi0.bvec dwi1.bvec dwi2.bvec')
+    assert ret.success
+
+
+def test_execution_processing_wrong_output(script_runner):
+    os.chdir(os.path.expanduser(tmp_dir.name))
+    in_dwi = os.path.join(get_home(), 'processing',
+                          'dwi_crop.nii.gz')
+    in_bval = os.path.join(get_home(), 'processing',
+                           'dwi.bval')
+    in_bvec = os.path.join(get_home(), 'processing',
+                           'dwi.bvec')
+    ret = script_runner.run('scil_split_image.py', in_dwi,
+                            in_bval, in_bvec, '5 15',
+                            '--out_dwi dwi0.nii.gz dwi1.nii.gz',
+                            '--out_bval dwi0.bval dwi1.bval dwi2.bval',
+                            '--out_bvec dwi0.bvec dwi1.bvec dwi2.bvec')
+    assert (not ret.success)
+
+    ret = script_runner.run('scil_split_image.py', in_dwi,
+                            in_bval, in_bvec, '5 15',
+                            '--out_dwi dwi0.nii.gz dwi1.nii.gz dwi2.nii.gz',
+                            '--out_bval dwi0.bval dwi1.bval dwi2.bval',
+                            '--out_bvec dwi0.bvec dwi1.bvec')
+    assert (not ret.success)
+
+    ret = script_runner.run('scil_split_image.py', in_dwi,
+                            in_bval, in_bvec, '5 15',
+                            '--out_dwi dwi0.nii.gz dwi1.nii.gz dwi2.nii.gz',
+                            '--out_bval dwi0.bval dwi1.bval',
+                            '--out_bvec dwi0.bvec dwi1.bvec dwi2.bvec')
+    assert (not ret.success)

--- a/scripts/tests/test_split_image.py
+++ b/scripts/tests/test_split_image.py
@@ -25,7 +25,7 @@ def test_execution_processing_no_output_given(script_runner):
     in_bvec = os.path.join(get_home(), 'processing',
                            'dwi.bvec')
     ret = script_runner.run('scil_split_image.py', in_dwi,
-                            in_bval, in_bvec, '5 15 25')
+                            in_bval, in_bvec, '5', '15', '25')
     assert ret.success
 
 
@@ -38,10 +38,11 @@ def test_execution_processing_good_output_given(script_runner):
     in_bvec = os.path.join(get_home(), 'processing',
                            'dwi.bvec')
     ret = script_runner.run('scil_split_image.py', in_dwi,
-                            in_bval, in_bvec, '5 15',
-                            '--out_dwi dwi0.nii.gz dwi1.nii.gz dwi2.nii.gz',
-                            '--out_bval dwi0.bval dwi1.bval dwi2.bval',
-                            '--out_bvec dwi0.bvec dwi1.bvec dwi2.bvec')
+                            in_bval, in_bvec, '5', '15',
+                            '--out_dwi', 'dwi0.nii.gz', 'dwi1.nii.gz',
+                            'dwi2.nii.gz', '--out_bval', 'dwi0.bval',
+                            'dwi1.bval', 'dwi2.bval', '--out_bvec',
+                            'dwi0.bvec', 'dwi1.bvec', 'dwi2.bvec')
     assert ret.success
 
 
@@ -54,22 +55,25 @@ def test_execution_processing_wrong_output(script_runner):
     in_bvec = os.path.join(get_home(), 'processing',
                            'dwi.bvec')
     ret = script_runner.run('scil_split_image.py', in_dwi,
-                            in_bval, in_bvec, '5 15',
-                            '--out_dwi dwi0.nii.gz dwi1.nii.gz',
-                            '--out_bval dwi0.bval dwi1.bval dwi2.bval',
-                            '--out_bvec dwi0.bvec dwi1.bvec dwi2.bvec')
+                            in_bval, in_bvec, '5', '15',
+                            '--out_dwi', 'dwi0.nii.gz', 'dwi1.nii.gz',
+                            '--out_bval', 'dwi0.bval',
+                            'dwi1.bval', 'dwi2.bval', '--out_bvec',
+                            'dwi0.bvec', 'dwi1.bvec', 'dwi2.bvec')
     assert (not ret.success)
 
     ret = script_runner.run('scil_split_image.py', in_dwi,
-                            in_bval, in_bvec, '5 15',
-                            '--out_dwi dwi0.nii.gz dwi1.nii.gz dwi2.nii.gz',
-                            '--out_bval dwi0.bval dwi1.bval dwi2.bval',
-                            '--out_bvec dwi0.bvec dwi1.bvec')
+                            in_bval, in_bvec, '5', '15',
+                            '--out_dwi', 'dwi0.nii.gz', 'dwi1.nii.gz',
+                            'dwi2.nii.gz', '--out_bval', 'dwi0.bval',
+                            'dwi1.bval', '--out_bvec',
+                            'dwi0.bvec', 'dwi1.bvec', 'dwi2.bvec')
     assert (not ret.success)
 
     ret = script_runner.run('scil_split_image.py', in_dwi,
-                            in_bval, in_bvec, '5 15',
-                            '--out_dwi dwi0.nii.gz dwi1.nii.gz dwi2.nii.gz',
-                            '--out_bval dwi0.bval dwi1.bval',
-                            '--out_bvec dwi0.bvec dwi1.bvec dwi2.bvec')
+                            in_bval, in_bvec, '5', '15',
+                            '--out_dwi', 'dwi0.nii.gz', 'dwi1.nii.gz',
+                            'dwi2.nii.gz', '--out_bval', 'dwi0.bval',
+                            'dwi1.bval', 'dwi2.bval', '--out_bvec',
+                            'dwi0.bvec', 'dwi1.bvec')
     assert (not ret.success)

--- a/scripts/tests/test_split_image.py
+++ b/scripts/tests/test_split_image.py
@@ -77,3 +77,15 @@ def test_execution_processing_wrong_output(script_runner):
                             'dwi1.bval', 'dwi2.bval', '--out_bvec',
                             'dwi0.bvec', 'dwi1.bvec')
     assert (not ret.success)
+
+def test_execution_processing_wrong_indices_given(script_runner):
+    os.chdir(os.path.expanduser(tmp_dir.name))
+    in_dwi = os.path.join(get_home(), 'processing',
+                          'dwi_crop.nii.gz')
+    in_bval = os.path.join(get_home(), 'processing',
+                           'dwi.bval')
+    in_bvec = os.path.join(get_home(), 'processing',
+                           'dwi.bvec')
+    ret = script_runner.run('scil_split_image.py', in_dwi,
+                            in_bval, in_bvec, '5', '25', '15')
+    assert (not ret.success)

--- a/scripts/tests/test_split_image.py
+++ b/scripts/tests/test_split_image.py
@@ -16,7 +16,7 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_processing_no_output_given(script_runner):
+def test_execution_processing(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi = os.path.join(get_home(), 'processing',
                           'dwi_crop.nii.gz')
@@ -25,21 +25,7 @@ def test_execution_processing_no_output_given(script_runner):
     in_bvec = os.path.join(get_home(), 'processing',
                            'dwi.bvec')
     ret = script_runner.run('scil_split_image.py', in_dwi,
-                            in_bval, in_bvec, '5', '15', '25')
-    assert ret.success
-
-
-def test_execution_processing_output_given(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
-    in_dwi = os.path.join(get_home(), 'processing',
-                          'dwi_crop.nii.gz')
-    in_bval = os.path.join(get_home(), 'processing',
-                           'dwi.bval')
-    in_bvec = os.path.join(get_home(), 'processing',
-                           'dwi.bvec')
-    ret = script_runner.run('scil_split_image.py', in_dwi,
-                            in_bval, in_bvec, '5', '15',
-                            '--out_basename', 'dwi')
+                            in_bval, in_bvec, 'dwi', '5', '15', '25')
     assert ret.success
 
 
@@ -52,5 +38,8 @@ def test_execution_processing_wrong_indices_given(script_runner):
     in_bvec = os.path.join(get_home(), 'processing',
                            'dwi.bvec')
     ret = script_runner.run('scil_split_image.py', in_dwi,
-                            in_bval, in_bvec, '5', '25', '15')
+                            in_bval, in_bvec, 'dwi', '0', '15', '25')
+    assert (not ret.success)
+    ret = script_runner.run('scil_split_image.py', in_dwi,
+                            in_bval, in_bvec, 'dwi', '5', '15', '200')
     assert (not ret.success)


### PR DESCRIPTION
Here is a small script that splits an image at certain given indices along the last dimension (so all the directions). I needed this to split a nifti file that had something like this: b-values = 0, 1500, 1500, 1500, 1500, 0, 1500, 1500, 1500, 1500, splited into separate dwi1_b0.nii.gz, dwi2_b0.nii.gz, dwi1_b1500.nii.gz and dwi2_b1500.nii.gz. The command for this particular example would be:

`scil_split_image.py dwi.nii.gz dwi.bval dwi.bvec 1 5 6 --out_dwi dwi1_b0.nii.gz dwi1_b1500.nii.gz dwi2_b0.nii.gz dwi2_b1500.nii.gz --out_bval dwi1_b0.bval dwi1_b1500.bval dwi2_b0.bval dwi2_b1500.bval --out_bvec dwi1_b0.bvec dwi1_b1500.bvec dwi2_b0.bvec dwi2_b1500.bvec`

where the input is dwi.nii.gz, dwi.bval and dwi.bvec.

By default, if no output names are given, the script will take the input names and append the indices to it, such as dwi_0_1.nii.gz, dwi_1_5.nii.gz, dwi_5_6.nii.gz and so on.

This can be easily tested on any data, so I don't think test data is useful for this PR. Also, I added a test file for the script.