### PR TITLE
Added a 'must_pass_mask'

### DIFF
--- a/scilpy/tractanalysis/scoring.py
+++ b/scilpy/tractanalysis/scoring.py
@@ -442,7 +442,7 @@ def extract_vb_vs(
         wpc_ids.extend(out_of_mask_ids)
         vs_ids = np.setdiff1d(vs_ids, wpc_ids)
 
-    # Remove streamlines no passing through must_pass_mask
+    # Remove streamlines not passing through must_pass_mask
     if len(vs_ids) > 0 and must_pass_mask is not None:
         tmp_sft = sft[vs_ids]
         _, in_mask_ids_from_vs = filter_grid_roi(

--- a/scripts/scil_score_tractogram.py
+++ b/scripts/scil_score_tractogram.py
@@ -125,7 +125,7 @@ from scilpy.tractanalysis.scoring import (compute_masks,
                                           extract_false_connections,
                                           get_binary_maps,
                                           compute_endpoint_masks,
-                                          extract_vb_vs,
+                                          extract_vb_vs_one_bundle,
                                           compute_f1_overlap_overreach)
 from scilpy.utils.filenames import split_name_with_nii
 
@@ -479,7 +479,7 @@ def compute_vb_vs(
 
         # Extract true connection
         vs_ids, wpc_ids, bundle_stats = \
-            extract_vb_vs(
+            extract_vb_vs_one_bundle(
                 sft[all_ids], head_filename, tail_filename, lengths[i],
                 angles[i], orientation_lengths[i], abs_orientation_lengths[i],
                 inv_all_masks[i], any_masks[i], args.dilate_endpoints)

--- a/scripts/tests/test_score_tractogram.py
+++ b/scripts/tests/test_score_tractogram.py
@@ -24,6 +24,8 @@ def test_score_bundles(script_runner):
         "example_bundle": {
             "angle": 300,
             "length": [30, 190],
+            "any_mask": os.path.join(get_home(), 'tracking',
+                                     'seeding_mask.nii.gz'),
             "gt_mask": os.path.join(get_home(), 'tracking',
                                     'seeding_mask.nii.gz'),
             "endpoints": os.path.join(get_home(), 'tracking',
@@ -36,5 +38,5 @@ def test_score_bundles(script_runner):
     ret = script_runner.run('scil_score_tractogram.py',
                             in_tractogram, "config_file.json",
                             'scoring_results/', '--no_empty',
-                            '--use_gt_masks_as_limits_masks')
+                            '--use_gt_masks_as_all_masks')
     assert ret.success


### PR DESCRIPTION
I was not able to differentiate to of my bundles with all the criteria already present. I added a 'must_pass_mask' (I am totally open to another name!).

So far we have
- endpoint mask or head + tail: where the streamlines must start and end
- gt_mask: the mask that will be used to compute the statistics (Overlap, Overreach)
- limits_mask: all streamlines must entirely stay inside that mask.

This adds:
- must_pass_mask: streamlines must pass through that region to be included in the bundle.


(Careful if you accept Antoine's PR before mine, I'll check if it needs refactoring)

@AntoineTheb 