### PR TITLE
[BF] Fix bug in scil_concatenate_dwi.py when supplying more than 2 images

### DIFF
--- a/scripts/scil_concatenate_dwi.py
+++ b/scripts/scil_concatenate_dwi.py
@@ -83,6 +83,7 @@ def main():
         curr_size = curr_dwi.shape[-1]
         all_dwi[..., last_count:last_count+curr_size] = \
             curr_dwi.get_fdata()
+        last_count += curr_size
 
     np.savetxt(args.out_bval, all_bvals, '%d')
     np.savetxt(args.out_bvec, all_bvecs.T, '%0.15f')


### PR DESCRIPTION
When concatenating more than 2 DWI volumes, the same indices are reused for each volume, resulting in the concatenation of the first and last supplied volumes with a lot of 0s in the remaining dimensions. This solves the issue.