### PR TITLE
Added OLO to reorder_connectivity

### DIFF
--- a/scilpy/connectivity/utils.py
+++ b/scilpy/connectivity/utils.py
@@ -1,20 +1,23 @@
 # -*- coding: utf-8 -*-
 
 
+from warnings import simplefilter
+
 import numpy as np
-from scipy.sparse import csr_matrix
-from scipy.sparse.csgraph import reverse_cuthill_mckee
+from scipy.cluster import hierarchy
+
+simplefilter("ignore", hierarchy.ClusterWarning)
 
 
-def compute_RCM(array, is_symmetric=True):
+def compute_OLO(array, is_symmetric=True):
     """
-    Reverse Cuthill–McKee algorithm permutes a sparse matrix that has a
-    symmetric sparsity pattern into a band matrix form with a small bandwidth.
+    Optimal Leaf Ordering permutes a weighted matrix that has a
+    symmetric sparsity pattern using hierarchical clustering.
 
     Parameters
     ----------
     array: ndarray (NxN)
-        Sparse connectivity matrix.
+        Connectivity matrix.
     is_symmetric: bool, optional
         Is the matrice symmetric. (if from scil_compute_connectivity.py, True)
 
@@ -25,13 +28,15 @@ def compute_RCM(array, is_symmetric=True):
     """
     if array.ndim != 2:
         raise ValueError('RCM can only be applied to 2D array.')
-    csr_arr = csr_matrix(array)
-    perm = reverse_cuthill_mckee(csr_arr, symmetric_mode=is_symmetric)
+
+    Z = hierarchy.ward(array)
+    perm = hierarchy.leaves_list(
+        hierarchy.optimal_leaf_ordering(Z, array))
 
     return perm
 
 
-def apply_RCM(array, perm):
+def apply_OLO(array, perm):
     """
     Apply the permutation from compute_RCM.
 

--- a/scilpy/connectivity/utils.py
+++ b/scilpy/connectivity/utils.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+
+
+import numpy as np
+from scipy.sparse import csr_matrix
+from scipy.sparse.csgraph import reverse_cuthill_mckee
+
+
+def compute_RCM(array, is_symmetric=True):
+    """
+    Reverse Cuthill–McKee algorithm permutes a sparse matrix that has a
+    symmetric sparsity pattern into a band matrix form with a small bandwidth.
+
+    Parameters
+    ----------
+    array: ndarray (NxN)
+        Sparse connectivity matrix.
+    is_symmetric: bool, optional
+        Is the matrice symmetric. (if from scil_compute_connectivity.py, True)
+
+    Returns
+    -------
+    perm: ndarray (N,)
+        Output permutations for rows and columns.
+    """
+    if array.ndim != 2:
+        raise ValueError('RCM can only be applied to 2D array.')
+    csr_arr = csr_matrix(array)
+    perm = reverse_cuthill_mckee(csr_arr, symmetric_mode=is_symmetric)
+
+    return perm
+
+
+def apply_RCM(array, perm):
+    """
+    Apply the permutation from compute_RCM.
+
+    Parameters
+    ----------
+    array: ndarray (NxN)
+        Sparse connectivity matrix.
+    perm: ndarray (N,)
+        Permutations for rows and columns to be applied.
+
+    Returns
+    -------
+    ndarray (N,N)
+        Reordered array.
+    """
+    if array.ndim != 2:
+        raise ValueError('RCM can only be applied to 2D array.')
+    return array[perm].T[perm]
+
+
+def parse_ordering(in_ordering_file, labels_list=None):
+    with open(in_ordering_file, 'r') as my_file:
+        lines = my_file.readlines()
+        ordering = [[int(val) for val in lines[0].split()],
+                    [int(val) for val in lines[1].split()]]
+    if labels_list:
+        labels_list = np.loadtxt(labels_list,
+                                 dtype=np.int16).tolist()
+        # If the reordering file refers to labels and not indices
+        real_ordering = [[], []]
+        real_ordering[0] = [labels_list.index(i) for i in ordering[0]]
+        real_ordering[1] = [labels_list.index(i) for i in ordering[1]]
+        return real_ordering
+
+    return ordering
+
+
+def apply_reordering(array, ordering):
+    """
+    Apply a non-symmetric array ordering that support non-square output.
+    The ordering can contain duplicated or discarded rows/columns.
+
+    Parameters
+    ----------
+    array: ndarray (NxN)
+        Sparse connectivity matrix.
+    ordering: list of lists
+        First elements of the list is the permutation to apply to the rows.
+        First elements of the list is the permutation to apply to the columns.
+
+    Returns
+    -------
+    tmp_array: ndarray (N,N)
+        Reordered array.
+    """
+    if array.ndim != 2:
+        raise ValueError('RCM can only be applied to 2D array.')
+    if not isinstance(ordering, list) or len(ordering) != 2:
+        raise ValueError('Ordering should be a list of lists.\n'
+                         '[[x1, x2,..., xn], [y1, y2,..., yn]]')
+    ind_1, ind_2 = ordering
+    if (np.array(ind_1) > array.shape[0]).any() \
+            or (ind_2 > np.array(array.shape[1])).any():
+        raise ValueError('Indices from configuration are larger than the'
+                         'matrix size, maybe you need a labels list?')
+    tmp_array = array[tuple(ind_1), :]
+    tmp_array = tmp_array[:, tuple(ind_2)]
+
+    return tmp_array

--- a/scripts/scil_reorder_connectivity.py
+++ b/scripts/scil_reorder_connectivity.py
@@ -15,7 +15,7 @@ one provided to the scil_decompose_connectivity.py
 To subsequently use scil_visualize_connectivity.py with a lookup table, you
 must use a label-based reording json and use --labels_list.
 
-You can also use the Reverse Cuthill–McKee (RCM) algorithm to transform a
+You can also use the Optimal Leaf Ordering(OLO) algorithm to transform a
 sparse matrix into an ordering that reduces the matrix bandwidth. The output
 file can then be re-used with --in_ordering. Only one input can be used with
 this option, we recommand an average streamline count or volume matrix.
@@ -26,7 +26,7 @@ import os
 
 import numpy as np
 
-from scilpy.connectivity.utils import (compute_RCM,
+from scilpy.connectivity.utils import (compute_OLO,
                                        parse_ordering,
                                        apply_reordering)
 from scilpy.io.utils import (add_overwrite_arg,
@@ -53,7 +53,7 @@ def _build_arg_parser():
     ord = p.add_mutually_exclusive_group(required=True)
     ord.add_argument('--in_ordering',
                      help='Txt file with the first row as x and second as y.')
-    ord.add_argument('--reverse_cuthill_mckee', metavar='OUT_FILE',
+    ord.add_argument('--optimal_leaf_ordering', metavar='OUT_FILE',
                      help='Output a text file with an ordering that aligns'
                           'structures along the diagonal.')
 
@@ -79,13 +79,14 @@ def main():
                         [args.labels_list, args.in_ordering])
     assert_output_dirs_exist_and_empty(parser, args, [], args.out_dir)
 
-    if args.reverse_cuthill_mckee is not None:
+    if args.optimal_leaf_ordering is not None:
         if len(args.in_matrices) > 1:
             parser.error('Only one input is supported with RCM.')
+        assert_outputs_exist(parser, args, args.optimal_leaf_ordering)
 
         matrix = load_matrix_in_any_format(args.in_matrices[0])
-        perm = compute_RCM(matrix).astype(np.uint16)
-        np.savetxt(args.reverse_cuthill_mckee, [perm.tolist(), perm.tolist()],
+        perm = compute_OLO(matrix).astype(np.uint16)
+        np.savetxt(args.optimal_leaf_ordering, [perm.tolist(), perm.tolist()],
                    fmt='%i')
     else:
         # Verify all the possible outputs to avoid overwriting files

--- a/scripts/tests/test_reorder_connectivity.py
+++ b/scripts/tests/test_reorder_connectivity.py
@@ -17,14 +17,14 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_compute_RCM(script_runner):
+def test_execution_compute_OLO(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
     in_sc = os.path.join(get_home(), 'connectivity',
                          'sc_norm.npy')
     in_labels_list = os.path.join(get_home(), 'connectivity',
                                   'labels_list.txt')
     ret = script_runner.run('scil_reorder_connectivity.py', in_sc,
-                            '--reverse_cuthill_mckee', 'RCM.txt',
+                            '--optimal_leaf_ordering', 'OLO.txt',
                             '--out_dir', os.path.expanduser(tmp_dir.name),
                             '--labels_list', in_labels_list, '-f')
     assert ret.success

--- a/scripts/tests/test_reorder_connectivity.py
+++ b/scripts/tests/test_reorder_connectivity.py
@@ -17,7 +17,20 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_connectivity(script_runner):
+def test_execution_compute_RCM(script_runner):
+    os.chdir(os.path.expanduser(tmp_dir.name))
+    in_sc = os.path.join(get_home(), 'connectivity',
+                         'sc_norm.npy')
+    in_labels_list = os.path.join(get_home(), 'connectivity',
+                                  'labels_list.txt')
+    ret = script_runner.run('scil_reorder_connectivity.py', in_sc,
+                            '--reverse_cuthill_mckee', 'RCM.txt',
+                            '--out_dir', os.path.expanduser(tmp_dir.name),
+                            '--labels_list', in_labels_list, '-f')
+    assert ret.success
+
+
+def test_execution_apply_ordering(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
     in_sc = os.path.join(get_home(), 'connectivity',
                          'sc_norm.npy')
@@ -25,7 +38,9 @@ def test_execution_connectivity(script_runner):
                           'reorder.txt')
     in_labels_list = os.path.join(get_home(), 'connectivity',
                                   'labels_list.txt')
-    ret = script_runner.run('scil_reorder_connectivity.py', in_sc, in_txt,
+    ret = script_runner.run('scil_reorder_connectivity.py', in_sc,
+                            '--in_ordering', in_txt,
                             '--out_suffix', '_sc_reo',
-                            '--labels_list', in_labels_list)
+                            '--out_dir', os.path.expanduser(tmp_dir.name),
+                            '--labels_list', in_labels_list, '-f')
     assert ret.success


### PR DESCRIPTION
Add a new automatic ordering method (to go from sparse matrix to dense along the diagonal). This works best on thresholded matrices.

The OLO has to be computed on a single matrix (--optimal_leaf_ordering) and then apply to all others (--in_ordering).
The previous behavior still works. --in_ordering is still a text file with two rows of integers to do the indexing in X and then Y (supports non-square output)

The behavior for the output filename convention changed a bit, before if you called the script with:
`scil_reorder_connectivity.py */*.npy --in_ordering config.txt --out_suffix _reo` 
it would create all the matrices with a suffix **in the current folder**, now they are saved with the suffix in **their original folder**. _To mimic the previous behavior:_
`scil_reorder_connectivity.py */*.npy --in_ordering config.txt --out_suffix _reo --out_dir ./` 

![image](https://user-images.githubusercontent.com/10820351/197220797-46c431ab-a239-4865-a311-34d90489a72e.png)
