### PR TITLE
Change default interpolation for mask

### DIFF
--- a/scripts/scil_compute_local_tracking_dev.py
+++ b/scripts/scil_compute_local_tracking_dev.py
@@ -104,7 +104,7 @@ def _build_arg_parser():
                          choices=['nearest', 'trilinear'],
                          help="Spherical harmonic interpolation: "
                               "nearest-neighbor \nor trilinear. [%(default)s]")
-    track_g.add_argument('--mask_interp', default='trilinear',
+    track_g.add_argument('--mask_interp', default='nearest',
                          choices=['nearest', 'trilinear'],
                          help="Mask interpolation: nearest-neighbor or "
                               "trilinear. [%(default)s]")


### PR DESCRIPTION
As discussed in #624, change default interpolation for tracking mask in dev tracking script.

Closes #624 .