### PR TITLE
Fix multiprocess in dev tracking

### DIFF
--- a/scilpy/tracking/seed.py
+++ b/scilpy/tracking/seed.py
@@ -110,7 +110,7 @@ class SeedGenerator(object):
 
         Return
         ------
-        seed_pos: List[tuple]
+        seed_pos: List[List]
             Positions of next seeds expressed seed_generator's space and
             origin.
         """

--- a/scilpy/tracking/tracker.py
+++ b/scilpy/tracking/tracker.py
@@ -4,13 +4,12 @@ import logging
 import multiprocessing
 import os
 import sys
-import traceback
+from tempfile import TemporaryDirectory
 from time import perf_counter
+import traceback
 from typing import Union
 
-from nibabel.tmpdirs import InTemporaryDirectory
 import numpy as np
-
 from dipy.data import get_sphere
 from dipy.io.stateful_tractogram import Space
 from dipy.reconst.shm import sh_to_sf_matrix
@@ -133,7 +132,7 @@ class Tracker(object):
         else:
             # Each process will use get_streamlines_at_seeds
             chunk_ids = np.arange(self.nbr_processes)
-            with InTemporaryDirectory() as tmpdir:
+            with TemporaryDirectory() as tmpdir:
 
                 pool = self._prepare_multiprocessing_pool(tmpdir)
 

--- a/scilpy/tracking/tracker.py
+++ b/scilpy/tracking/tracker.py
@@ -8,7 +8,7 @@ import traceback
 from time import perf_counter
 from typing import Union
 
-import nibabel as nib
+from nibabel.tmpdirs import InTemporaryDirectory
 import numpy as np
 
 from dipy.data import get_sphere
@@ -133,7 +133,7 @@ class Tracker(object):
         else:
             # Each process will use get_streamlines_at_seeds
             chunk_ids = np.arange(self.nbr_processes)
-            with nib.tmpdirs.InTemporaryDirectory() as tmpdir:
+            with InTemporaryDirectory() as tmpdir:
 
                 pool = self._prepare_multiprocessing_pool(tmpdir)
 

--- a/scilpy/tracking/tracker.py
+++ b/scilpy/tracking/tracker.py
@@ -198,10 +198,10 @@ class Tracker(object):
         pool = multiprocessing.Pool(
             self.nbr_processes,
             initializer=self._send_multiprocess_args_to_global,
-            initargs={
+            initargs=({
                 'data_file_name': data_file_name,
                 'mmap_mode': self.mmap_mode
-            })
+            },))
 
         return pool
 

--- a/scilpy/tracking/tracker.py
+++ b/scilpy/tracking/tracker.py
@@ -6,12 +6,13 @@ import os
 import sys
 import traceback
 from time import perf_counter
+from typing import Union
 
 import nibabel as nib
 import numpy as np
 
 from dipy.data import get_sphere
-from dipy.io.stateful_tractogram import Space, StatefulTractogram
+from dipy.io.stateful_tractogram import Space
 from dipy.reconst.shm import sh_to_sf_matrix
 from dipy.tracking.streamlinespeed import compress_streamlines
 
@@ -31,7 +32,8 @@ class Tracker(object):
     def __init__(self, propagator: AbstractPropagator, mask: DataVolume,
                  seed_generator: SeedGenerator, nbr_seeds, min_nbr_pts,
                  max_nbr_pts, max_invalid_dirs, compression_th=0.1,
-                 nbr_processes=1, save_seeds=False, mmap_mode=None,
+                 nbr_processes=1, save_seeds=False,
+                 mmap_mode: Union[str, None] = None,
                  rng_seed=1234, track_forward_only=False, skip=0):
         """
         Parameters


### PR DESCRIPTION
During multiprocessing Pool, the argument sent is a dict, but the multiprocessing sends it as *args, thus deconstructing the dict.
Modifying to (dict, ), so that instead it will diconstruct the tuple and leave the dict intact.

Not sure how we did not find this bug sooner... Sorry.