### PR TITLE
Coloring connectomics

### DIFF
--- a/scilpy/io/image.py
+++ b/scilpy/io/image.py
@@ -6,6 +6,42 @@ import numpy as np
 import os
 
 
+def merge_labels_into_mask(atlas, filtering_args):
+    """
+    Merge labels into a mask.
+
+    Parameters
+    ----------
+    atlas: np.ndarray
+        Atlas with labels as a numpy array (uint16) to merge.
+
+    filtering_args: str
+        Filtering arguments from the command line.
+
+    Return
+    ------
+    mask: nibabel.nifti1.Nifti1Image
+        Mask obtained from the combination of multiple labels.
+    """
+    mask = np.zeros(atlas.shape, dtype=np.uint16)
+
+    if ' ' in filtering_args:
+        values = filtering_args.split(' ')
+        for filter_opt in values:
+            if ':' in filter_opt:
+                values = [int(x) for x in filter_opt.split(':')]
+                mask[(atlas >= int(min(values))) & (atlas <= int(max(values)))] = 1
+            else:
+                mask[atlas == int(filter_opt)] = 1
+    elif ':' in filtering_args:
+        values = [int(x) for x in filtering_args.split(':')]
+        mask[(atlas >= int(min(values))) & (atlas <= int(max(values)))] = 1
+    else:
+        mask[atlas == int(filtering_args)] = 1
+
+    return mask
+
+
 def assert_same_resolution(images):
     """
     Check the resolution of multiple images.

--- a/scilpy/utils/streamlines.py
+++ b/scilpy/utils/streamlines.py
@@ -9,7 +9,6 @@ from dipy.io.stateful_tractogram import StatefulTractogram, Space
 from dipy.io.utils import get_reference_info, is_header_compatible
 from dipy.tracking.streamline import transform_streamlines, set_number_of_points
 from dipy.tracking.streamlinespeed import compress_streamlines
-import matplotlib
 from nibabel.streamlines.array_sequence import ArraySequence
 import numpy as np
 from scipy.ndimage import map_coordinates
@@ -19,7 +18,7 @@ from sklearn.cluster import KMeans
 from scilpy.tracking.tools import smooth_line_gaussian, smooth_line_spline
 from scilpy.tractanalysis.features import get_streamlines_centroid
 
-from scilpy.tracking.tools import resample_streamlines_num_points
+from scilpy.viz.utils import get_colormap
 MIN_NB_POINTS = 10
 KEY_INDEX = np.concatenate((range(5), range(-1, -6, -1)))
 
@@ -191,7 +190,7 @@ def uniformize_bundle_sft_using_mask_barycenter(sft, mask, swap=False):
     barycenter = np.average(np.argwhere(mask), axis=0)
 
     for i in range(len(sft.streamlines)):
-        if (np.linalg.norm(sft.streamlines[i][0] - barycenter) > \
+        if (np.linalg.norm(sft.streamlines[i][0] - barycenter) >
                 np.linalg.norm(sft.streamlines[i][-1] - barycenter)) ^ bool(swap):
             sft.streamlines[i] = sft.streamlines[i][::-1]
             for key in sft.data_per_point[i]:
@@ -216,11 +215,12 @@ def get_color_streamlines_along_length(sft, colormap='jet'):
         streamlines
 
     """
-    cmap = matplotlib.cm.get_cmap(colormap)
+    cmap = get_colormap(colormap)
     color_dpp = copy.deepcopy(sft.streamlines)
 
     for i in range(len(sft.streamlines)):
-        color_dpp[i] = cmap(np.linspace(0, 1, len(sft.streamlines[i])))[:, 0:3] * 255
+        color_dpp[i] = cmap(np.linspace(0, 1, len(sft.streamlines[i])))[
+            :, 0:3] * 255
 
     return color_dpp._data
 

--- a/scilpy/utils/streamlines.py
+++ b/scilpy/utils/streamlines.py
@@ -9,6 +9,7 @@ from dipy.io.stateful_tractogram import StatefulTractogram, Space
 from dipy.io.utils import get_reference_info, is_header_compatible
 from dipy.tracking.streamline import transform_streamlines, set_number_of_points
 from dipy.tracking.streamlinespeed import compress_streamlines
+import matplotlib
 from nibabel.streamlines.array_sequence import ArraySequence
 import numpy as np
 from scipy.ndimage import map_coordinates
@@ -18,6 +19,7 @@ from sklearn.cluster import KMeans
 from scilpy.tracking.tools import smooth_line_gaussian, smooth_line_spline
 from scilpy.tractanalysis.features import get_streamlines_centroid
 
+from scilpy.tracking.tools import resample_streamlines_num_points
 MIN_NB_POINTS = 10
 KEY_INDEX = np.concatenate((range(5), range(-1, -6, -1)))
 
@@ -170,6 +172,57 @@ def uniformize_bundle_sft(sft, axis=None, ref_bundle=None, swap=False):
                             sft.data_per_point[key][i][::-1]
     sft.to_space(old_space)
     sft.to_origin(old_origin)
+
+
+def uniformize_bundle_sft_using_mask_barycenter(sft, mask, swap=False):
+    """Uniformize the streamlines in the given tractogram so head is closer to
+    to the barycenter.
+
+    Parameters
+    ----------
+    sft: StatefulTractogram
+         The tractogram that contains the list of streamlines to be uniformized
+    mask: np.ndarray
+        Mask to use as a reference for the barycenter.
+    swap: boolean, optional
+        Swap the orientation of streamlines
+    """
+
+    barycenter = np.average(np.argwhere(mask), axis=0)
+
+    for i in range(len(sft.streamlines)):
+        if (np.linalg.norm(sft.streamlines[i][0] - barycenter) > \
+                np.linalg.norm(sft.streamlines[i][-1] - barycenter)) ^ bool(swap):
+            sft.streamlines[i] = sft.streamlines[i][::-1]
+            for key in sft.data_per_point[i]:
+                sft.data_per_point[key][i] = \
+                    sft.data_per_point[key][i][::-1]
+
+
+def get_color_streamlines_along_length(sft, colormap='jet'):
+    """Color streamlines according to their length.
+
+    Parameters
+    ----------
+    sft: StatefulTractogram
+        The tractogram that contains the list of streamlines to be colored
+    colormap: str
+        The colormap to use.
+
+    Returns
+    -------
+    color: np.ndarray
+        An array of shape (nb_streamlines, 3) containing the RGB values of
+        streamlines
+
+    """
+    cmap = matplotlib.cm.get_cmap(colormap)
+    color_dpp = copy.deepcopy(sft.streamlines)
+
+    for i in range(len(sft.streamlines)):
+        color_dpp[i] = cmap(np.linspace(0, 1, len(sft.streamlines[i])))[:, 0:3] * 255
+
+    return color_dpp._data
 
 
 def perform_streamlines_operation(operation, streamlines, precision=None):

--- a/scilpy/viz/chord_chart.py
+++ b/scilpy/viz/chord_chart.py
@@ -7,10 +7,11 @@ max/min values, alpha for visualisation, etc.
 """
 
 import math
-import matplotlib
 from matplotlib.path import Path
 import matplotlib.patches as patches
 import numpy as np
+
+from scilpy.viz.utils import get_colormap
 
 
 def polar2xy(r, theta):
@@ -183,7 +184,8 @@ def selfChordArc(start=0, end=60, radius=1.0, chordwidth=0.7, ax=None,
 
 
 def chordDiagram(X, ax, colors=None, width=0.1, pad=2, chordwidth=0.7,
-                 angle_threshold=1, alpha=0.1, text_dist=1.1):
+                 angle_threshold=1, alpha=0.1, text_dist=1.1,
+                 colormap='plasma'):
     """Plot a chord diagram
     Parameters
     ----------
@@ -208,7 +210,7 @@ def chordDiagram(X, ax, colors=None, width=0.1, pad=2, chordwidth=0.7,
     ax.set_ylim(-text_dist, text_dist)
 
     if colors is None:
-        cmap = matplotlib.cm.get_cmap('plasma')
+        cmap = get_colormap(colormap)
         colors = [cmap(i)[0:3] for i in np.linspace(0, 1, len(x))]
 
     # find position for each start and end

--- a/scilpy/viz/scene_utils.py
+++ b/scilpy/viz/scene_utils.py
@@ -3,7 +3,6 @@
 from enum import Enum
 import numpy as np
 
-import matplotlib.pyplot as plt
 import vtk
 from dipy.reconst.shm import sh_to_sf_matrix
 from fury import window, actor
@@ -12,6 +11,7 @@ from PIL import Image
 
 from scilpy.io.utils import snapshot
 from scilpy.reconst.bingham import bingham_to_sf
+from scilpy.viz.utils import get_colormap
 
 
 class CamParams(Enum):
@@ -623,7 +623,7 @@ def create_image_from_scene(scene, size, mode=None, cmap_name=None):
     _arr = scene
     if cmap_name:
         # Apply the colormap
-        cmap = plt.get_cmap(cmap_name)
+        cmap = get_colormap(cmap_name)
         # data returned by cmap is normalized to the [0,1] range: scale to the
         # [0, 255] range and convert to uint8 for Pillow
         _arr = (cmap(_arr) * 255).astype("uint8")

--- a/scilpy/viz/utils.py
+++ b/scilpy/viz/utils.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+
+import matplotlib.pyplot as plt
+from matplotlib import colors
+
+
+def get_colormap(name):
+    """Get a matplotlib colormap from a name or a list of named colors.
+
+    Parameters
+    ----------
+    name : str
+        Name of the colormap or a list of named colors (separated by a -).
+
+    Returns
+    -------
+    matplotlib.colors.Colormap
+        The colormap
+    """
+
+    if '-' in name:
+        name_list = name.split('-')
+        colors_list = [colors.to_rgba(color)[0:3] for color in name_list]
+        cmap = colors.LinearSegmentedColormap.from_list('CustomCmap',
+                                                        colors_list)
+        return cmap
+
+    return plt.cm.get_cmap(name)

--- a/scripts/scil_assign_custom_color_to_tractogram.py
+++ b/scripts/scil_assign_custom_color_to_tractogram.py
@@ -37,7 +37,6 @@ import logging
 from dipy.io.streamline import save_tractogram
 import nibabel as nib
 import numpy as np
-import matplotlib.pyplot as plt
 from scipy.ndimage import map_coordinates
 
 from scilpy.io.streamlines import load_tractogram_with_reference
@@ -47,6 +46,7 @@ from scilpy.io.utils import (assert_inputs_exist,
                              add_reference_arg,
                              load_matrix_in_any_format)
 from scilpy.utils.streamlines import get_color_streamlines_along_length
+from scilpy.viz.utils import get_colormap
 
 COLORBAR_NB_VALUES = 255
 
@@ -90,7 +90,8 @@ def _build_arg_parser():
     g2 = p.add_argument_group(title='Coloring Options')
     g2.add_argument('--colormap', default='jet',
                     help='Select the colormap for colored trk (dps/dpp) '
-                    '[%(default)s].')
+                    '[%(default)s].\nUse two Matplotlib named color separeted '
+                    'by a - to create your own colormap.')
     g2.add_argument('--min_range', type=float,
                     help='Set the minimum value when using dps/dpp/anatomy.')
     g2.add_argument('--max_range', type=float,
@@ -183,7 +184,7 @@ def main():
                             'of the provided LUT.\nConsider using '
                             'scil_resample_streamlines.py')
 
-    cmap = plt.get_cmap(args.colormap)
+    cmap = get_colormap(args.colormap)
     if args.use_dps or args.use_dpp or args.load_dps or args.load_dpp:
         if args.use_dps:
             data = np.squeeze(sft.data_per_streamline[args.use_dps])
@@ -218,7 +219,6 @@ def main():
         color = get_color_streamlines_along_length(sft, args.colormap)
     else:
         parser.error('No coloring method specified.')
-
 
     if len(color) == len(sft):
         tmp = [np.tile([color[i][0], color[i][1], color[i][2]],

--- a/scripts/scil_assign_custom_color_to_tractogram.py
+++ b/scripts/scil_assign_custom_color_to_tractogram.py
@@ -46,6 +46,7 @@ from scilpy.io.utils import (assert_inputs_exist,
                              add_overwrite_arg,
                              add_reference_arg,
                              load_matrix_in_any_format)
+from scilpy.utils.streamlines import get_color_streamlines_along_length
 
 COLORBAR_NB_VALUES = 255
 
@@ -82,6 +83,9 @@ def _build_arg_parser():
     p1.add_argument('--from_anatomy', metavar='FILE',
                     help='Use the voxel data for coloring,\n'
                          'linear scaling from minmax.')
+    p1.add_argument('--along_profile', action='store_true',
+                    help='Color streamlines according to each point position'
+                         'along its length.\nMust be uniformized head/tail.')
 
     g2 = p.add_argument_group(title='Coloring Options')
     g2.add_argument('--colormap', default='jet',
@@ -210,8 +214,11 @@ def main():
                                  order=0)
         color = cmap(values)[:, 0:3] * 255
         sft.to_rasmm()
+    elif args.along_profile:
+        color = get_color_streamlines_along_length(sft, args.colormap)
     else:
         parser.error('No coloring method specified.')
+
 
     if len(color) == len(sft):
         tmp = [np.tile([color[i][0], color[i][1], color[i][2]],

--- a/scripts/scil_assign_custom_color_to_tractogram.py
+++ b/scripts/scil_assign_custom_color_to_tractogram.py
@@ -27,8 +27,13 @@ Example: Use --from_anatomy with a voxel labels map (values from 1-20) with a
 text file containing 20 p-values to map p-values to the bundle for
 visualisation.
 
+A custom colormap can be provided using --colormap. It should be a string
+containing a colormap name OR multiple Matplotlib named colors separated by -.
 The colormap used for mapping values to colors can be saved to a png/jpg image
 using the --out_colorbar option.
+
+The script can also be used to color streamlines according to their length
+using the --along_profile option. The streamlines must be uniformized.
 """
 
 import argparse

--- a/scripts/scil_compute_bundle_voxel_label_map.py
+++ b/scripts/scil_compute_bundle_voxel_label_map.py
@@ -36,6 +36,7 @@ from scilpy.tractanalysis.distance_to_centroid import min_dist_to_centroid
 from scipy.ndimage import map_coordinates
 from scipy.ndimage.filters import gaussian_filter
 from scilpy.utils.streamlines import uniformize_bundle_sft
+from scilpy.viz.utils import get_colormap
 
 
 def _build_arg_parser():
@@ -216,7 +217,7 @@ def main():
     final_streamlines = []
     final_label = []
     final_dist = []
-    for c, cluster in enumerate(clusters_map):
+    for _, cluster in enumerate(clusters_map):
         tmp_sft = StatefulTractogram.from_sft([cluster.centroid], concat_sft)
         uniformize_bundle_sft(tmp_sft, ref_bundle=sft_centroid)
         cluster_centroid = tmp_sft.streamlines[0] if args.new_labeling \
@@ -298,10 +299,7 @@ def main():
                 np.average(labels_val, weights=dist_vox))
             distance_map[tuple(ind)] = np.average(dist_vox)
 
-    nib.save(nib.Nifti1Image(labels_map.astype(np.uint16), sft_list[0].affine),
-             os.path.join(args.out_dir, 'labels_map.nii.gz'))
-    nib.save(nib.Nifti1Image(distance_map, sft_list[0].affine),
-             os.path.join(args.out_dir, 'distance_map.nii.gz'))
+        cmap = get_colormap(args.colormap)
 
     for i, sft in enumerate(sft_list):
         if len(sft_list) > 1:

--- a/scripts/scil_estimate_bundles_diameter.py
+++ b/scripts/scil_estimate_bundles_diameter.py
@@ -27,7 +27,6 @@ import os
 
 from dipy.io.utils import is_header_compatible
 from fury import window, actor
-import matplotlib.pyplot as plt
 import nibabel as nib
 import numpy as np
 from scipy.linalg import svd
@@ -43,6 +42,7 @@ from scilpy.io.utils import (add_overwrite_arg,
                              parser_color_type,
                              snapshot)
 from scilpy.viz.scene_utils import create_tube_with_radii
+from scilpy.viz.utils import get_colormap
 
 
 def _build_arg_parser():
@@ -283,7 +283,7 @@ def main():
                                                 wireframe=args.wireframe,
                                                 error_coloring=args.error_coloring)
             scene.add(tube_actor)
-            cmap = plt.get_cmap('jet')
+            cmap = get_colormap('jet')
             coloring = cmap(pts_labels / np.max(pts_labels))[:, 0:3]
             streamlines_actor = actor.streamtube(sft.streamlines,
                                                  linewidth=args.width,

--- a/scripts/scil_filter_tractogram.py
+++ b/scripts/scil_filter_tractogram.py
@@ -45,8 +45,9 @@ import nibabel as nib
 import numpy as np
 from scipy import ndimage
 
+from scilpy.io.image import (get_data_as_mask,
+                             merge_labels_into_mask)
 from scilpy.image.labels import get_data_as_labels
-from scilpy.io.image import get_data_as_mask
 from scilpy.io.streamlines import load_tractogram_with_reference
 from scilpy.io.utils import (add_json_args,
                              add_overwrite_arg,
@@ -154,7 +155,8 @@ def prepare_filtering_list(parser, args):
         for roi_opt in content:
             if "\"" in roi_opt:
                 tmp_opt = [i.strip() for i in roi_opt.strip().split("\"")]
-                roi_opt_list.append(tmp_opt[0].split() + [tmp_opt[1]] + tmp_opt[2].split())
+                roi_opt_list.append(
+                    tmp_opt[0].split() + [tmp_opt[1]] + tmp_opt[2].split())
             else:
                 roi_opt_list.append(roi_opt.strip().split())
 
@@ -227,21 +229,7 @@ def main():
                 mask = get_data_as_mask(img)
             else:
                 atlas = get_data_as_labels(img)
-                mask = np.zeros(atlas.shape, dtype=np.uint16)
-
-                if ' ' in filter_arg_2:
-                    values = filter_arg_2.split(' ')
-                    for filter_opt in values:
-                        if ':' in filter_opt:
-                            values = [int(x) for x in filter_opt.split(':')]
-                            mask[(atlas >= int(min(values))) & (atlas <= int(max(values)))] = 1
-                        else:
-                            mask[atlas == int(filter_opt)] = 1
-                elif ':' in filter_arg_2:
-                    values = [int(x) for x in filter_arg_2.split(':')]
-                    mask[(atlas >= int(min(values))) & (atlas <= int(max(values)))] = 1
-                else:
-                    mask[atlas == int(filter_arg_2)] = 1
+                mask = merge_labels_into_mask(atlas, filter_arg_2)
 
                 if args.extract_masks_atlas_roi:
                     atlas_roi_item = atlas_roi_item + 1

--- a/scripts/scil_screenshot_bundle.py
+++ b/scripts/scil_screenshot_bundle.py
@@ -21,7 +21,6 @@ from dipy.io.stateful_tractogram import Space, StatefulTractogram
 from dipy.io.streamline import load_tractogram
 from dipy.tracking.streamline import transform_streamlines
 from fury import actor
-import matplotlib.pyplot as plt
 import nibabel as nib
 from nilearn import plotting
 import numpy as np
@@ -34,6 +33,7 @@ from scilpy.io.utils import (add_overwrite_arg,
                              assert_outputs_exist)
 from scilpy.utils.image import register_image
 from scilpy.viz.screenshot import display_slices
+from scilpy.viz.utils import get_colormap
 
 
 def _build_arg_parser():
@@ -217,7 +217,7 @@ def main():
         sft.to_rasmm()
         colors = []
         normalized_data = reference_data / np.max(reference_data)
-        cmap = plt.get_cmap(args.reference_coloring)
+        cmap = get_colormap(args.reference_coloring)
         for points in streamlines_vox:
             values = map_coordinates(normalized_data, points.T,
                                      order=1, mode='nearest')

--- a/scripts/scil_uniformize_streamlines_endpoints.py
+++ b/scripts/scil_uniformize_streamlines_endpoints.py
@@ -63,6 +63,7 @@ def _build_arg_parser():
                              'automatically determined axis.')
     method.add_argument('--target_roi', nargs='+',
                         help='Provide a target ROI and the labels to use.\n'
+                             'Align heads to be closest to the mask barycenter.\n'
                              'If no labels are provided, all labels will be used.')
     p.add_argument('--swap', action='store_true',
                    help='Swap head <-> tail convention. '

--- a/scripts/scil_uniformize_streamlines_endpoints.py
+++ b/scripts/scil_uniformize_streamlines_endpoints.py
@@ -10,6 +10,10 @@ If the input bundle is poorly defined, it is possible heuristic will be wrong.
 
 The default is to flip each streamline so their first point's coordinate in the
 defined axis is smaller than their last point (--swap does the opposite).
+
+The --target option will use the barycenter of the target mask to define the
+axis. The target mask can be a binary mask or an atlas. If an atlas is
+used, labels are expected in the form of --target atlas.nii.gz 2 3 5:7.
 """
 
 import argparse
@@ -18,8 +22,14 @@ import logging
 from dipy.io.streamline import save_tractogram
 import nibabel as nib
 
+<<<<<<< HEAD
 from scilpy.image.labels import get_data_as_labels
 from scilpy.io.image import merge_labels_into_mask
+=======
+from scilpy.io.image import (merge_labels_into_mask,
+get_data_as_label,
+get_data_as_mask)
+>>>>>>> e0570904 (support mask)
 from scilpy.io.streamlines import load_tractogram_with_reference
 from scilpy.io.utils import (add_overwrite_arg,
                              add_reference_arg,

--- a/scripts/scil_uniformize_streamlines_endpoints.py
+++ b/scripts/scil_uniformize_streamlines_endpoints.py
@@ -22,14 +22,8 @@ import logging
 from dipy.io.streamline import save_tractogram
 import nibabel as nib
 
-<<<<<<< HEAD
 from scilpy.image.labels import get_data_as_labels
 from scilpy.io.image import merge_labels_into_mask
-=======
-from scilpy.io.image import (merge_labels_into_mask,
-get_data_as_label,
-get_data_as_mask)
->>>>>>> e0570904 (support mask)
 from scilpy.io.streamlines import load_tractogram_with_reference
 from scilpy.io.utils import (add_overwrite_arg,
                              add_reference_arg,

--- a/scripts/scil_visualize_connectivity.py
+++ b/scripts/scil_visualize_connectivity.py
@@ -32,7 +32,6 @@ import json
 import math
 import logging
 
-import matplotlib
 import matplotlib.pyplot as plt
 from matplotlib.font_manager import FontProperties
 import numpy as np
@@ -41,6 +40,7 @@ from scilpy.image.operations import EPSILON
 from scilpy.io.utils import (add_overwrite_arg, assert_inputs_exist,
                              assert_outputs_exist, load_matrix_in_any_format)
 from scilpy.viz.chord_chart import chordDiagram, polar2xy
+from scilpy.viz.utils import get_colormap
 
 
 def _build_arg_parser():
@@ -163,10 +163,11 @@ def main():
         min_value = args.legend_min_max[0]
         max_value = args.legend_min_max[1]
 
+    cmap = get_colormap(args.colormap)
     fig, ax = plt.subplots()
     im = ax.imshow(matrix.T,
                    interpolation='nearest',
-                   cmap=args.colormap, vmin=min_value, vmax=max_value)
+                   cmap=cmap, vmin=min_value, vmax=max_value)
 
     if args.write_values:
         if np.prod(matrix.shape) > 1000:
@@ -251,7 +252,7 @@ def main():
 
         _, _, patches = ax.hist(matrix_hist, bins=args.nb_bins)
         nbr_bins = len(patches)
-        color = plt.cm.get_cmap(args.colormap)(np.linspace(0, 1, nbr_bins))
+        color = get_colormap(args.colormap)(np.linspace(0, 1, nbr_bins))
         for i in range(0, nbr_bins):
             patches[i].set_facecolor(color[i])
 
@@ -300,7 +301,6 @@ def main():
         new_matrix = np.delete(new_matrix, empty_to_del, axis=0)
         new_matrix = np.delete(new_matrix, empty_to_del, axis=1)
 
-        cmap = matplotlib.cm.get_cmap(args.colormap)
         colors = [cmap(i)[0:3] for i in np.linspace(0, 1, len(new_matrix))]
         nodePos = chordDiagram(new_matrix, ax, colors=colors,
                                angle_threshold=args.angle_threshold,


### PR DESCRIPTION
Modifying existing scripts to facilitate Laurent's life with coloring bundles when doing connectomics-like approach.

The Uniformize endpoints scripts now accept ROIs (similar to the --drawn_roi X.nii.gz 1:5) to perform a head/tail flip based on the proximity to the ROI's barycenter (rather than an x/y/z method).

Then a new coloring option was added to color along the length using default OR custom colormap (declared as `--colormap red-orange-yellow-green-blue-pink`)

To be tested by Laurent first.

