### PR TITLE
Fix total count

### DIFF
--- a/scilpy/tractanalysis/scoring.py
+++ b/scilpy/tractanalysis/scoring.py
@@ -218,7 +218,7 @@ def compute_tractometry(
     ic_count = np.sum(ic_per_ib_bundle)
 
     nc_count = len(nc_sft) if nc_sft is not None else 0
-    total_count = vb_count + wpc_count + ic_count + nc_count
+    total_count = vs_count + wpc_count + ic_count + nc_count
 
     nb_bundles = len(bundles_names)
 


### PR DESCRIPTION
Again a mini-fix, sorry.

vb_count (ex; 25 valid bundles) was used rather than vs_count (number of streamlines).