### PR TITLE
Modify scil_cut_streamlines.py

### DIFF
--- a/scripts/scil_cut_streamlines.py
+++ b/scripts/scil_cut_streamlines.py
@@ -95,9 +95,11 @@ def main():
         new_sft = cut_between_masks_streamlines(sft, binary_mask)
 
     else:
-        logging.error('The provided mask has more than 2 entities. Cannot cut '
-                      'between >2.')
-        return
+        logging.warning('The provided mask has MORE THAN 2 entity '
+                    'cut_between_masks_streamlines function selected. '
+                    'This may cause problems with the outputed streamlines.'
+                    'Please inspect the output carefully.')
+        new_sft = cut_between_masks_streamlines(sft, binary_mask)
 
     if len(new_sft) == 0:
         logging.warning('No streamline intersected the provided mask. '


### PR DESCRIPTION
So previously, if you gave to `scil_cut_streamlines.py` a mask containing 2 blobs, but one of your blob happened to have a lonely voxel (disconnected from the main blob), the script would stop with an error, stating that you have more than 2 blobs. I had such blobs, and tried replacing the error by a warning and continuing with the process. The script seems to perform well in that case, so I was wondering why forcing it to stop and not just warn the user that something might be wrong? This way we can run the script with blobs that have solo voxels and it doesn't break the results.

Let me know if I got something wrong here @frheault.