### PR TITLE
Fix the unique len issue

### DIFF
--- a/scilpy/image/labels.py
+++ b/scilpy/image/labels.py
@@ -4,7 +4,7 @@ import logging
 import os
 
 import numpy as np
-from scipy.spatial.ckdtree import cKDTree
+from scipy.spatial import cKDTree
 
 
 def get_data_as_labels(in_img):
@@ -70,7 +70,7 @@ def split_labels(labels_volume, label_indices):
         One 3D volume per label.
     """
     split_data = []
-    for label in np.unique(label_indices):
+    for label in label_indices:
         label_occurences = np.where(labels_volume == int(label))
         if len(label_occurences) != 0:
             split_label = np.zeros(labels_volume.shape, dtype=np.uint16)
@@ -282,7 +282,7 @@ def dilate_labels(data, vox_size, distance, nbr_processes,
     # Compute the nearest labels for each voxel of the background
     dist, indices = ckd_tree.query(
         background_pos, k=1, distance_upper_bound=distance,
-        n_jobs=nbr_processes)
+        workers=nbr_processes)
 
     # Associate indices to the nearest label (in distance)
     valid_nearest = np.squeeze(np.isfinite(dist))

--- a/scilpy/image/labels.py
+++ b/scilpy/image/labels.py
@@ -4,7 +4,7 @@ import logging
 import os
 
 import numpy as np
-from scipy.spatial import cKDTree
+from scipy.spatial.ckdtree import cKDTree
 
 
 def get_data_as_labels(in_img):
@@ -282,7 +282,7 @@ def dilate_labels(data, vox_size, distance, nbr_processes,
     # Compute the nearest labels for each voxel of the background
     dist, indices = ckd_tree.query(
         background_pos, k=1, distance_upper_bound=distance,
-        workers=nbr_processes)
+        n_jobs=nbr_processes)
 
     # Associate indices to the nearest label (in distance)
     valid_nearest = np.squeeze(np.isfinite(dist))

--- a/scilpy/image/tests/test_labels.py
+++ b/scilpy/image/tests/test_labels.py
@@ -152,6 +152,6 @@ def test_split_labels():
     in_labels = deepcopy(ref_in_labels)
     out_labels = split_labels(in_labels, [6, 7, 7])
 
-    assert len(out_labels) == 2
+    assert len(out_labels) == 3
     assert_equal(np.unique(out_labels[0]), [0, 6])
     assert_equal(np.unique(out_labels[1]), [0])

--- a/scilpy/version.py
+++ b/scilpy/version.py
@@ -5,7 +5,7 @@ import glob
 # Format expected by setup.py and doc/source/conf.py: string of form "X.Y.Z"
 _version_major = 1
 _version_minor = 4
-_version_micro = 1
+_version_micro = 2
 _version_extra = ''
 
 # Construct full version string from these.

--- a/scripts/scil_split_volume_by_labels.py
+++ b/scripts/scil_split_volume_by_labels.py
@@ -15,7 +15,6 @@ import json
 import os
 
 import nibabel as nib
-import numpy as np
 
 from scilpy.image.labels import get_data_as_labels, get_lut_dir, split_labels
 from scilpy.io.utils import (add_overwrite_arg,

--- a/scripts/scil_split_volume_by_labels.py
+++ b/scripts/scil_split_volume_by_labels.py
@@ -15,6 +15,7 @@ import json
 import os
 
 import nibabel as nib
+import numpy as np
 
 from scilpy.image.labels import get_data_as_labels, get_lut_dir, split_labels
 from scilpy.io.utils import (add_overwrite_arg,
@@ -62,14 +63,12 @@ def main():
     if args.scilpy_lut:
         with open(os.path.join(get_lut_dir(), args.scilpy_lut + '.json')) as f:
             label_dict = json.load(f)
-        (label_indices, label_names) = zip(*label_dict.items())
     else:
         with open(args.custom_lut) as f:
             label_dict = json.load(f)
-        (label_indices, label_names) = zip(*label_dict.items())
 
     output_filenames = []
-    for label, name in zip(label_indices, label_names):
+    for label, name in label_dict.items():
         if int(label) != 0:
             if args.out_prefix:
                 output_filenames.append(os.path.join(
@@ -83,6 +82,9 @@ def main():
     assert_outputs_exist(parser, args, output_filenames)
 
     # Extract the voxels that match the label and save them to a file.
+    label_indices = list(label_dict.keys())
+    indexes = np.unique(label_indices, return_index=True)[1]
+    label_indices = [label_indices[index] for index in sorted(indexes)]
     split_data = split_labels(label_img_data, label_indices)
 
     for i in range(len(label_indices)):

--- a/scripts/scil_split_volume_by_labels.py
+++ b/scripts/scil_split_volume_by_labels.py
@@ -83,8 +83,6 @@ def main():
 
     # Extract the voxels that match the label and save them to a file.
     label_indices = list(label_dict.keys())
-    indexes = np.unique(label_indices, return_index=True)[1]
-    label_indices = [label_indices[index] for index in sorted(indexes)]
     split_data = split_labels(label_img_data, label_indices)
 
     for i in range(len(label_indices)):


### PR DESCRIPTION
np.unique() was sorting the results and changing the length which was messing up the naming convention.

I discovered it while trying Tractoflow ABS and it was not working at ALL (the mask where all messed up).

I simply removed the np.unique() and now it is the job of the user to have a decent LUT