### PR TITLE
Adding check for ints

### DIFF
--- a/scilpy/utils/image.py
+++ b/scilpy/utils/image.py
@@ -42,7 +42,12 @@ def transform_anatomy(transfo, reference, moving, filename_to_save,
     static_data = nib.load(reference).get_fdata(dtype=np.float32)
 
     nib_file = nib.load(moving)
-    moving_data = nib_file.get_fdata(dtype=np.float32)
+    curr_type = nib_file.get_data_dtype()
+    if np.issubdtype(curr_type, np.signedinteger) or \
+       np.issubdtype(curr_type, np.unsignedinteger):
+        moving_data = np.asanyarray(nib_file.dataobj).astype(curr_type)
+    else:
+        moving_data = nib_file.get_fdata(dtype=curr_type)
     moving_affine = nib_file.affine
 
     if moving_data.ndim == 3 and isinstance(moving_data[0, 0, 0],


### PR DESCRIPTION
Really small PR. Quick fix for the function `transform_anatomy` from utils/image.py. Previously, it was forcing the input file to be loaded in float32 with `get_fdata(dtype=np.float32)`, and later the output was saved using the dtype of the loaded file, which was always float32 regardless of the "real" input dtype. I added a check for uint or int, which is followed by `moving_data = np.asanyarray(nib_file.dataobj).astype(curr_type)` if True, and `moving_data = nib_file.get_fdata(dtype=curr_type)` if False, where `curr_type = nib_file.get_data_dtype()`.

I was getting this problem when using `scil_reshape_to_reference.py` with labels (.mgz) in int32. The output (.nii.gz) ended up in float32 and `scil_split_volume_by_ids.py` didn't work.

You can test this either directly with the function `transform_anatomy` or by calling `scil_reshape_to_reference.py` with `in_file` being an int or a float (testing both) file.