### PR TITLE
Creating module 'labels'

### DIFF
--- a/scilpy/image/labels.py
+++ b/scilpy/image/labels.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+import os
+
+import numpy as np
+
+
+def get_data_as_labels(in_img):
+    """
+    Get data as label (force type np.uint16), check data type before casting.
+
+    Parameters
+    ----------
+    in_img: nibabel.nifti1.Nifti1Image
+        Image.
+
+    Return
+    ------
+    data: numpy.ndarray
+        Data (dtype: np.uint16).
+    """
+    curr_type = in_img.get_data_dtype()
+
+    if np.issubdtype(curr_type, np.signedinteger) or \
+       np.issubdtype(curr_type, np.unsignedinteger):
+        return np.asanyarray(in_img.dataobj).astype(np.uint16)
+    else:
+        basename = os.path.basename(in_img.get_filename())
+        raise IOError('The image {} cannot be loaded as label because '
+                      'its format {} is not compatible with a label '
+                      'image'.format(basename, curr_type))

--- a/scilpy/image/labels.py
+++ b/scilpy/image/labels.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import logging
 import os
 
 import numpy as np
@@ -28,3 +29,101 @@ def get_data_as_labels(in_img):
         raise IOError('The image {} cannot be loaded as label because '
                       'its format {} is not compatible with a label '
                       'image'.format(basename, curr_type))
+
+
+def combine_labels(data_list, indices_per_input_volume, out_labels_choice,
+                   background_id=0, merge_groups=False):
+    """
+    - Output options: Only one of out_labels, unique or group_in_m may be
+      chosen.
+    - Merge_groups can only be used in group_in_m.
+
+    Parameters
+    ----------
+    data_list: list
+        List of np.ndarray. Data as labels.
+    indices_per_input_volume: list[np.ndarray]
+        List of np.ndarray containing the indices to use in each input volume.
+    out_labels_choice: tuple(str, any)
+        Tuple of a string expressing the choice of output option and the
+        associated necessary value. Choices are:
+        ('all_labels'): Keeps values from the input volumes, or with
+            merge_groups, used the volumes ordering.
+        ('out_label_ids', list): Out labels will be renamed as given from
+            the list.
+        ('unique'): Out labels will be renamed to range from 1 to
+            total_nb_labels (+ the background).
+        ('group_in_m'): Add (x * 10 000) to each volume labels, where x is the
+            input volume order number.
+    background_id: int
+        Background id, excluded from output. The value is also used as output
+        background value. Default : 0.
+    merge_groups: bool
+        If true, indices from indices_per_input_volume will be merged for each
+        volume, as a single label. Can only be used with 'all_labels' or
+        'out_label_ids'. Default: False.
+    """
+    assert out_labels_choice[0] in ['all_labels', 'out_labels_ids',
+                                    'unique', 'group_in_m']
+    if merge_groups and out_labels_choice[0] in ['unique', 'group_in_m']:
+        raise ValueError("Merge groups cannot be used together with "
+                         "'unique' in 'group_in_m options.")
+
+    nb_volumes = len(data_list)
+
+    filtered_ids_per_vol = []
+    total_nb_input_ids = 0
+    # Remove background labels
+    for id_list in indices_per_input_volume:
+        id_list = np.asarray(id_list)
+        new_ids = id_list[~np.in1d(id_list, background_id)]
+        filtered_ids_per_vol.append(new_ids)
+        total_nb_input_ids += len(new_ids)
+
+    # Prepare output ids.
+    if out_labels_choice[0] == 'out_labels_ids':
+        out_labels = out_labels_choice[1]
+        if merge_groups:
+            assert len(out_labels) == nb_volumes, \
+                "Expecting {} output labels.".format(nb_volumes)
+        else:
+            assert len(out_labels) == total_nb_input_ids
+    elif out_labels_choice[0] == 'unique':
+        stack = np.hstack(filtered_ids_per_vol)
+        ids = np.arange(len(stack) + 1)
+        out_labels = np.setdiff1d(ids, background_id)[:len(stack)]
+    elif out_labels_choice[0] == 'group_in_m':
+        m_list = []
+        for i in range(len(filtered_ids_per_vol)):
+            prefix = i * 10000
+            m_list.append(prefix + np.asarray(filtered_ids_per_vol[i]))
+        out_labels = np.hstack(m_list)
+    else:  # all_labels
+        if merge_groups:
+            out_labels = np.arange(nb_volumes) + 1
+        else:
+            out_labels = np.hstack(filtered_ids_per_vol)
+
+    if len(np.unique(out_labels)) != len(out_labels):
+        logging.warning("The same output label number will be used for "
+                        "multiple inputs!")
+
+    # Create the resulting volume
+    current_id = 0
+    resulting_labels = (np.ones_like(data_list[0], dtype=np.uint16)
+                        * background_id)
+    for i in range(nb_volumes):
+        # Loop on ids for this volume.
+        for this_id in filtered_ids_per_vol[i]:
+            mask = data_list[i] == this_id
+            if np.count_nonzero(mask) == 0:
+                logging.warning(
+                    "Label {} was not in the volume".format(this_id))
+
+            if merge_groups:
+                resulting_labels[mask] = out_labels[i]
+            else:
+                resulting_labels[mask] = out_labels[current_id]
+                current_id += 1
+
+    return resulting_labels

--- a/scilpy/image/labels.py
+++ b/scilpy/image/labels.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
+import inspect
 import logging
 import os
 
 import numpy as np
 from scipy.spatial.ckdtree import cKDTree
+
+import scilpy  # ToDo. Is this the only way?
 
 
 def get_data_as_labels(in_img):
@@ -32,6 +35,37 @@ def get_data_as_labels(in_img):
                       'image'.format(basename, curr_type))
 
 
+def get_lut_dir():
+    """
+    Return LUT directory in scilpy repository
+
+    Returns
+    -------
+    lut_dir: string
+        LUT path
+    """
+    # Get the valid LUT choices.
+    module_path = inspect.getfile(scilpy)
+
+    lut_dir = os.path.join(os.path.dirname(
+        os.path.dirname(module_path)) + "/data/LUT/")
+
+    return lut_dir
+
+
+def split_labels(labels_volume, label_indices):
+    split_data = []
+    for label in label_indices:
+        if int(label) != 0:
+            split_label = np.zeros(labels_volume.shape, dtype=np.uint16)
+            split_label[np.where(labels_volume == int(label))] = label
+            split_data.append(split_label)
+        else:
+            logging.info("Label {} not present in the image.".format(label))
+            split_data.append(None)
+    return split_data
+
+
 def remove_labels(labels_volume, indices, background):
     """
     Remove given labels from the volume.
@@ -56,7 +90,7 @@ def remove_labels(labels_volume, indices, background):
 def combine_labels(data_list, indices_per_input_volume, out_labels_choice,
                    background_id=0, merge_groups=False):
     """
-    
+
     Parameters
     ----------
     data_list: list

--- a/scilpy/image/labels.py
+++ b/scilpy/image/labels.py
@@ -6,8 +6,6 @@ import os
 import numpy as np
 from scipy.spatial.ckdtree import cKDTree
 
-import scilpy  # ToDo. Is this the only way?
-
 
 def get_data_as_labels(in_img):
     """
@@ -45,6 +43,7 @@ def get_lut_dir():
         LUT path
     """
     # Get the valid LUT choices.
+    import scilpy  # ToDo. Is this the only way?
     module_path = inspect.getfile(scilpy)
 
     lut_dir = os.path.join(os.path.dirname(
@@ -54,11 +53,28 @@ def get_lut_dir():
 
 
 def split_labels(labels_volume, label_indices):
+    """
+    For each label in list, return a separate volume containing only that
+    label.
+
+    Parameters
+    ----------
+    labels_volume: np.ndarray
+        A 3D volume.
+    label_indices: list or np.array
+        The list of labels to extract.
+
+    Returns
+    -------
+    split_data: list
+        One 3D volume per label.
+    """
     split_data = []
     for label in label_indices:
-        if int(label) != 0:
+        label_occurences = np.where(labels_volume == int(label))
+        if len(label_occurences) != 0:
             split_label = np.zeros(labels_volume.shape, dtype=np.uint16)
-            split_label[np.where(labels_volume == int(label))] = label
+            split_label[label_occurences] = label
             split_data.append(split_label)
         else:
             logging.info("Label {} not present in the image.".format(label))

--- a/scilpy/image/labels.py
+++ b/scilpy/image/labels.py
@@ -32,13 +32,31 @@ def get_data_as_labels(in_img):
                       'image'.format(basename, curr_type))
 
 
+def remove_labels(labels_volume, indices, background):
+    """
+    Remove given labels from the volume.
+
+    Parameters
+    ----------
+    labels_volume: np.ndarray
+        The volume (as labels).
+    indices: list
+        List of labels indices to remove.
+    background: int
+        Value used for removed labels
+    """
+    for index in np.unique(indices):
+        mask = labels_volume == index
+        labels_volume[mask] = background
+        if np.count_nonzero(mask) == 0:
+            logging.warning("Label {} was not in the volume".format(index))
+    return labels_volume
+
+
 def combine_labels(data_list, indices_per_input_volume, out_labels_choice,
                    background_id=0, merge_groups=False):
     """
-    - Output options: Only one of out_labels, unique or group_in_m may be
-      chosen.
-    - Merge_groups can only be used in group_in_m.
-
+    
     Parameters
     ----------
     data_list: list

--- a/scilpy/io/image.py
+++ b/scilpy/io/image.py
@@ -73,30 +73,3 @@ def get_data_as_mask(in_img, dtype=np.uint8):
                       'with a mask'.format(basename, curr_type))
 
     return data
-
-
-def get_data_as_label(in_img):
-    """
-    Get data as label (force type np.uint16), check data type before casting.
-
-    Parameters
-    ----------
-    in_img: nibabel.nifti1.Nifti1Image
-        Image.
-
-    Return
-    ------
-
-    data: numpy.ndarray
-        Data (dtype: np.uint16).
-    """
-
-    curr_type = in_img.get_data_dtype()
-    basename = os.path.basename(in_img.get_filename())
-    if np.issubdtype(curr_type, np.signedinteger) or \
-       np.issubdtype(curr_type, np.unsignedinteger):
-        return np.asanyarray(in_img.dataobj).astype(np.uint16)
-    else:
-        raise IOError('The image {} cannot be loaded as label because '
-                      'its format {} is not compatible with a label '
-                      'image'.format(basename, curr_type))

--- a/scripts/scil_analyse_lesions_load.py
+++ b/scripts/scil_analyse_lesions_load.py
@@ -19,8 +19,8 @@ import nibabel as nib
 import numpy as np
 import scipy.ndimage as ndi
 
-
-from scilpy.io.image import get_data_as_mask, get_data_as_label
+from scilpy.image.labels import get_data_as_labels
+from scilpy.io.image import get_data_as_mask
 from scilpy.io.streamlines import load_tractogram_with_reference
 from scilpy.io.utils import (add_overwrite_arg,
                              assert_inputs_exist,
@@ -101,7 +101,7 @@ def main():
         bundle_name, _ = split_name_with_nii(os.path.basename(
             args.bundle_labels_map))
         map_img = nib.load(args.bundle_labels_map)
-        map_data = get_data_as_label(map_img)
+        map_data = get_data_as_labels(map_img)
 
     is_single_label = args.bundle_labels_map is None
     voxel_sizes = lesion_img.header.get_zooms()[0:3]

--- a/scripts/scil_combine_labels.py
+++ b/scripts/scil_combine_labels.py
@@ -19,7 +19,7 @@ from dipy.io.utils import is_header_compatible
 import nibabel as nib
 import numpy as np
 
-from scilpy.io.image import get_data_as_label
+from scilpy.image.labels import get_data_as_labels
 from scilpy.io.utils import (add_overwrite_arg, assert_inputs_exist,
                              assert_outputs_exist)
 
@@ -101,7 +101,7 @@ def main():
     for i in range(len(image_files)):
         # Load images
         volume_nib = nib.load(image_files[i])
-        data = get_data_as_label(volume_nib)
+        data = get_data_as_labels(volume_nib)
         data_list.append(data)
         assert (is_header_compatible(first_img, image_files[i]))
 

--- a/scripts/scil_combine_labels.py
+++ b/scripts/scil_combine_labels.py
@@ -2,13 +2,16 @@
 # -*- coding: utf-8 -*-
 
 """
-    Script to combine labels from multiple volumes,
-        if there is overlap, it will overwrite them based on the input order.
+    Script to combine labels from multiple volumes.
+    If there is overlap, it will overwrite them based on the input order.
 
-    >>> scil_combine_labels.py out_labels.nii.gz  -v animal_labels.nii 20\\
-            DKT_labels.nii.gz 44 53  --out_labels_indices 20 44 53
-    >>> scil_combine_labels.py slf_labels.nii.gz  -v a2009s_aseg.nii.gz all\\
-            -v clean/s1__DKT.nii.gz 1028 2028
+    >>> scil_combine_labels.py out_labels.nii.gz
+            --volume_ids animal_labels.nii 20
+            --volume_ids DKT_labels.nii.gz 44 53
+            --out_labels_indices 20 44 53
+    >>> scil_combine_labels.py slf_labels.nii.gz
+            --volume_ids a2009s_aseg.nii.gz all
+            --volume_ids clean/s1__DKT.nii.gz 1028 2028
 """
 
 
@@ -19,7 +22,7 @@ from dipy.io.utils import is_header_compatible
 import nibabel as nib
 import numpy as np
 
-from scilpy.image.labels import get_data_as_labels
+from scilpy.image.labels import get_data_as_labels, combine_labels
 from scilpy.io.utils import (add_overwrite_arg, assert_inputs_exist,
                              assert_outputs_exist)
 
@@ -39,28 +42,29 @@ def _build_arg_parser():
     p.add_argument('output',
                    help='Combined labels volume output.')
 
-    p.add_argument('-v', '--volume_ids', nargs='+', default=[],
+    p.add_argument('--volume_ids', nargs='+', default=[],
                    action='append', required=True,
                    help='List of volumes directly followed by their labels:\n'
-                        '  -v atlasA  id1a id2a   -v  atlasB  id1b id2b ... \n'
+                        '  --volume_ids atlasA  id1a id2a \n'
+                        '  --volume_ids atlasB  id1b id2b ... \n'
                         '  "all" can be used instead of id numbers.')
 
     o_ids = p.add_mutually_exclusive_group()
     o_ids.add_argument('--out_labels_ids', type=int, nargs='+', default=[],
-                       help='Give a list of labels indices for output images.')
+                       help='List of labels indices for output images.')
     o_ids.add_argument('--unique', action='store_true',
-                       help='Output id with unique labels,'
-                            ' excluding first background value.')
+                       help='If set, output id with unique labels, excluding '
+                            'first background value.')
     o_ids.add_argument('--group_in_m', action='store_true',
-                       help='Add (x*1000000) to each volume labels,'
+                       help='Add (x * 10 000) to each volume labels,'
                             ' where x is the input volume order number.')
 
     p.add_argument('--background', type=int, default=0,
                    help='Background id, excluded from output [%(default)s],\n'
                         ' the value is used as output background value.')
     p.add_argument('--merge_groups', action='store_true',
-                   help='Each group for the -v option will be merge as a'
-                        'single labels.')
+                   help='Each group from the --volume_ids option will be '
+                        'merged as a single labels.')
     add_overwrite_arg(p)
     return p
 
@@ -70,7 +74,7 @@ def main():
     args = parser.parse_args()
 
     image_files = []
-    indices_per_volume = []
+    indices_per_input_volume = []
     # Separate argument per volume
     used_indices_all = False
     for v_args in args.volume_ids:
@@ -80,9 +84,9 @@ def main():
         image_files.append(v_args[0])
         if "all" in v_args:
             used_indices_all = True
-            indices_per_volume.append("all")
+            indices_per_input_volume.append("all")
         else:
-            indices_per_volume.append(np.asarray(v_args[1:], dtype=int))
+            indices_per_input_volume.append(np.asarray(v_args[1:], dtype=int))
 
     if used_indices_all and args.out_labels_ids:
         parser.error("'all' indices cannot be used with --out_labels_ids.")
@@ -105,68 +109,25 @@ def main():
         data_list.append(data)
         assert (is_header_compatible(first_img, image_files[i]))
 
-        if (isinstance(indices_per_volume[i], str)
-                and indices_per_volume[i] == "all"):
-            indices_per_volume[i] = np.unique(data)
+        if (isinstance(indices_per_input_volume[i], str)
+                and indices_per_input_volume[i] == "all"):
+            indices_per_input_volume[i] = np.unique(data)
 
-    filtered_ids_per_vol = []
-    # Remove background labels
-    for id_list in indices_per_volume:
-        id_list = np.asarray(id_list)
-        new_ids = id_list[~np.in1d(id_list, args.background)]
-        filtered_ids_per_vol.append(new_ids)
-
-    # Prepare output indices
     if args.out_labels_ids:
-        out_labels = args.out_labels_ids
-        if not args.merge_groups \
-                and len(out_labels) != len(np.hstack(indices_per_volume)):
-            parser.error("--out_labels_ids, requires the same amount"
-                         " of total given input indices.")
-        elif len(out_labels) != len(args.volume_ids):
-            parser.error("--out_labels_ids, requires the same amount"
-                         " of total given groups (to merge).")
+        out_choice = ('out_labels_ids', args.out_labels_ids)
     elif args.unique:
-        stack = np.hstack(filtered_ids_per_vol)
-        ids = np.arange(len(stack) + 1)
-        out_labels = np.setdiff1d(ids, args.background)[:len(stack)]
+        out_choice = ('unique',)
     elif args.group_in_m:
-        m_list = []
-        for i in range(len(filtered_ids_per_vol)):
-            prefix = i * 10000
-            m_list.append(prefix + np.asarray(filtered_ids_per_vol[i]))
-        out_labels = np.hstack(m_list)
+        out_choice = ('group_in_m',)
     else:
-        if args.merge_groups:
-            out_labels = np.arange(len(args.volume_ids))+1
-        else:
-            out_labels = np.hstack(filtered_ids_per_vol)
+        out_choice = ('all_labels',)
 
-    if len(np.unique(out_labels)) != len(out_labels):
-        logging.error("The same output label number was used "
-                      "for multiple inputs")
-
-    # Create the resulting volume
-    current_id = 0
-    resulting_labels = (np.ones_like(data_list[0], dtype=np.uint16)
-                        * args.background)
-    for i in range(len(image_files)):
-        # Add given labels for each volume
-        for index in filtered_ids_per_vol[i]:
-            if args.merge_groups:
-                for j, curr_volume_ids in enumerate(args.volume_ids):
-                    if str(index) in curr_volume_ids[1:]:
-                        where_at = j
-                mask = data_list[i] == index
-                resulting_labels[mask] = out_labels[where_at]
-            else:
-                mask = data_list[i] == index
-                resulting_labels[mask] = out_labels[current_id]
-                current_id += 1
-
-                if np.count_nonzero(mask) == 0:
-                    logging.warning(
-                        "Label {} was not in the volume".format(index))
+    # Combine labels
+    resulting_labels = combine_labels(data_list,
+                                      indices_per_input_volume,
+                                      out_choice,
+                                      background_id=args.background,
+                                      merge_groups=args.merge_groups)
 
     # Save final combined volume
     nib.save(nib.Nifti1Image(resulting_labels, first_img.affine,

--- a/scripts/scil_compute_bundle_mean_std_per_point.py
+++ b/scripts/scil_compute_bundle_mean_std_per_point.py
@@ -15,7 +15,8 @@ import os
 import nibabel as nib
 import numpy as np
 
-from scilpy.io.image import assert_same_resolution, get_data_as_label
+from scilpy.image.labels import get_data_as_labels
+from scilpy.io.image import assert_same_resolution
 from scilpy.io.streamlines import load_tractogram_with_reference
 from scilpy.io.utils import (add_json_args, add_reference_arg,
                              add_overwrite_arg,
@@ -78,7 +79,7 @@ def main():
     metrics = [nib.load(metric) for metric in args.in_metrics]
 
     labels_img = nib.load(args.in_labels)
-    labels = get_data_as_label(labels_img)
+    labels = get_data_as_labels(labels_img)
 
     if args.distance_weighting:
         distance_file = nib.load(args.distance_weighting)

--- a/scripts/scil_compute_bundle_volume_per_label.py
+++ b/scripts/scil_compute_bundle_volume_per_label.py
@@ -15,7 +15,7 @@ import json
 import nibabel as nib
 import numpy as np
 
-from scilpy.io.image import get_data_as_label
+from scilpy.image.labels import get_data_as_labels
 from scilpy.io.utils import (add_json_args,
                              add_overwrite_arg,
                              assert_inputs_exist)
@@ -44,7 +44,7 @@ def main():
     assert_inputs_exist(parser, args.voxel_label_map)
 
     voxel_label_map_img = nib.load(args.voxel_label_map)
-    voxel_label_map_data = get_data_as_label(voxel_label_map_img)
+    voxel_label_map_data = get_data_as_labels(voxel_label_map_img)
     voxel_size = voxel_label_map_img.header['pixdim'][1:4]
 
     labels = np.unique(voxel_label_map_data.astype(np.uint8))[1:]

--- a/scripts/scil_compute_connectivity.py
+++ b/scripts/scil_compute_connectivity.py
@@ -53,7 +53,8 @@ import nibabel as nib
 import numpy as np
 import scipy.ndimage as ndi
 
-from scilpy.io.image import get_data_as_label, get_data_as_mask
+from scilpy.image.labels import get_data_as_labels
+from scilpy.io.image import get_data_as_mask
 from scilpy.io.streamlines import reconstruct_streamlines_from_hdf5
 from scilpy.io.utils import (add_overwrite_arg, add_processes_arg,
                              add_verbose_arg,
@@ -180,7 +181,7 @@ def _processing_wrapper(args):
 
                 voxel_sizes = lesion_img.header.get_zooms()[0:3]
                 lesion_img.set_filename('tmp.nii.gz')
-                lesion_atlas = get_data_as_label(lesion_img)
+                lesion_atlas = get_data_as_labels(lesion_img)
                 tmp_dict = compute_lesion_stats(
                     density.astype(bool), lesion_atlas,
                     voxel_sizes=voxel_sizes, single_label=True,
@@ -353,7 +354,7 @@ def main():
         logging.info('data_per_streamline weighting is activated.')
 
     img_labels = nib.load(args.in_labels)
-    data_labels = get_data_as_label(img_labels)
+    data_labels = get_data_as_labels(img_labels)
     if not args.force_labels_list:
         labels_list = np.unique(data_labels)[1:].tolist()
     else:

--- a/scripts/scil_compute_seed_by_labels.py
+++ b/scripts/scil_compute_seed_by_labels.py
@@ -13,7 +13,7 @@ import json
 import nibabel as nib
 import numpy as np
 
-from scilpy.io.image import get_data_as_label
+from scilpy.image.labels import get_data_as_labels
 from scilpy.io.utils import add_overwrite_arg, assert_inputs_exist
 
 
@@ -43,7 +43,7 @@ def main():
 
     # Load atlas image
     label_img = nib.load(args.in_labels)
-    label_img_data = get_data_as_label(label_img)
+    label_img_data = get_data_as_labels(label_img)
 
     # Load atlas lut
     with open(args.in_labels_lut) as f:

--- a/scripts/scil_decompose_connectivity.py
+++ b/scripts/scil_decompose_connectivity.py
@@ -44,7 +44,7 @@ import nibabel as nib
 from nibabel.streamlines.array_sequence import ArraySequence
 import numpy as np
 
-from scilpy.io.image import get_data_as_label
+from scilpy.image.labels import get_data_as_labels
 from scilpy.io.streamlines import load_tractogram_with_reference
 from scilpy.io.utils import (add_overwrite_arg,
                              add_verbose_arg,
@@ -258,7 +258,7 @@ def main():
     set_sft_logger_level('WARNING')
 
     img_labels = nib.load(args.in_labels)
-    data_labels = get_data_as_label(img_labels)
+    data_labels = get_data_as_labels(img_labels)
     real_labels = np.unique(data_labels)[1:]
     if args.out_labels_list:
         np.savetxt(args.out_labels_list, real_labels, fmt='%i')

--- a/scripts/scil_dilate_labels.py
+++ b/scripts/scil_dilate_labels.py
@@ -20,9 +20,8 @@ import logging
 
 import nibabel as nib
 import numpy as np
-from scipy.spatial.ckdtree import cKDTree
 
-from scilpy.image.labels import get_data_as_labels
+from scilpy.image.labels import get_data_as_labels, dilate_labels
 from scilpy.io.image import get_data_as_mask
 from scilpy.io.utils import (add_overwrite_arg, add_processes_arg,
                              assert_inputs_exist, assert_outputs_exist)
@@ -46,17 +45,18 @@ def _build_arg_parser():
                    help='Output filename of the dilated labels.')
 
     p.add_argument('--distance', type=float, default=2.0,
-                   help='Maximal distance to dilated (in mm) [%(default)s].')
+                   help='Maximal distance to dilate (in mm) [%(default)s].')
 
-    p.add_argument('--label_to_dilate', type=int, nargs='+', default=None,
-                   help='Label list to dilate, by default it dilate all that\n'
-                        ' are not in label_to_fill nor label_not_to_dilate.')
+    p.add_argument('--labels_to_dilate', type=int, nargs='+', default=None,
+                   help='Label list to dilate. By default it dilates all \n'
+                        'labels not in labels_to_fill nor in '
+                        'labels_not_to_dilate.')
 
-    p.add_argument('--label_to_fill', type=int, nargs='+', default=[0],
+    p.add_argument('--labels_to_fill', type=int, nargs='+', default=[0],
                    help='Background id / labels to be filled [%(default)s],\n'
                         ' the first one is given as output background value.')
 
-    p.add_argument('--label_not_to_dilate', type=int, nargs='+', default=[],
+    p.add_argument('--labels_not_to_dilate', type=int, nargs='+', default=[],
                    help='Label list not to dilate.')
 
     p.add_argument('--mask',
@@ -83,76 +83,18 @@ def main():
     volume_nib = nib.load(args.in_file)
     data = get_data_as_labels(volume_nib)
     vox_size = np.reshape(volume_nib.header.get_zooms(), (1, 3))
-    img_shape = data.shape
 
-    # Check if in both: label_to_fill & not_to_fill
-    fill_and_not = np.in1d(args.label_not_to_dilate, args.label_to_fill)
-    if np.any(fill_and_not):
-        logging.error("Error, both in not_to_dilate and to_fill: {}".format(
-                      np.asarray(args.label_not_to_dilate)[fill_and_not]))
-
-    # Create background mask
-    is_background_mask = np.zeros(img_shape, dtype=bool)
-    for i in args.label_to_fill:
-        is_background_mask = np.logical_or(is_background_mask, data == i)
-
-    # Create not_to_dilate mask (initialized to background)
-    not_to_dilate = np.copy(is_background_mask)
-    for i in args.label_not_to_dilate:
-
-        not_to_dilate = np.logical_or(not_to_dilate, data == i)
-
-    # Add mask
     if args.mask:
         mask_nib = nib.load(args.mask)
         mask_data = get_data_as_mask(mask_nib)
-        to_dilate_mask = np.logical_and(is_background_mask, mask_data)
     else:
-        to_dilate_mask = is_background_mask
+        mask_data = None
 
-    # Create label mask
-    is_label_mask = ~not_to_dilate
-
-    if args.label_to_dilate is not None:
-        # Check if in both: to_dilate & not_to_dilate
-        dil_and_not = np.in1d(args.label_to_dilate, args.label_not_to_dilate)
-        if np.any(dil_and_not):
-            logging.error("Error, both in dilate and Not to dilate: {}".format(
-                          np.asarray(args.label_to_dilate)[dil_and_not]))
-
-        # Check if in both: to_dilate & to_fill
-        dil_and_fill = np.in1d(args.label_to_dilate, args.label_to_fill)
-        if np.any(dil_and_fill):
-            logging.error("Error, both in dilate and to fill: {}".format(
-                          np.asarray(args.label_to_dilate)[dil_and_fill]))
-
-        # Create new label to dilate list
-        new_label_mask = np.zeros_like(data, dtype=bool)
-        for i in args.label_to_dilate:
-            new_label_mask = np.logical_or(new_label_mask, data == i)
-
-        # Combine both new_label_mask and not_to_dilate
-        is_label_mask = np.logical_and(new_label_mask, ~not_to_dilate)
-
-    # Get the list of indices
-    background_pos = np.argwhere(to_dilate_mask) * vox_size
-    label_pos = np.argwhere(is_label_mask) * vox_size
-    ckd_tree = cKDTree(label_pos)
-
-    # Compute the nearest labels for each voxel of the background
-    dist, indices = ckd_tree.query(
-        background_pos, k=1, distance_upper_bound=args.distance,
-        n_jobs=args.nbr_processes)
-
-    # Associate indices to the nearest label (in distance)
-    valid_nearest = np.squeeze(np.isfinite(dist))
-    id_background = np.flatnonzero(to_dilate_mask)[valid_nearest]
-    id_label = np.flatnonzero(is_label_mask)[indices[valid_nearest]]
-
-    # Change values of those background
-    data = data.flatten()
-    data[id_background.T] = data[id_label.T]
-    data = data.reshape(img_shape)
+    data = dilate_labels(data, vox_size, args.distance, args.nbr_processes,
+                         labels_to_dilate=args.labels_to_dilate,
+                         labels_not_to_dilate=args.labels_not_to_dilate,
+                         labels_to_fill=args.labels_to_fill,
+                         mask=mask_data)
 
     # Save image
     nib.save(nib.Nifti1Image(data.astype(np.uint16), volume_nib.affine,

--- a/scripts/scil_dilate_labels.py
+++ b/scripts/scil_dilate_labels.py
@@ -22,7 +22,8 @@ import nibabel as nib
 import numpy as np
 from scipy.spatial.ckdtree import cKDTree
 
-from scilpy.io.image import get_data_as_label, get_data_as_mask
+from scilpy.image.labels import get_data_as_labels
+from scilpy.io.image import get_data_as_mask
 from scilpy.io.utils import (add_overwrite_arg, add_processes_arg,
                              assert_inputs_exist, assert_outputs_exist)
 
@@ -80,7 +81,7 @@ def main():
 
     # load volume
     volume_nib = nib.load(args.in_file)
-    data = get_data_as_label(volume_nib)
+    data = get_data_as_labels(volume_nib)
     vox_size = np.reshape(volume_nib.header.get_zooms(), (1, 3))
     img_shape = data.shape
 

--- a/scripts/scil_filter_tractogram.py
+++ b/scripts/scil_filter_tractogram.py
@@ -45,7 +45,8 @@ import nibabel as nib
 import numpy as np
 from scipy import ndimage
 
-from scilpy.io.image import get_data_as_label, get_data_as_mask
+from scilpy.image.labels import get_data_as_labels
+from scilpy.io.image import get_data_as_mask
 from scilpy.io.streamlines import load_tractogram_with_reference
 from scilpy.io.utils import (add_json_args,
                              add_overwrite_arg,
@@ -225,7 +226,7 @@ def main():
             if filter_type == 'drawn_roi':
                 mask = get_data_as_mask(img)
             else:
-                atlas = get_data_as_label(img)
+                atlas = get_data_as_labels(img)
                 mask = np.zeros(atlas.shape, dtype=np.uint16)
 
                 if ' ' in filter_arg_2:

--- a/scripts/scil_filter_tractogram_anatomically.py
+++ b/scripts/scil_filter_tractogram_anatomically.py
@@ -55,12 +55,13 @@ import nibabel as nib
 import numpy as np
 from scipy.spatial.ckdtree import cKDTree
 
+from scilpy.image.labels import get_data_as_labels
 from scilpy.segment.streamlines import filter_grid_roi
 from scilpy.tractanalysis.features import remove_loops_and_sharp_turns
 from scilpy.tracking.tools import filter_streamlines_by_length
 from scilpy.utils.streamlines import (filter_tractogram_data, difference,
                                       perform_streamlines_operation)
-from scilpy.io.image import get_data_as_label, get_data_as_mask
+from scilpy.io.image import get_data_as_mask
 from scilpy.io.streamlines import load_tractogram_with_reference
 from scilpy.io.utils import (add_json_args,
                              add_overwrite_arg,
@@ -402,7 +403,7 @@ def main():
     if args.csf_bin:
         mask = get_data_as_mask(img_csf)
     else:
-        atlas = get_data_as_label(img_wmparc)
+        atlas = get_data_as_labels(img_wmparc)
         mask = binarize_labels(atlas, wm_labels["csf_labels"])
 
     # Filter tractogram
@@ -464,7 +465,7 @@ def main():
     ctx_fs_labels = wm_labels["ctx_lh_fs_labels"] + \
         wm_labels["ctx_rh_fs_labels"]
     vox_size = np.reshape(img_wmparc.header.get_zooms(), (1, 3))
-    atlas_wm = get_data_as_label(img_wmparc)
+    atlas_wm = get_data_as_labels(img_wmparc)
     atlas_shape = atlas_wm.shape
     wmparc_ctx = binarize_labels(atlas_wm, ctx_fs_labels)
     wmparc_nuclei = binarize_labels(atlas_wm, wm_labels["nuclei_fs_labels"])

--- a/scripts/scil_normalize_connectivity.py
+++ b/scripts/scil_normalize_connectivity.py
@@ -48,9 +48,8 @@ import itertools
 import nibabel as nib
 import numpy as np
 
-
+from scilpy.image.labels import get_data_as_labels
 from scilpy.image.operations import normalize_max, normalize_sum, base_10_log
-from scilpy.io.image import get_data_as_label
 from scilpy.io.utils import (add_overwrite_arg,
                              assert_inputs_exist,
                              assert_outputs_exist,
@@ -123,7 +122,7 @@ def main():
         assert_inputs_exist(parser, [atlas_filepath, labels_filepath])
 
         atlas_img = nib.load(atlas_filepath)
-        atlas_data = get_data_as_label(atlas_img)
+        atlas_data = get_data_as_labels(atlas_img)
 
         voxels_size = atlas_img.header.get_zooms()[:3]
         if voxels_size[0] != voxels_size[1] \

--- a/scripts/scil_remove_labels.py
+++ b/scripts/scil_remove_labels.py
@@ -14,7 +14,7 @@ import logging
 import nibabel as nib
 import numpy as np
 
-from scilpy.io.image import get_data_as_label
+from scilpy.image.labels import get_data_as_labels
 from scilpy.io.utils import (add_overwrite_arg, assert_inputs_exist,
                              assert_outputs_exist)
 EPILOG = """
@@ -53,7 +53,7 @@ def main():
 
     # Load volume
     label_img = nib.load(args.in_labels)
-    labels_volume = get_data_as_label(label_img)
+    labels_volume = get_data_as_labels(label_img)
 
     # Remove given labels from the volume
     for index in np.unique(args.indices):

--- a/scripts/scil_remove_labels.py
+++ b/scripts/scil_remove_labels.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 """
-    Script to remove specific labels from a atlas volumes.
+    Script to remove specific labels from an atlas volume.
 
     >>> scil_remove_labels.py DKT_labels.nii out_labels.nii.gz -i 5001 5002
 """
@@ -14,7 +14,7 @@ import logging
 import nibabel as nib
 import numpy as np
 
-from scilpy.image.labels import get_data_as_labels
+from scilpy.image.labels import get_data_as_labels, remove_labels
 from scilpy.io.utils import (add_overwrite_arg, assert_inputs_exist,
                              assert_outputs_exist)
 EPILOG = """
@@ -55,12 +55,7 @@ def main():
     label_img = nib.load(args.in_labels)
     labels_volume = get_data_as_labels(label_img)
 
-    # Remove given labels from the volume
-    for index in np.unique(args.indices):
-        mask = labels_volume == index
-        labels_volume[mask] = args.background
-        if np.count_nonzero(mask) == 0:
-            logging.warning("Label {} was not in the volume".format(index))
+    labels_volume = remove_labels(labels_volume, args.indices, args.background)
 
     # Save final volume
     nii = nib.Nifti1Image(labels_volume, label_img.affine, label_img.header)

--- a/scripts/scil_split_volume_by_ids.py
+++ b/scripts/scil_split_volume_by_ids.py
@@ -15,7 +15,7 @@ import re
 import nibabel as nib
 import numpy as np
 
-from scilpy.io.image import get_data_as_label
+from scilpy.image.labels import get_data_as_labels
 from scilpy.io.utils import (add_overwrite_arg,
                              assert_inputs_exist, assert_outputs_exist,
                              assert_output_dirs_exist_and_empty)
@@ -77,7 +77,7 @@ def main():
     assert_inputs_exist(parser, required)
 
     label_img = nib.load(args.in_labels)
-    label_img_data = get_data_as_label(label_img)
+    label_img_data = get_data_as_labels(label_img)
 
     if args.range:
         label_indices = [item for sublist in args.range for item in sublist]

--- a/scripts/scil_split_volume_by_ids.py
+++ b/scripts/scil_split_volume_by_ids.py
@@ -53,8 +53,9 @@ def main():
     label_img_data = get_data_as_labels(label_img)
 
     if args.range is not None:
+        # Ex: From 173 to 175 = range(173, 176).
         label_indices = np.concatenate(
-            [np.arange(r[0], r[1]) for r in args.range])
+            [np.arange(r[0], r[1] + 1) for r in args.range])
     else:
         label_indices = np.unique(label_img_data)
     label_names = [str(i) for i in label_indices]

--- a/scripts/scil_split_volume_by_labels.py
+++ b/scripts/scil_split_volume_by_labels.py
@@ -15,7 +15,6 @@ import json
 import os
 
 import nibabel as nib
-import numpy as np
 
 from scilpy.image.labels import get_data_as_labels, get_lut_dir, split_labels
 from scilpy.io.utils import (add_overwrite_arg,

--- a/scripts/scil_split_volume_by_labels.py
+++ b/scripts/scil_split_volume_by_labels.py
@@ -19,7 +19,7 @@ import nibabel as nib
 import numpy as np
 
 import scilpy
-from scilpy.io.image import get_data_as_label
+from scilpy.image.labels import get_data_as_labels
 from scilpy.io.utils import (add_overwrite_arg,
                              assert_inputs_exist, assert_outputs_exist,
                              assert_output_dirs_exist_and_empty)
@@ -79,7 +79,7 @@ def main():
     assert_inputs_exist(parser, required)
 
     label_img = nib.load(args.in_label)
-    label_img_data = get_data_as_label(label_img)
+    label_img_data = get_data_as_labels(label_img)
 
     if args.scilpy_lut:
         with open(os.path.join(get_lut_dir(), args.scilpy_lut + '.json')) as f:

--- a/scripts/scil_visualize_scatterplot.py
+++ b/scripts/scil_visualize_scatterplot.py
@@ -47,7 +47,8 @@ import matplotlib.pyplot as plt
 import nibabel as nib
 import numpy as np
 
-from scilpy.io.image import get_data_as_mask, get_data_as_label
+from scilpy.image.labels import get_data_as_labels
+from scilpy.io.image import get_data_as_mask
 from scilpy.io.utils import add_overwrite_arg, assert_inputs_exist
 
 
@@ -188,7 +189,7 @@ def main():
 
     if args.in_atlas:
         label_image = nib.load(args.in_atlas)
-        label_data = get_data_as_label(label_image)
+        label_data = get_data_as_labels(label_image)
 
         with open(args.atlas_lut) as f:
             label_dict = json.load(f)

--- a/scripts/tests/test_combine_labels.py
+++ b/scripts/tests/test_combine_labels.py
@@ -23,9 +23,9 @@ def test_execution_atlas(script_runner):
     in_brainstem = os.path.join(get_home(), 'atlas', 'brainstem.nii.gz')
     ret = script_runner.run('scil_combine_labels.py',
                             'atlas_freesurfer_v2_single_brainstem.nii.gz',
-                            '-v', in_atlas_1, '8', '47', '251', '252',
-                            '253', '254', '1022', '1024', '2022', '2024',
-                            '-v', in_brainstem, '16')
+                            '--volume_ids', in_atlas_1, '8', '47', '251',
+                            '252', '253', '254', '1022', '1024', '2022',
+                            '2024', '--volume_ids', in_brainstem, '16')
     assert ret.success
 
 
@@ -36,7 +36,8 @@ def test_execution_atlas_merge(script_runner):
     in_brainstem = os.path.join(get_home(), 'atlas', 'brainstem.nii.gz')
     ret = script_runner.run('scil_combine_labels.py',
                             'atlas_freesurfer_v2_merge_brainstem.nii.gz',
-                            '-v', in_atlas_1, '8', '47', '251', '252',
-                            '253', '254', '1022', '1024', '2022', '2024',
-                            '-v', in_brainstem, '16', '--merge_groups')
+                            '--volume_ids', in_atlas_1, '8', '47', '251',
+                            '252', '253', '254', '1022', '1024', '2022',
+                            '2024', '--volume_ids', in_brainstem, '16',
+                            '--merge_groups')
     assert ret.success

--- a/scripts/tests/test_split_volume_by_ids.py
+++ b/scripts/tests/test_split_volume_by_ids.py
@@ -21,5 +21,5 @@ def test_execution_atlas(script_runner):
     in_atlas = os.path.join(get_home(), 'atlas',
                             'atlas_freesurfer_v2.nii.gz')
     ret = script_runner.run('scil_split_volume_by_ids.py', in_atlas,
-                            '--out_prefix', 'brainstem', '-r', '173-175')
+                            '--out_prefix', 'brainstem', '-r', '173', '175')
     assert ret.success


### PR DESCRIPTION
One step into the cleaning of the modules. It seems an easy one to start with, not too much chances to get mixed up with something else.

I placed it in `scilpy.image.labels.py`.

I cleaned the 5 labels scripts that I found. Their main now only do imports and saving.
- scil_combine_labels
- scil_dilate_labels
- scil_remove_labels
- scil_split_volume_by_ids
- scil_split_volume_by_labels

I moved `scil.io.image.get_data_as_label` into scil.image.labels, explaining the other modifications. It could also be kept in io as it does fetch the data from the img.