### PR TITLE
Fix rare division by 0 in f1

### DIFF
--- a/scilpy/tractanalysis/scoring.py
+++ b/scilpy/tractanalysis/scoring.py
@@ -60,6 +60,11 @@ def compute_f1_score(overlap, overreach):
 
     Ref: https://en.wikipedia.org/wiki/F1_score
     """
+    # In the case where overlap = 0 (found the bundle but entirely out of the
+    # mask; overreach = 100%), we avoid division by 0 and define f1 as 0.
+    if overlap == 0 and overreach == 1:
+        return 0.
+
     # Recall = True positive / (True positive + False negative)
     #        = |B inter A| / |A|
     #        = overlap


### PR DESCRIPTION
I came over a weird case, with a bundle found with 0% overlap, 100% overreach.

The f1 fails with a division by 0. In that case, by definition, the f1 score (Dice score) = how good you are, should be 0.

![image](https://user-images.githubusercontent.com/4967417/199775662-86bc5079-6ed2-416a-93bb-0ce28940555d.png)
