### PR TITLE
Gradient sampling ajustment

### DIFF
--- a/scilpy/gradientsampling/optimize_gradient_sampling.py
+++ b/scilpy/gradientsampling/optimize_gradient_sampling.py
@@ -49,7 +49,8 @@ def swap_sampling_eddy(points, shell_idx, verbose=1):
 
         # System energy matrix
         # TODO: test other energy functions such as electron repulsion
-        dist = squareform(pdist(shell_pts, 'Euclidean')) + 2 * np.eye(shell_pts.shape[0])
+        dist = squareform(pdist(shell_pts, 'Euclidean')) \
+            + 2 * np.eye(shell_pts.shape[0])
 
         it = 0
         converged = False
@@ -183,10 +184,9 @@ def correct_b0s_philips(points, shell_idx, verbose=1):
 
     new_points = points.copy()
 
-    non_b0_pts = points[np.where(shell_idx != -1)]
-
     # Assume non-collinearity of non-b0s bvecs (i.e. Caruyer sampler type)
-    new_points[np.where(shell_idx == -1)[0]] = non_b0_pts
+    new_points[np.where(shell_idx == -1)[0][1:]] \
+        = new_points[np.where(shell_idx == -1)[0][1:] - 1]
 
     logging.info('Done adapting b0s for Philips scanner.')
 
@@ -260,7 +260,8 @@ def compute_min_duty_cycle_bruteforce(points, shell_idx, bvals, ker_size=10,
             logging.debug('Iter {} / {}  : {}'.format(it, Niter, power_best))
 
         ordering_current = np.random.permutation(N_dir)
-        q_scheme_current[non_b0s_mask] = q_scheme[non_b0s_mask][ordering_current]
+        q_scheme_current[non_b0s_mask] \
+            = q_scheme[non_b0s_mask][ordering_current]
 
         power_current = compute_peak_power(q_scheme_current, ker_size=ker_size)
 

--- a/scripts/scil_generate_gradient_sampling.py
+++ b/scripts/scil_generate_gradient_sampling.py
@@ -5,8 +5,8 @@
 Generate multi-shell gradient sampling with various processing to accelerate
 acquisition and help artefact correction.
 
-Multi-shell gradient sampling is generated as in [1], the bvecs are then flipped
-to maximize spread for eddy current correction, b0s are interleaved
+Multi-shell gradient sampling is generated as in [1], the bvecs are then
+flipped to maximize spread for eddy current correction, b0s are interleaved
 at equal spacing and the non-b0 samples are finally shuffled
 to minimize the total diffusion gradient amplitude over a few TR.
 """
@@ -21,6 +21,7 @@ from scilpy.io.utils import (assert_outputs_exist,
 from scilpy.gradientsampling.gen_gradient_sampling import generate_gradient_sampling
 from scilpy.gradientsampling.optimize_gradient_sampling import (add_b0s,
                                                                 add_bvalue_b0,
+                                                                correct_b0s_philips,
                                                                 compute_bvalue_lin_b,
                                                                 compute_bvalue_lin_q,
                                                                 compute_min_duty_cycle_bruteforce,
@@ -72,6 +73,10 @@ def _build_arg_parser():
                    help='Add a b0 as last sample. [%(default)s]')
     p.add_argument('--b0_value',
                    type=float, default=0.0,
+                   help='b-value of the b0s. [%(default)s]')
+
+    p.add_argument('--b0_philips',
+                   action='store_true',
                    help='b-value of the b0s. [%(default)s]')
 
     bvals_group = p.add_mutually_exclusive_group(required=True)
@@ -138,6 +143,7 @@ def main():
     b0_every = args.b0_every
     b0_end = args.b0_end
     b0_value = args.b0_value
+    b0_philips = args.b0_philips
 
     # Only a b0 at the beginning
     if (b0_every > K) or (b0_every < 0):
@@ -180,6 +186,10 @@ def main():
     if duty:
         points, shell_idx = compute_min_duty_cycle_bruteforce(
             points, shell_idx, bvals)
+
+    # Correcting b0s bvecs for Philips
+    if b0_philips and np.sum(shell_idx == -1) > 1:
+        points, shell_idx = correct_b0s_philips(points, shell_idx)
 
     if fsl:
         save_gradient_sampling_fsl(points, shell_idx, bvals,

--- a/scripts/scil_generate_gradient_sampling.py
+++ b/scripts/scil_generate_gradient_sampling.py
@@ -74,10 +74,10 @@ def _build_arg_parser():
     p.add_argument('--b0_value',
                    type=float, default=0.0,
                    help='b-value of the b0s. [%(default)s]')
-
     p.add_argument('--b0_philips',
                    action='store_true',
-                   help='b-value of the b0s. [%(default)s]')
+                   help='Replace values of b0s bvecs by existing bvecs for '
+                        'Philips handling. [%(default)s]')
 
     bvals_group = p.add_mutually_exclusive_group(required=True)
     bvals_group.add_argument('--bvals',


### PR DESCRIPTION
Very small change in the `scil_generate_gradient_sampling.py` script, in order to get a gradient table readable by a Philips scanner. Indeed, Philips scanners require that the gtab have unique pairs of bvecs and bvals for each line. By default, the script outputs the same pair of bvecs [0, 0, 0] and bvals [0] for each bvals in the gtab. The added option simply copies the bvecs from the previous line for each bvals, except the first one.

To test this, simply run the script, for example `scil_generate_gradient_sampling.py 16 32 64 dwi --eddy --duty --b0_every 18 --bvals 500 1000 2000 --mrtrix --b0_philips`, and make sure that no b0 has the same bvecs.