### PR TITLE
Small changes in the dev tracker

### DIFF
--- a/scilpy/tracking/propagator.py
+++ b/scilpy/tracking/propagator.py
@@ -147,7 +147,7 @@ class AbstractPropagator(object):
 
         return is_direction_valid, v_out
 
-    def propagate(self, pos, v_in):
+    def propagate(self, line, v_in):
         """
         Given the current position and direction, computes the next position
         and direction using Runge-Kutta integration method. If no valid
@@ -155,7 +155,7 @@ class AbstractPropagator(object):
 
         Parameters
         ----------
-        pos: ndarrray (3,)
+        line: list[ndarrray (3,)]
             Current position.
         v_in: ndarray (3,) or TrackingDirection
             Previous tracking direction.
@@ -169,6 +169,9 @@ class AbstractPropagator(object):
         is_direction_valid: bool
             True if new_dir is valid.
         """
+        # Finding last coordinate
+        pos = line[-1]
+
         if self.rk_order == 1:
             is_direction_valid, new_dir = \
                 self._sample_next_direction_or_go_straight(pos, v_in)

--- a/scilpy/tracking/propagator.py
+++ b/scilpy/tracking/propagator.py
@@ -52,8 +52,17 @@ class AbstractPropagator(object):
         self.rk_order = rk_order
 
     def reset_data(self, new_data=None):
-        # Maybe not necessary. See #toDo in tracker
-        #  For multiprocessing.
+        """
+        Reset data before starting a new process. In current implementation,
+        we reset the internal data to None before starting a multiprocess, then
+        load it back when process has started.
+
+        Params
+        ------
+        new_data: Any
+            Will replace self.dataset.data.
+
+        """
         self.dataset.data = new_data
 
     def prepare_forward(self, seeding_pos):
@@ -191,26 +200,6 @@ class AbstractPropagator(object):
         new_pos = pos + self.step_size * np.array(new_dir)
 
         return new_pos, new_dir, is_direction_valid
-
-    def is_voxmm_in_bound(self, pos, origin):
-        """
-        Test if the streamline point is inside the boundary of the image.
-
-        Parameters
-        ----------
-        pos : tuple
-            3D positions.
-        origin: str
-            'Center': Voxel 0,0,0 goes from [-resx/2, -resy/2, -resz/2] to
-                [resx/2, resy/2, resz/2].
-            'Corner': Voxel 0,0,0 goes from [0,0,0] to [resx, resy, resz].
-
-        Return
-        ------
-        value: bool
-            True if the streamline point is inside the boundary of the image.
-        """
-        return self.dataset.is_voxmm_in_bound(*pos, origin)
 
     def _sample_next_direction(self, pos, v_in):
         """

--- a/scilpy/tracking/seed.py
+++ b/scilpy/tracking/seed.py
@@ -91,7 +91,7 @@ class SeedGenerator(object):
         ------
         random_generator : numpy random generator
             Initialized numpy number generator.
-        indices : List
+        indices : ndarray
             Indices of current seeding map.
         """
         random_generator = np.random.RandomState(random_initial_value)

--- a/scilpy/tracking/tracker.py
+++ b/scilpy/tracking/tracker.py
@@ -370,7 +370,7 @@ class Tracker(object):
         propagation_can_continue = True
         while len(line) < self.max_nbr_pts and propagation_can_continue:
             new_pos, new_tracking_info, is_direction_valid = \
-                self.propagator.propagate(line[-1], tracking_info)
+                self.propagator.propagate(line, tracking_info)
 
             # Verifying and appending
             if is_direction_valid:

--- a/scilpy/tracking/tracker.py
+++ b/scilpy/tracking/tracker.py
@@ -16,9 +16,9 @@ from scilpy.tracking.propagator import AbstractPropagator, PropagationStatus
 from scilpy.tracking.seed import SeedGenerator
 
 # For the multi-processing:
-# Iterable. Will contain all parameters necessary for a sub-process
+# Dictionary. Will contain all parameters necessary for a sub-process
 # initialization.
-multiprocess_init_args = []
+multiprocess_init_args = {}
 
 
 class Tracker(object):
@@ -184,7 +184,10 @@ class Tracker(object):
         pool = multiprocessing.Pool(
             self.nbr_processes,
             initializer=self._send_multiprocess_args_to_global,
-            initargs=(data_file_name, self.mmap_mode))
+            initargs={
+                'data_file_name': data_file_name,
+                'mmap_mode': self.mmap_mode
+            })
 
         return pool
 
@@ -236,7 +239,7 @@ class Tracker(object):
             (file where the data is saved, mmap_mode).
         """
         self.propagator.reset_data(np.load(
-            init_args[0], mmap_mode=init_args[1]))
+            init_args['data_file_name'], mmap_mode=init_args['mmap_mode']))
 
     def _get_streamlines(self, chunk_id):
         """

--- a/scilpy/tracking/tracker.py
+++ b/scilpy/tracking/tracker.py
@@ -22,8 +22,6 @@ multiprocess_init_args = []
 
 
 class Tracker(object):
-    printing_frequency = 1000
-
     def __init__(self, propagator: AbstractPropagator, mask: DataVolume,
                  seed_generator: SeedGenerator, nbr_seeds, min_nbr_pts,
                  max_nbr_pts, max_invalid_dirs, compression_th=0.1,
@@ -97,6 +95,8 @@ class Tracker(object):
             self.mmap_mode = None
 
         self.nbr_processes = self._set_nbr_processes(nbr_processes)
+
+        self.printing_frequency = 1000
 
     def track(self):
         """
@@ -173,9 +173,8 @@ class Tracker(object):
         # doing manually with a static class.
         # Be careful however, parameter changes inside the method will
         # not be kept.
-        # toDo
-        # must be better designed for dipy
-        # the tracking should not know which data to deal with
+
+        # Saving data. We will reload it in each process.
         data_file_name = os.path.join(tmpdir, 'data.npy')
         np.save(data_file_name, self.propagator.dataset.data)
 

--- a/scilpy/tracking/utils.py
+++ b/scilpy/tracking/utils.py
@@ -79,12 +79,13 @@ def add_out_options(p):
 
 
 def verify_streamline_length_options(parser, args):
-    if not args.min_length > 0:
-        parser.error('min_length must be > 0, {}mm was provided.'
+    if not args.min_length >= 0:
+        parser.error('min_length must be >= 0, but {}mm was provided.'
                      .format(args.min_length))
     if args.max_length < args.min_length:
-        parser.error('max_length must be > than minL, but minL={}mm and '
-                     'maxL={}mm.'.format(args.min_length, args.max_length))
+        parser.error('max_length must be > than min_length, but '
+                     'min_length={}mm and max_length={}mm.'
+                     .format(args.min_length, args.max_length))
 
 
 def verify_seed_options(parser, args):


### PR DESCRIPTION
- Encapsulated parts for easier management with dwi_ml.
 (Multiprocessing does not need to save data to tmpdir and load it back because we use hdf5 files with lazy use, which deal well with multiprocessing).
 
- Made the processing frequency param (this way, I can have more prints in dwi_ml).
 
- Added docstring.
 
- Removed unused method in the propagator.
 
- Removed the comment #todo must be better designed for dipy: I don't thing we intend to change this.

- Sending line instead of line[-1] to propagator. In our case, propagator sometimes needs to know where you are coming from.