### PR TITLE
[ENH] POC : Use mocking to get faster execution of tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ target/
 
 # VS Code
 .vscode/
+
+# Virtualenv
+venv/

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,7 @@ coloredlogs==10.0.*
 nilearn==0.6.*
 pytest==5.3.*
 pytest_console_scripts==0.2.*
+pytest-mock==3.10.*
 requests==2.23.*
 bctpy==0.5.*
 statsmodels==0.11.*

--- a/scilpy/io/fetcher.py
+++ b/scilpy/io/fetcher.py
@@ -68,7 +68,10 @@ def get_testing_files_dict():
              'bcc21835cf0bf7210bdc99ba5d8df44b'],
             'anatomical_filtering.zip':
             ['1Li8DdySnMnO9Gich4pilhXisjkjz1-Dy',
-             '6f0eff5154ff0973a3dc26db00e383ea']}
+             '6f0eff5154ff0973a3dc26db00e383ea'],
+            'fodf_filtering.zip':
+            ['1iyoX2ltLOoLer-v-49LHOzopHCFZ_Tv6',
+             'e79c4291af584fdb25814aa7b403a6ce']}
 
 
 def fetch_data(files_dict, keys=None):

--- a/scripts/tests/test_execute_angle_aware_bilateral_filtering.py
+++ b/scripts/tests/test_execute_angle_aware_bilateral_filtering.py
@@ -6,23 +6,26 @@ import numpy as np
 import os
 import pytest
 import tempfile
-import time
+
+from scilpy.io.fetcher import get_testing_files_dict, fetch_data, get_home
 
 
+# If they already exist, this only takes 5 seconds (check md5sum)
+fetch_data(get_testing_files_dict(), keys=['processing.zip'])
+data_path = os.path.join(get_home(), 'processing')
 tmp_dir = tempfile.TemporaryDirectory()
-cwd = os.getcwd()
 
 
 @pytest.fixture
 def mock_filtering(mocker, out_fodf):
     def _mock(*args, **kwargs):
         img = nib.load(out_fodf)
-        return img.get_fdata()
+        return img.get_fdata().astype(np.float32)
 
     script = 'scil_execute_angle_aware_bilateral_filtering'
     filtering_fn = "angle_aware_bilateral_filtering"
     return mocker.patch("scripts.{}.{}".format(script, filtering_fn),
-                        side_effect=_mock)
+                        side_effect=_mock, create=True)
 
 
 def test_help_option(script_runner):
@@ -31,13 +34,14 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-@pytest.mark.parametrize("out_fodf",
-                         [os.path.join(cwd, "test_fodf.nii.gz")])
-def test_asym_basis_output(script_runner, mock_filtering, out_fodf):
+@pytest.mark.parametrize("in_fodf,out_fodf",
+    [[os.path.join(data_path, 'fodf_descoteaux07_sub.nii.gz'),
+      os.path.join(data_path, 'fodf_descoteaux07_sub_full.nii.gz')]])
+def test_asym_basis_output(script_runner, mock_filtering, in_fodf, out_fodf):
     os.chdir(os.path.expanduser(tmp_dir.name))
 
     ret = script_runner.run('scil_execute_angle_aware_bilateral_filtering.py',
-                            os.path.join(cwd, 'in_fodf.nii.gz'),
+                            in_fodf,
                             'out_fodf1.nii.gz',
                             '--sphere', 'repulsion100',
                             '--sigma_angular', '1.0',
@@ -55,13 +59,16 @@ def test_asym_basis_output(script_runner, mock_filtering, out_fodf):
     assert np.allclose(ret_fodf.get_fdata(), test_fodf.get_fdata())
 
 
-@pytest.mark.parametrize("out_fodf",
-                         [os.path.join(cwd, "test_fodf.nii.gz")])
-def test_sym_basis_output(script_runner, mock_filtering, out_fodf):
+@pytest.mark.parametrize("in_fodf,out_fodf,sym_fodf",
+    [[os.path.join(data_path, "fodf_descoteaux07_sub.nii.gz"),
+      os.path.join(data_path, "fodf_descoteaux07_sub_full.nii.gz"),
+      os.path.join(data_path, "fodf_descoteaux07_sub_sym.nii.gz")]])
+def test_sym_basis_output(
+    script_runner, mock_filtering, in_fodf, out_fodf, sym_fodf):
     os.chdir(os.path.expanduser(tmp_dir.name))
 
     ret = script_runner.run('scil_execute_angle_aware_bilateral_filtering.py',
-                            os.path.join(cwd, 'in_fodf.nii.gz'),
+                            in_fodf,
                             'out_fodf2.nii.gz',
                             '--out_sym', 'out_sym.nii.gz',
                             '--sphere', 'repulsion100',
@@ -74,19 +81,20 @@ def test_sym_basis_output(script_runner, mock_filtering, out_fodf):
 
     assert ret.success
     mock_filtering.assert_called_once()
-    
-    ret_fodf = nib.load("out_sym.nii.gz")
-    test_fodf = nib.load(os.path.join(cwd, "test_fodf_sym.nii.gz"))
-    assert np.allclose(ret_fodf.get_fdata(), test_fodf.get_fdata())
+
+    ret_sym_fodf = nib.load("out_sym.nii.gz")
+    test_sym_fodf = nib.load(sym_fodf)
+    assert np.allclose(ret_sym_fodf.get_fdata(), test_sym_fodf.get_fdata())
 
 
-@pytest.mark.parametrize("out_fodf",
-                         [os.path.join(cwd, "test_fodf2.nii.gz")])
-def test_asym_input(script_runner, mock_filtering, out_fodf):
+@pytest.mark.parametrize("in_fodf,out_fodf",
+    [[os.path.join(data_path, "fodf_descoteaux07_sub_full.nii.gz"),
+      os.path.join(data_path, "fodf_descoteaux07_sub_twice.nii.gz")]])
+def test_asym_input(script_runner, mock_filtering, in_fodf, out_fodf):
     os.chdir(os.path.expanduser(tmp_dir.name))
 
     ret = script_runner.run('scil_execute_angle_aware_bilateral_filtering.py',
-                            os.path.join(cwd, 'test_fodf.nii.gz'),
+                            in_fodf,
                             'out_fodf3.nii.gz',
                             '--sphere', 'repulsion100',
                             '--sigma_angular', '1.0',

--- a/scripts/tests/test_execute_angle_aware_bilateral_filtering.py
+++ b/scripts/tests/test_execute_angle_aware_bilateral_filtering.py
@@ -11,8 +11,8 @@ from scilpy.io.fetcher import get_testing_files_dict, fetch_data, get_home
 
 
 # If they already exist, this only takes 5 seconds (check md5sum)
-fetch_data(get_testing_files_dict(), keys=['processing.zip'])
-data_path = os.path.join(get_home(), 'processing')
+fetch_data(get_testing_files_dict(), keys=['fodf_filtering.zip'])
+data_path = os.path.join(get_home(), 'fodf_filtering')
 tmp_dir = tempfile.TemporaryDirectory()
 
 

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,11 @@ opts = dict(name=NAME,
             ext_modules=get_extensions(),
             setup_requires=['cython', 'numpy'],
             install_requires=external_dependencies,
-            scripts=SCRIPTS,
+            entry_points={
+                'console_scripts': ["{}=scripts.{}:main".format(
+                    os.path.basename(s),
+                    os.path.basename(s).split(".")[0]) for s in SCRIPTS]
+            },
             data_files=[('data/LUT',
                          ["data/LUT/freesurfer_desikan_killiany.json",
                           "data/LUT/freesurfer_subcortical.json",


### PR DESCRIPTION
To decrease the length of scripts tests, mocking is used to skip code blocks or algorithm calls that take too long.

Here, the call to `scilpy.denoise.bilateral_filtering.angle_aware_bilateral_filtering` is mocked, so the actual filtering is never executed. The whole script executes up to the call to `angle_aware_bilateral_filtering`, where the created mock is activated and returns the expected filtered volume, upon which the end of the script executes. Thus, everything in the script around the specific function is still tested.

Here is the command to run the test : `pytest scripts/tests/test_execute_angle_aware_bilateral_filtering.py --script-launch-mode inprocess`

The argument `--script-launch-mode inprocess` is mandatory for mock to work with pytest-console-script, else a new process is started for the script execution and its python interpreter is not mocked.

[Here is the data required for the test](https://usherbrooke-my.sharepoint.com/:u:/g/personal/vala2004_usherbrooke_ca/EeFJ-Gc1OQ5LqFpqpF6R8k4BbRmto9F3P2Kn0HmSQrdSTw?e=2JVuL8). Unpack the archive in the directory where the command is run. The tests expect the images to be in the current working directory.

In addition, the setup.py script was updated. To make the mocking work, scripts must be installed as entry_points. It changes nothing on the user end, only that there is an additional init file in the scripts directory.