### PR TITLE
Enhance GPU tracking

### DIFF
--- a/scilpy/tracking/local_tracking.cl
+++ b/scilpy/tracking/local_tracking.cl
@@ -13,6 +13,7 @@ SH volume. Tracking is performed in voxel space.
 #define N_THETAS 0
 #define STEP_SIZE 0
 #define MAX_LENGTH 0
+#define FORWARD_ONLY false
 
 // CONSTANTS
 #define FLOAT_TO_BOOL_EPSILON 0.1f
@@ -241,7 +242,7 @@ __kernel void track(__global const float* sh_coeffs,
                                sh_to_sf_mat,  out_streamlines);
 
     // reverse streamline for backward tracking
-    if(current_length > 1 && current_length < MAX_LENGTH)
+    if(current_length > 1 && current_length < MAX_LENGTH && !FORWARD_ONLY)
     {
         // reset last direction to initial direction
         last_dir.x = out_streamlines[get_flat_index(seed_indice, 0, 0, 0,

--- a/scilpy/tracking/tracker.py
+++ b/scilpy/tracking/tracker.py
@@ -404,7 +404,7 @@ class GPUTacker():
     mask : ndarray
         Tracking mask. Tracking stops outside the mask.
     seed : ndarray (n_seeds, 3)
-        Seed positions.
+        Seed positions with origin center.
     step_size : float
         Step size in voxel space.
     min_nbr_pts : int
@@ -414,46 +414,55 @@ class GPUTacker():
     theta : float or list of float, optional
         Maximum angle (degrees) between 2 steps. If a list, a theta
         is randomly drawn from the list for each streamline.
-    sharpness : float, optional
-        Exponent on ODF amplitude to control sharpness.
-    batch_size : int, optional
-        Approximate size of GPU batches.
     sh_order : int, optional
         Spherical harmonics order.
     sh_basis : str, optional
         Spherical harmonics basis.
+    batch_size : int, optional
+        Approximate size of GPU batches.
+    rng_seed : int, optional
+        Seed for random number generator.
 
     Returns
     -------
     streamlines: list
         List of streamlines.
     """
-    def __init__(self, sh, mask, seeds, step_size,
-                 min_nbr_pts, max_nbr_pts, theta=20.0,
-                 sh_basis='descoteaux07', batch_size=100000):
+    def __init__(self, sh, mask, seeds, step_size, min_nbr_pts, max_nbr_pts,
+                 theta=20.0, sh_basis='descoteaux07', batch_size=100000,
+                 forward_only=False, rng_seed=None):
         if not have_opencl:
             raise ImportError('pyopencl is not installed. In order to use'
                               'GPU tracker, you need to install it first.')
         self.sh = sh
         self.mask = mask
 
-        # translate seeds to origin corner
-        seeds = seeds + 0.5
+        # Seeds
+        seeds = seeds + 0.5  # translate to origin corner
         self.n_seeds = len(seeds)
         self.seed_batches =\
             np.array_split(seeds, np.ceil(len(seeds)/batch_size))
+
+        # tracking step_size and number of points
         self.step_size = step_size
         self.min_strl_points = min_nbr_pts
         self.max_strl_points = max_nbr_pts
 
+        # convert theta to array
         if isinstance(theta, float):
             theta = np.array([theta])
         self.theta = theta
 
         self.sh_basis = sh_basis
-        self.batch_size = batch_size
+        self.forward_only = forward_only
+
+        # Instantiate random number generator
+        self.rng = np.random.default_rng(rng_seed)
 
     def track(self):
+        """
+        Generate streamlines on the GPU. Yield them one by one.
+        """
         t0 = perf_counter()
 
         # Load the sphere
@@ -475,6 +484,8 @@ class GPUTacker():
         cl_kernel.set_define('N_THETAS', len(self.theta))
         cl_kernel.set_define('STEP_SIZE', '{}f'.format(self.step_size))
         cl_kernel.set_define('MAX_LENGTH', self.max_strl_points)
+        cl_kernel.set_define('FORWARD_ONLY',
+                             'true' if self.forward_only else 'false')
 
         # Create CL program
         n_input_params = 7
@@ -494,31 +505,29 @@ class GPUTacker():
 
         cl_manager.add_input_buffer(6, max_cos_theta)
 
-        # Output buffers
-        cl_manager.add_output_buffer(
-            0, (self.batch_size, self.max_strl_points, 3))
-        cl_manager.add_output_buffer(1, (self.batch_size, 1))
         logging.debug('Initialized OpenCL program in {:.2f}s.'
                       .format(perf_counter() - t0))
 
         # Generate streamlines in batches
         t0 = perf_counter()
-        nb_streamlines = 0
-        streamlines = []
-        seeds = []
+        nb_processed_streamlines = 0
+        nb_valid_streamlines = 0
         for seed_batch in self.seed_batches:
             # Generate random values for sf sampling
             # TODO: Implement random number generator directly
             #       on the GPU to generate values on-the-fly.
-            rand_vals = np.random.uniform(0.0, 1.0,
-                                          (len(seed_batch),
-                                           self.max_strl_points))
+            rand_vals = self.rng.uniform(0.0, 1.0,
+                                         (len(seed_batch),
+                                          self.max_strl_points))
 
             # Update buffers
             cl_manager.add_input_buffer(4, seed_batch)
             cl_manager.add_input_buffer(5, rand_vals)
+
+            # output streamlines buffer
             cl_manager.add_output_buffer(
                 0, (len(seed_batch), self.max_strl_points, 3))
+            # output streamlines length buffer
             cl_manager.add_output_buffer(1, (len(seed_batch), 1))
 
             # Run the kernel
@@ -526,13 +535,17 @@ class GPUTacker():
             n_points = n_points.squeeze().astype(np.int16)
             for (strl, seed, n_pts) in zip(tracks, seed_batch, n_points):
                 if n_pts >= self.min_strl_points:
-                    # shift to origin center
-                    streamlines.append(strl[:n_pts] - 0.5)
-                    seeds.append(seed - 0.5)
-            nb_streamlines += len(seed_batch)
+                    # translate back to original space
+                    strl = strl[:n_pts] - 0.5
+                    seed = seed - 0.5
+
+                    # output is yielded so that we can use lazy tractogram.
+                    yield strl, seed
+                    nb_valid_streamlines += 1
+
+            nb_processed_streamlines += len(seed_batch)
             logging.info('{0:>8}/{1} streamlines generated'
-                         .format(nb_streamlines, self.n_seeds))
+                         .format(nb_processed_streamlines, self.n_seeds))
 
         logging.info('Tracked {0} streamlines in {1:.2f}s.'
-                     .format(len(streamlines), perf_counter() - t0))
-        return streamlines, seeds
+                     .format(nb_valid_streamlines, perf_counter() - t0))

--- a/scilpy/tracking/tracker.py
+++ b/scilpy/tracking/tracker.py
@@ -370,7 +370,7 @@ class GPUTacker():
     """
     Perform probabilistic tracking on a ODF field inside a binary mask. The
     tracking is executed on the GPU using the OpenCL API. Tracking is performed
-    in voxel space.
+    in voxel space with origin `corner`.
 
     Streamlines are interrupted as soon as they reach maximum length and
     returned even if they end inside the tracking mask. The ODF image is
@@ -384,7 +384,7 @@ class GPUTacker():
     mask : ndarray
         Tracking mask. Tracking stops outside the mask.
     seeds : ndarray (n_seeds, 3)
-        Seed positions with origin center.
+        Seed positions in voxel space with origin `corner`.
     step_size : float
         Step size in voxel space.
     min_nbr_pts : int

--- a/scripts/scil_compute_local_tracking_gpu.py
+++ b/scripts/scil_compute_local_tracking_gpu.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Perform probabilistic tractography [1] on a ODF field inside a binary mask.
+Perform probabilistic tractography on a ODF field inside a binary mask.
 The tracking is executed on the GPU using the OpenCL API.
 
 Streamlines are filtered by minimum length, but not by maximum length. For this

--- a/scripts/scil_compute_local_tracking_gpu.py
+++ b/scripts/scil_compute_local_tracking_gpu.py
@@ -24,11 +24,7 @@ from time import perf_counter
 import nibabel as nib
 import numpy as np
 
-
-from dipy.io.stateful_tractogram import Space, StatefulTractogram
-from dipy.io.streamline import save_tractogram
 from nibabel.streamlines.tractogram import LazyTractogram, TractogramItem
-from nibabel.affines import apply_affine
 from scilpy.io.utils import (add_overwrite_arg, add_sh_basis_args,
                              add_verbose_arg, assert_inputs_exist,
                              assert_outputs_exist)
@@ -147,7 +143,9 @@ def main():
 
             # TODO: Investigate why the streamline must not be shifted to
             # origin `corner` for LazyTractogram.
-            strl *= voxel_size
+            strl *= voxel_size  # in mm.
+            if args.compress:
+                strl = compress_streamlines(strl, args.compress)
             yield TractogramItem(strl, dps, {})
 
     # instantiate tractogram

--- a/scripts/scil_compute_local_tracking_gpu.py
+++ b/scripts/scil_compute_local_tracking_gpu.py
@@ -47,38 +47,52 @@ EPILOG = """
 def _build_arg_parser():
     p = argparse.ArgumentParser(description=__doc__, epilog=EPILOG,
                                 formatter_class=argparse.RawTextHelpFormatter)
+
+    # rename `optional arguments` group to `Generic options`
+    p._optionals.title = 'Generic options'
+
     # mandatory tracking options
     add_mandatory_options_tracking(p)
 
-    add_seeding_options(p)
-    p.add_argument('--step_size', type=float, default=0.5,
-                   help='Step size in mm. [%(default)s]')
-    p.add_argument('--theta', type=float, nargs='+', default=20.0,
-                   help='Maximum angle between 2 steps. If more than one value'
-                        '\nare given, the maximum angle will be drawn at '
-                        'random\nfrom the distribution for each streamline. '
-                        '[%(default)s]')
-    p.add_argument('--min_length', type=float, default=20.0,
-                   help='Minimum length of the streamline '
-                        'in mm. [%(default)s]')
-    p.add_argument('--max_length', type=float, default=300.0,
-                   help='Maximum length of the streamline '
-                        'in mm. [%(default)s]')
-    p.add_argument('--forward_only', action='store_true',
-                   help='Only perform forward tracking.')
-    p.add_argument('--batch_size', type=int, default=100000,
-                   help='Approximate size of GPU batches. The default value is'
-                        ' quite conservative. [%(default)s]')
-    p.add_argument('--save_seeds', action='store_true',
-                   help='Save seed positions in data_per_streamline.')
-    p.add_argument('--compress', type=float,
-                   help='Compress streamlines using the given threshold.')
-    p.add_argument('--rng_seed', type=int,
-                   help='Random number generator seed.')
+    track_g = p.add_argument_group('Tracking options')
+    track_g.add_argument('--step_size', type=float, default=0.5,
+                         help='Step size in mm. [%(default)s]')
+    track_g.add_argument('--theta', type=float, nargs='+', default=20.0,
+                         help='Maximum angle between 2 steps. If more than one'
+                              ' value\nare given, the maximum angle will be '
+                              'drawn at random\nfrom the distribution for each'
+                              ' streamline. [%(default)s]')
+    track_g.add_argument('--min_length', type=float, default=20.0,
+                         help='Minimum length of the streamline '
+                              'in mm. [%(default)s]')
+    track_g.add_argument('--max_length', type=float, default=300.0,
+                         help='Maximum length of the streamline '
+                              'in mm. [%(default)s]')
+    track_g.add_argument('--forward_only', action='store_true',
+                         help='Only perform forward tracking.')
+    add_sh_basis_args(track_g)
 
-    add_sh_basis_args(p)
-    add_overwrite_arg(p)
-    add_verbose_arg(p)
+    # seeding options
+    add_seeding_options(p)
+    out_g = p.add_argument_group('Output options')
+    out_g.add_argument('--save_seeds', action='store_true',
+                       help='Save seed positions in data_per_streamline.')
+    out_g.add_argument('--compress', type=float,
+                       help='Compress streamlines using the given threshold.')
+
+    # random number generator for SF sampling
+    out_g.add_argument('--rng_seed', type=int,
+                       help='Random number generator seed.')
+    add_overwrite_arg(out_g)
+
+    gpu_g = p.add_argument_group('GPU options')
+    gpu_g.add_argument('--batch_size', type=int, default=100000,
+                       help='Approximate size of GPU batches (number\n'
+                            'of streamlines to track in parallel).'
+                            ' [%(default)s]')
+
+    log_g = p.add_argument_group('Logging options')
+    add_verbose_arg(log_g)
     return p
 
 

--- a/scripts/scil_compute_local_tracking_gpu.py
+++ b/scripts/scil_compute_local_tracking_gpu.py
@@ -141,7 +141,7 @@ def main():
             # seed must be saved in voxel space, with origin `center`.
             dps = {'seeds': seed - 0.5} if args.save_seeds else {}
 
-            # TODO: Investigate why the streamline must not be shifted to
+            # TODO: Investigate why the streamline must NOT be shifted to
             # origin `corner` for LazyTractogram.
             strl *= voxel_size  # in mm.
             if args.compress:


### PR DESCRIPTION
Addresses some (but not all) of the enhancements suggested in issue #583 .
In particular:
* Add compress streamlines option;
* Save streamlines on-the-fly using `LazyTractogram` (so much faster and way more memory-friendly);
* Add random number generator seed for reproducibility;
* Add `forward_only` mode for disabling backward pass.