### PR TITLE
[BF] BG color as optional function argument

### DIFF
--- a/scilpy/viz/scene_utils.py
+++ b/scilpy/viz/scene_utils.py
@@ -413,7 +413,8 @@ def create_tube_with_radii(positions, radii, error, error_coloring=False,
     return actor
 
 
-def create_scene(actors, orientation, slice_index, volume_shape, bg_color):
+def create_scene(actors, orientation, slice_index,
+                 volume_shape, bg_color=(0, 0, 0)):
     """
     Create a 3D scene containing actors fitting inside a grid. The camera is
     placed based on the orientation supplied by the user. The projection mode
@@ -429,6 +430,8 @@ def create_scene(actors, orientation, slice_index, volume_shape, bg_color):
         Index of the slice to visualize along the chosen orientation.
     volume_shape : tuple
         Shape of the sliced volume.
+    bg_color: tuple, optional
+        Background color expressed as RGB triplet in the range [0, 1].
 
     Returns
     -------


### PR DESCRIPTION
`scil_screenshot_volume_mosaic_overlap.py` does not work anymore because of the `bg_color` arg added to `scene_utils.create_scene`. Make optional so that everything works again.

@jhlegarreta @karanphil 