### PR TITLE
Clarify vox space

### DIFF
--- a/scilpy/image/datasets.py
+++ b/scilpy/image/datasets.py
@@ -61,7 +61,7 @@ class DataVolume(object):
         value: ndarray (self.dim[-1],)
             The value evaluated at voxel x, y, z.
         """
-        i, j, k = self._idx_to_closest_coord(i, j, k)
+        i, j, k = self._clip_idx_to_bound(i, j, k)
         return self.data[i][j][k]
 
     def is_idx_in_bound(self, i, j, k):
@@ -82,17 +82,21 @@ class DataVolume(object):
                 0 <= j < (self.dim[1]) and
                 0 <= k < (self.dim[2]))
 
-    def _idx_to_closest_coord(self, i, j, k):
+    def _clip_idx_to_bound(self, i, j, k):
+        """
+        Returns i, j, k if the index is valid inside the bounding box. Else,
+        finds the closest valid index on the border.
+        """
         if not self.is_idx_in_bound(i, j, k):
             i = max(0, min(self.dim[0] - 1, i))
             j = max(0, min(self.dim[1] - 1, j))
             k = max(0, min(self.dim[2] - 1, k))
         return i, j, k
 
-    def _vox_to_closest_coord(self, x, y, z, origin):
+    def _clip_vox_to_bound(self, x, y, z, origin):
         """
-        In voxel space, get closest coordinate in the voxel in out of bout.
-        Else, return initial coordinates.
+        Returns x, y, z if the voxel coordinate is valid inside the bounding
+        box. Else, finds the closest valid value on the border.
 
         Parameters
         ----------
@@ -170,7 +174,7 @@ class DataVolume(object):
         """
         if self.interpolation is not None:
             # Checking if out of bound.
-            x, y, z = self._vox_to_closest_coord(x, y, z, origin)
+            x, y, z = self._clip_vox_to_bound(x, y, z, origin)
 
             # Interpolation: Using dipy's pyx methods. The doc can be found in
             # the file dipy.core.interpolation.pxd. Dipy works with origin

--- a/scilpy/image/datasets.py
+++ b/scilpy/image/datasets.py
@@ -235,7 +235,7 @@ class DataVolume(object):
             # Interpolation: Using dipy's pyx methods. The doc can be found in
             # the file dipy.core.interpolation.pxd. Dipy works with origin
             # center.
-            coord = np.array((x, y, z), dtype=np.float64)
+            coord = np.array((x, y, z), dtype=np.float32)
             if origin == Origin('corner'):
                 coord -= 0.5
 

--- a/scilpy/image/datasets.py
+++ b/scilpy/image/datasets.py
@@ -235,7 +235,8 @@ class DataVolume(object):
             # Interpolation: Using dipy's pyx methods. The doc can be found in
             # the file dipy.core.interpolation.pxd. Dipy works with origin
             # center.
-            coord = np.array((x, y, z), dtype=np.float32)
+            # Note. Data is expected to be double (float64), can't use float32.
+            coord = np.array((x, y, z), dtype=np.float64)
             if origin == Origin('corner'):
                 coord -= 0.5
 

--- a/scilpy/io/image.py
+++ b/scilpy/io/image.py
@@ -11,7 +11,7 @@ def assert_same_resolution(images):
     Check the resolution of multiple images.
     Parameters
     ----------
-    images : array of string or string
+    images : list of string or string
         List of images or an image.
     """
     if isinstance(images, str):

--- a/scilpy/tracking/propagator.py
+++ b/scilpy/tracking/propagator.py
@@ -42,8 +42,15 @@ class AbstractPropagator(object):
             Order for the Runge Kutta integration.
         space: dipy Space
             Space of the streamlines during tracking.
+            value.
         origin: dipy Origin
-            Origin of the streamlines during tracking.
+            Origin of the streamlines during tracking. All coordinates received
+            in the propagator's methods will be expected to respect that origin.
+
+        A note on space and origin: All coordinates received in the
+        propagator's methods will be expected to respect those values.
+        Tracker will verify that the propagator has the same internal values as
+        itself.
         """
         self.dataset = dataset
 
@@ -83,6 +90,8 @@ class AbstractPropagator(object):
         Parameters
         ----------
         seeding_pos: tuple(x,y,z)
+            The seeding position. Important, position must be in the same space
+            and origin as self.space, self.origin!
 
         Returns
         -------
@@ -130,7 +139,8 @@ class AbstractPropagator(object):
         Parameters
         ----------
         last_pos: ndarray (3,)
-            Last propagated position.
+            Last propagated position. Important, position must be in the same
+            space and origin as self.space, self.origin!
         v_in: TrackingDirection
             Last propagated direction.
 
@@ -175,7 +185,8 @@ class AbstractPropagator(object):
         Return
         ------
         new_pos: ndarray (3,)
-            The new segment position.
+            The new segment position, expressed in propagator's space and
+            origin.
         new_dir: ndarray (3,) or TrackingDirection
             The new segment direction.
         is_direction_valid: bool
@@ -224,7 +235,8 @@ class AbstractPropagator(object):
         Parameters
         ----------
         pos: ndarray (3,)
-            Current tracking position.
+            Current tracking position.  Important, position must be in the same
+            space and origin as self.space, self.origin!
         v_in: ndarray (3,)
             Previous tracking direction.
 
@@ -264,9 +276,6 @@ class PropagatorOnSphere(AbstractPropagator):
         for i in range(len(self.sphere.vertices)):
             self.dirs[i] = TrackingDirection(self.sphere.vertices[i], i)
 
-    def prepare_forward(self, seeding_pos):
-        raise NotImplementedError
-
     def prepare_backward(self, line, forward_dir):
         """
         Called at the beginning of backward tracking, in case we need to
@@ -297,26 +306,6 @@ class PropagatorOnSphere(AbstractPropagator):
         #  x,y, z or rho, phi? self.sphere.vertices[ind] might not be
         #  exactly equal to last_dir or to backward_dir.
         return TrackingDirection(self.sphere.vertices[ind], ind)
-
-    def _sample_next_direction(self, pos, v_in):
-        """
-        Chooses a next tracking direction from all possible directions offered
-        by the tracking field.
-
-        Parameters
-        ----------
-        pos: ndarray (3,)
-            Current tracking position.
-        v_in: ndarray (3,)
-            Previous tracking direction.
-
-        Return
-        -------
-        direction: ndarray (3,)
-            A valid tracking direction. None if no valid direction is found.
-            Direction should be normalized.
-        """
-        raise NotImplementedError
 
 
 class ODFPropagator(PropagatorOnSphere):
@@ -413,7 +402,8 @@ class ODFPropagator(PropagatorOnSphere):
         Parameters
         ----------
         pos: ndarray (3,)
-            Position in the trackable dataset, either in vox or voxmm space.
+            Position in the trackable dataset. Important, position should be
+            in the same space and origin as self.space, self.origin!
 
         Return
         ------
@@ -445,6 +435,8 @@ class ODFPropagator(PropagatorOnSphere):
         Parameters
         ----------
         seeding_pos: tuple(x,y,z)
+            The seeding position. Important, position must be in the same space
+            and origin as self.space, self.origin!
 
         Returns
         -------
@@ -477,7 +469,8 @@ class ODFPropagator(PropagatorOnSphere):
         Parameters
         ----------
         pos: ndarray (3,)
-            Current tracking position.
+            Current tracking position.  Important, position must be in the same
+            space and origin as self.space, self.origin!
         v_in: ndarray (3,)
             Previous tracking direction.
 
@@ -521,7 +514,8 @@ class ODFPropagator(PropagatorOnSphere):
         Parameters
         ----------
         pos: ndarray (3,)
-            Position in trackable dataset, expressed in mm.
+            Position in trackable dataset. Important, position must be in the
+            same space and origin as self.space, self.origin!
         v_in: TrackingDirection
             Incoming direction. Outcoming direction won't be further than an
             angle theta.
@@ -546,7 +540,8 @@ class ODFPropagator(PropagatorOnSphere):
         Parameters
         ----------
         pos: ndarray (3,)
-            Position in trackable dataset, expressed in mm.
+            Position in trackable dataset. Important, position must be in the
+            same space and origin as self.space, self.origin!
         previous_direction: TrackingDirection
             Incoming direction. Outcoming direction won't be further than an
             angle theta.

--- a/scilpy/tracking/propagator.py
+++ b/scilpy/tracking/propagator.py
@@ -52,6 +52,9 @@ class AbstractPropagator(object):
                              str(rk_order) + ". Choices : 1, 2, 4")
         self.rk_order = rk_order
 
+        # By default, normalizing directions. Adding option for child classes.
+        self.normalize_directions = True
+
     def reset_data(self, new_data=None):
         """
         Reset data before starting a new process. In current implementation,
@@ -106,7 +109,10 @@ class AbstractPropagator(object):
         """
         if len(line) > 1:
             v = line[-1] - line[-2]
-            return v / np.linalg.norm(v)
+            if self.normalize_directions:
+                return v / np.linalg.norm(v)
+            else:
+                return v
         elif forward_dir is not None:
             return [-dir_i for dir_i in forward_dir]
         else:

--- a/scilpy/tracking/propagator.py
+++ b/scilpy/tracking/propagator.py
@@ -34,7 +34,8 @@ class AbstractPropagator(object):
         dataset: scilpy.image.datasets.DataVolume
             Trackable Dataset object.
         step_size: float
-            The step size for tracking.
+            The step size for tracking. Important: step size should be in the
+            same units as the space of the tracking! Here, voxmm => in mm.
         rk_order: int
             Order for the Runge Kutta integration.
         """

--- a/scilpy/tracking/seed.py
+++ b/scilpy/tracking/seed.py
@@ -34,7 +34,6 @@ class SeedGenerator(object):
 
         # self.seed are all the voxels where a seed could be placed
         # (voxel space, int numbers).
-        # See also dipy's random_seeds_from_mask
         self.seeds = np.array(np.where(np.squeeze(data) > 0),
                               dtype=float).transpose()
         if len(self.seeds) == 0:

--- a/scilpy/tracking/seed.py
+++ b/scilpy/tracking/seed.py
@@ -34,6 +34,7 @@ class SeedGenerator(object):
 
         # self.seed are all the voxels where a seed could be placed
         # (voxel space, int numbers).
+        # See also dipy's random_seeds_from_mask
         self.seeds = np.array(np.where(np.squeeze(data) > 0),
                               dtype=float).transpose()
         if len(self.seeds) == 0:

--- a/scilpy/tracking/seed.py
+++ b/scilpy/tracking/seed.py
@@ -78,13 +78,23 @@ class SeedGenerator(object):
         y += r_y
         z += r_z
 
-        assert self.origin == 'corner'
+        if self.origin == 'center':
+            # Bound [0, 0, 0] is now [-0.5, -0.5, -0.5]
+            x -= 0.5
+            y -= 0.5
+            z -= 0.5
+        elif self.origin != 'corner':
+            raise ValueError("Wrong origin!")
+
         if self.space == 'vox':
             return x, y, z
         elif self.space == 'voxmm':
             return x * self.voxres[0], y * self.voxres[1], z * self.voxres[2]
         else:
             raise NotImplementedError("We do not support rasmm space.")
+
+        # Dealing with origin
+
 
     def init_generator(self, random_initial_value, first_seed_of_chunk):
         """

--- a/scilpy/tracking/tracker.py
+++ b/scilpy/tracking/tracker.py
@@ -309,6 +309,7 @@ class Tracker(object):
 
                 if self.save_seeds:
                     seeds.append(np.asarray(seed, dtype='float32'))
+
         return streamlines, seeds
 
     def _get_line_both_directions(self, seeding_pos):

--- a/scilpy/tracking/tracker.py
+++ b/scilpy/tracking/tracker.py
@@ -401,17 +401,28 @@ class Tracker(object):
         return line
 
     def _verify_stopping_criteria(self, invalid_direction_count, last_pos):
+
         # Checking number of consecutive invalid directions
         if invalid_direction_count > self.max_invalid_dirs:
             return False
 
         # Checking if out of bound
-        if not self.mask.is_voxmm_in_bound(*last_pos, origin=self.origin):
-            return False
+        # Space in voxmm in this class but verifying in case a child class
+        # allows a different space usage.
+        if self.space == 'voxmm':
+            if not self.mask.is_voxmm_in_bound(*last_pos, origin=self.origin):
+                return False
 
-        # Checking if out of mask
-        if self.mask.voxmm_to_value(*last_pos, origin=self.origin) <= 0:
-            return False
+            # Checking if out of mask
+            if self.mask.voxmm_to_value(*last_pos, origin=self.origin) <= 0:
+                return False
+        elif self.space == 'vox':
+            if not self.mask.is_vox_in_bound(*last_pos, origin=self.origin):
+                return False
+
+            # Checking if out of mask
+            if self.mask.vox_to_value(*last_pos, origin=self.origin) <= 0:
+                return False
 
         return True
 

--- a/scripts/scil_compute_local_tracking.py
+++ b/scripts/scil_compute_local_tracking.py
@@ -231,8 +231,12 @@ def main():
         data_per_streamlines = {}
 
     if args.compress:
+        # Compressing. Threshold is in mm, but we are working in voxel space.
+        # Equivalent of sft.to_voxmm:  streamline *= voxres
+        # Equivalent of sft.to_vox: streamline /= voxres
         filtered_streamlines = (
-            compress_streamlines(s, args.compress)
+            compress_streamlines(s * voxel_size,
+                                 args.compress) / voxel_size
             for s in filtered_streamlines)
 
     tractogram = LazyTractogram(lambda: filtered_streamlines,

--- a/scripts/scil_compute_local_tracking.py
+++ b/scripts/scil_compute_local_tracking.py
@@ -194,6 +194,9 @@ def main():
     voxel_size = odf_sh_img.header.get_zooms()[0]
     vox_step_size = args.step_size / voxel_size
     seed_img = nib.load(args.in_seed)
+
+    # Note. Seeds are in voxel world, center origin.
+    # (See the examples in random_seeds_from_mask).
     seeds = track_utils.random_seeds_from_mask(
         seed_img.get_fdata(dtype=np.float32),
         np.eye(4),

--- a/scripts/scil_compute_local_tracking.py
+++ b/scripts/scil_compute_local_tracking.py
@@ -234,9 +234,10 @@ def main():
         # Compressing. Threshold is in mm, but we are working in voxel space.
         # Equivalent of sft.to_voxmm:  streamline *= voxres
         # Equivalent of sft.to_vox: streamline /= voxres
+        voxres = np.asarray(odf_sh_img.header.get_zooms()[0:3])
         filtered_streamlines = (
-            compress_streamlines(s * voxel_size,
-                                 args.compress) / voxel_size
+            compress_streamlines(s * voxres,
+                                 args.compress) / voxres
             for s in filtered_streamlines)
 
     tractogram = LazyTractogram(lambda: filtered_streamlines,

--- a/scripts/scil_compute_local_tracking_dev.py
+++ b/scripts/scil_compute_local_tracking_dev.py
@@ -198,10 +198,16 @@ def main():
     dataset = DataVolume(odf_sh_data, odf_sh_res, args.sh_interp)
 
     logging.debug("Instantiating propagator.")
+    # Converting step size to vox space
+    # We only support iso vox for now.
+    assert odf_sh_res[0] == odf_sh_res[1] == odf_sh_res[2]
+    voxel_size = odf_sh_img.header.get_zooms()[0]
+    vox_step_size = args.step_size / voxel_size
+
     # Using space and origin in the propagator: vox and center, like
     # in dipy.
     propagator = ODFPropagator(
-        dataset, args.step_size, args.rk_order, args.algo, args.sh_basis,
+        dataset, vox_step_size, args.rk_order, args.algo, args.sh_basis,
         args.sf_threshold, args.sf_threshold_init, theta, args.sphere,
         space=our_space, origin=our_origin)
 

--- a/scripts/scil_compute_local_tracking_dev.py
+++ b/scripts/scil_compute_local_tracking_dev.py
@@ -165,13 +165,13 @@ def main():
     if args.npv:
         # toDo. This will not really produce n seeds per voxel, only true
         #  in average.
-        nbr_seeds = len(seed_generator.seeds) * args.npv
+        nbr_seeds = len(seed_generator.seeds_vox) * args.npv
     elif args.nt:
         nbr_seeds = args.nt
     else:
         # Setting npv = 1.
-        nbr_seeds = len(seed_generator.seeds)
-    if len(seed_generator.seeds) == 0:
+        nbr_seeds = len(seed_generator.seeds_vox)
+    if len(seed_generator.seeds_vox) == 0:
         parser.error('Seed mask "{}" does not have any voxel with value > 0.'
                      .format(args.in_seed))
 

--- a/scripts/scil_compute_local_tracking_dev.py
+++ b/scripts/scil_compute_local_tracking_dev.py
@@ -160,6 +160,8 @@ def main():
     assert_same_resolution([args.in_mask, args.in_odf, args.in_seed])
 
     # Choosing our space and origin for this tracking
+    # If save_seeds, space and origin must be vox, center. Choosing those
+    # values.
     our_space = Space.VOX
     our_origin = Origin('center')
 
@@ -226,8 +228,6 @@ def main():
     # We seeded (and tracked) in vox, center, which is what is expected for
     # seeds.
     if args.save_seeds:
-        assert our_origin == Origin('center')
-        assert our_space == Space.VOX
         data_per_streamline = {'seeds': seeds}
     else:
         data_per_streamline = {}

--- a/scripts/scil_compute_seed_density_map.py
+++ b/scripts/scil_compute_seed_density_map.py
@@ -24,7 +24,7 @@ def _build_arg_parser():
     p.add_argument('tractogram_filename',
                    help='Tracts filename. Format must be .trk. \nFile should '
                         'contain a "seeds" value in the data_per_streamline.\n'
-                        'These seeds must be in voxel world, center origin.')
+                        'These seeds must be in space: voxel, origin: corner.')
     p.add_argument('seed_density_filename',
                    help='Output seed density filename. Format must be Nifti.')
     p.add_argument('--binary',

--- a/scripts/tests/test_compute_local_tracking.py
+++ b/scripts/tests/test_compute_local_tracking.py
@@ -24,6 +24,7 @@ def test_execution_tracking_fodf(script_runner):
                            'fodf.nii.gz')
     in_mask = os.path.join(get_home(), 'tracking',
                            'seeding_mask.nii.gz')
+
     ret = script_runner.run('scil_compute_local_tracking.py', in_fodf,
                             in_mask, in_mask, 'local_prob.trk', '--nt', '1000',
                             '--compress', '0.1', '--sh_basis', 'descoteaux07',
@@ -31,10 +32,25 @@ def test_execution_tracking_fodf(script_runner):
     assert ret.success
 
 
+def test_execution_tracking_fodf_no_compression(script_runner):
+    os.chdir(os.path.expanduser(tmp_dir.name))
+    in_fodf = os.path.join(get_home(), 'tracking',
+                           'fodf.nii.gz')
+    in_mask = os.path.join(get_home(), 'tracking',
+                           'seeding_mask.nii.gz')
+
+    ret = script_runner.run('scil_compute_local_tracking.py', in_fodf,
+                            in_mask, in_mask, 'local_prob2.trk',
+                            '--nt', '100', '--sh_basis', 'descoteaux07',
+                            '--max_length', '200')
+
+    assert ret.success
+
+
 def test_execution_tracking_peaks(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
     in_peaks = os.path.join(get_home(), 'tracking',
-                           'peaks.nii.gz')
+                            'peaks.nii.gz')
     in_mask = os.path.join(get_home(), 'tracking',
                            'seeding_mask.nii.gz')
     ret = script_runner.run('scil_compute_local_tracking.py', in_peaks,

--- a/scripts/tests/test_compute_local_tracking_dev.py
+++ b/scripts/tests/test_compute_local_tracking_dev.py
@@ -28,5 +28,5 @@ def test_execution_tracking_fodf(script_runner):
                             in_mask, in_mask, 'local_prob.trk', '--nt', '10',
                             '--compress', '0.1', '--sh_basis', 'descoteaux07',
                             '--min_length', '20', '--max_length', '200',
-                            '--save_seeds')
+                            '--save_seeds', '--rng_seed', '0')
     assert ret.success

--- a/scripts/tests/test_compute_local_tracking_dev.py
+++ b/scripts/tests/test_compute_local_tracking_dev.py
@@ -27,5 +27,6 @@ def test_execution_tracking_fodf(script_runner):
     ret = script_runner.run('scil_compute_local_tracking_dev.py', in_fodf,
                             in_mask, in_mask, 'local_prob.trk', '--nt', '10',
                             '--compress', '0.1', '--sh_basis', 'descoteaux07',
-                            '--min_length', '20', '--max_length', '200')
+                            '--min_length', '20', '--max_length', '200',
+                            '--save_seeds')
     assert ret.success


### PR DESCRIPTION
So far in our script, we coded everything in voxmm, and use the `voxmm_to_...` methods of the DatasetVolume. I needed the equivalent methods starting from vox space for dwi_ml.  So, base idea of this PR: to add methods in the DatasetVolume such as `vox_to_voxmm`, `is_vox_in_bound`, etc.

But, looking back at the code made me realise there were some incoherencies We called 'vox' space something that did not depend on the origin, which does not fit with dipy's usage. Clarified those methods names. 

Another change:  Other scripts such as scil_compute_seed_density_maps use seeds in vox space, center origin. Modified.


Note. Summary:  
- dipy uses voxmm, center. 
- scil_compute_local_tracking uses voxmm, corner
- scripts using seeds use vox, center.
- dwi_ml uses vox, corner (because torch's trilinear interpolation method uses vox space).
Could be dangerous to get mixed up. But so far, doc is added, and  self.space, self.origin variables have been added for clarity.
