### PR TITLE
Add arguments for RGB color ODF and RGB background color

### DIFF
--- a/scilpy/viz/scene_utils.py
+++ b/scilpy/viz/scene_utils.py
@@ -413,7 +413,7 @@ def create_tube_with_radii(positions, radii, error, error_coloring=False,
     return actor
 
 
-def create_scene(actors, orientation, slice_index, volume_shape):
+def create_scene(actors, orientation, slice_index, volume_shape, bg_color):
     """
     Create a 3D scene containing actors fitting inside a grid. The camera is
     placed based on the orientation supplied by the user. The projection mode
@@ -439,6 +439,7 @@ def create_scene(actors, orientation, slice_index, volume_shape):
     camera = initialize_camera(orientation, slice_index, volume_shape)
 
     scene = window.Scene()
+    scene.background(bg_color)
     scene.projection('parallel')
     scene.set_camera(position=camera[CamParams.VIEW_POS],
                      focal_point=camera[CamParams.VIEW_CENTER],

--- a/scripts/scil_visualize_fodf.py
+++ b/scripts/scil_visualize_fodf.py
@@ -87,7 +87,7 @@ def _build_arg_parser():
                         'then a RGB colormap will be used. [%(default)s]')
 
     q.add_argument('--color_rgb', nargs=3, type=float, default=None,
-                   help='Uniform color for the ODF slicer given as GRB, '
+                   help='Uniform color for the ODF slicer given as RGB, '
                         'scaled between 0 and 1. [%(default)s]')
 
     p.add_argument('--scale', default=0.5, type=float,

--- a/scripts/scil_visualize_fodf.py
+++ b/scripts/scil_visualize_fodf.py
@@ -83,12 +83,12 @@ def _build_arg_parser():
     q = p.add_mutually_exclusive_group()
 
     q.add_argument('--colormap', default=None,
-                       help='Colormap for the ODF slicer. If None, '
-                            'then a RGB colormap will be used. [%(default)s]')
+                   help='Colormap for the ODF slicer. If None, '
+                        'then a RGB colormap will be used. [%(default)s]')
 
     q.add_argument('--color_rgb', nargs=3, type=float, default=None,
-                       help='Uniform color for the ODF slicer given as GRB, '
-                            'between 0 and 255. [%(default)s]')
+                   help='Uniform color for the ODF slicer given as GRB, '
+                        'between 0 and 255. [%(default)s]')
 
     p.add_argument('--scale', default=0.5, type=float,
                    help='Scaling factor for FODF. [%(default)s]')
@@ -241,9 +241,6 @@ def main():
     else:
         mask = None
 
-    print("TTTTTTTTTTOOO")
-    print(args.colormap or args.color_rgb)
-
     # Instantiate the ODF slicer actor
     odf_actor = create_odf_slicer(data['fodf'], args.axis_name,
                                   args.slice_index, mask, sph,
@@ -251,7 +248,7 @@ def main():
                                   args.sh_basis, full_basis,
                                   args.scale,
                                   not args.radial_scale_off,
-                                  not args.norm_off, 
+                                  not args.norm_off,
                                   args.colormap or args.color_rgb)
     actors.append(odf_actor)
 

--- a/scripts/scil_visualize_fodf.py
+++ b/scripts/scil_visualize_fodf.py
@@ -122,9 +122,9 @@ def _build_arg_parser():
                         '[%(default)s]')
 
     p.add_argument('--bg_color', nargs=3, type=float, default=(0, 0, 0),
-                   help='The color of the real background, behind everything. '
-                        'Must be RGB values scaled between 0 and 1. '
-                        '[%(default)s]')
+                   help='The color of the overall background, behind '
+                        'everything. Must be RGB values scaled between 0 and '
+                        '1. [%(default)s]')
 
     # Peaks input file options
     p.add_argument('--peaks',

--- a/scripts/scil_visualize_fodf.py
+++ b/scripts/scil_visualize_fodf.py
@@ -88,7 +88,7 @@ def _build_arg_parser():
 
     q.add_argument('--color_rgb', nargs=3, type=float, default=None,
                    help='Uniform color for the ODF slicer given as GRB, '
-                        'between 0 and 255. [%(default)s]')
+                        'scaled between 0 and 1. [%(default)s]')
 
     p.add_argument('--scale', default=0.5, type=float,
                    help='Scaling factor for FODF. [%(default)s]')
@@ -241,6 +241,9 @@ def main():
     else:
         mask = None
 
+    if args.color_rgb:
+        color_rgb = np.round(np.asarray(args.color_rgb) * 255)
+
     # Instantiate the ODF slicer actor
     odf_actor = create_odf_slicer(data['fodf'], args.axis_name,
                                   args.slice_index, mask, sph,
@@ -249,7 +252,7 @@ def main():
                                   args.scale,
                                   not args.radial_scale_off,
                                   not args.norm_off,
-                                  args.colormap or args.color_rgb)
+                                  args.colormap or color_rgb)
     actors.append(odf_actor)
 
     # Instantiate a texture slicer actor if a background image is supplied

--- a/scripts/scil_visualize_fodf.py
+++ b/scripts/scil_visualize_fodf.py
@@ -243,6 +243,8 @@ def main():
 
     if args.color_rgb:
         color_rgb = np.round(np.asarray(args.color_rgb) * 255)
+    else:
+        color_rgb = None
 
     # Instantiate the ODF slicer actor
     odf_actor = create_odf_slicer(data['fodf'], args.axis_name,
@@ -306,6 +308,7 @@ def main():
             args.axis_name,
             args.slice_index,
             data['transparency_mask'].shape,
+            args.bg_color,
         )
 
     render_scene(scene, args.win_dims, args.interactor,

--- a/scripts/scil_visualize_fodf.py
+++ b/scripts/scil_visualize_fodf.py
@@ -80,9 +80,15 @@ def _build_arg_parser():
                    help='Optional mask file. Only fODF inside '
                         'the mask are displayed.')
 
-    p.add_argument('--colormap', default=None,
-                   help='Colormap for the ODF slicer. If None, '
-                        'then a RGB colormap will be used. [%(default)s]')
+    q = p.add_mutually_exclusive_group()
+
+    q.add_argument('--colormap', default=None,
+                       help='Colormap for the ODF slicer. If None, '
+                            'then a RGB colormap will be used. [%(default)s]')
+
+    q.add_argument('--color_rgb', nargs=3, type=float, default=None,
+                       help='Uniform color for the ODF slicer given as GRB, '
+                            'between 0 and 255. [%(default)s]')
 
     p.add_argument('--scale', default=0.5, type=float,
                    help='Scaling factor for FODF. [%(default)s]')
@@ -115,13 +121,19 @@ def _build_arg_parser():
                    help='Interpolation mode for the background image. '
                         '[%(default)s]')
 
+    p.add_argument('--bg_color', nargs=3, type=float, default=(0, 0, 0),
+                   help='The color of the real background, behind everything. '
+                        'Must be RGB values scaled between 0 and 1. '
+                        '[%(default)s]')
+
     # Peaks input file options
     p.add_argument('--peaks',
                    help='Peaks image file.')
 
     p.add_argument('--peaks_color', nargs=3, type=float,
-                   help='Color used for peaks. If None, '
-                        'then a RGB colormap is used. [%(default)s]')
+                   help='Color used for peaks, as RGB values scaled between 0 '
+                        'and 1. If None, then a RGB colormap is used. '
+                        '[%(default)s]')
 
     p.add_argument('--peaks_width', default=1.0, type=float,
                    help='Width of peaks segments. [%(default)s]')
@@ -229,6 +241,9 @@ def main():
     else:
         mask = None
 
+    print("TTTTTTTTTTOOO")
+    print(args.colormap or args.color_rgb)
+
     # Instantiate the ODF slicer actor
     odf_actor = create_odf_slicer(data['fodf'], args.axis_name,
                                   args.slice_index, mask, sph,
@@ -236,7 +251,8 @@ def main():
                                   args.sh_basis, full_basis,
                                   args.scale,
                                   not args.radial_scale_off,
-                                  not args.norm_off, args.colormap)
+                                  not args.norm_off, 
+                                  args.colormap or args.color_rgb)
     actors.append(odf_actor)
 
     # Instantiate a texture slicer actor if a background image is supplied
@@ -273,7 +289,8 @@ def main():
     # Prepare and display the scene
     scene = create_scene(actors, args.axis_name,
                          args.slice_index,
-                         data['fodf'].shape[:3])
+                         data['fodf'].shape[:3],
+                         args.bg_color)
 
     mask_scene = None
     if 'transparency_mask' in data:


### PR DESCRIPTION
Small modifications to `scil_visualize_fodf.py` and `scene_utils.py` in order to be able to set a uniform color for the ODFs as RGB and to set also a uniform color for the overall background of the image, which is usually black by default.

Maybe @CHrlS98 and @jhlegarreta can test it quickly.