### PR TITLE
skip __init__ in search_keyword.

### DIFF
--- a/scilpy/io/utils.py
+++ b/scilpy/io/utils.py
@@ -540,9 +540,12 @@ def load_matrix_in_any_format(filepath):
         # antsRegistration that encode a 4x4 transformation matrix.
         transfo_dict = loadmat(filepath)
         lps2ras = np.diag([-1, -1, 1])
+        transfo_key = 'AffineTransform_double_3_3'
+        if transfo_key not in transfo_dict:
+            transfo_key = 'AffineTransform_float_3_3'
 
-        rot = transfo_dict['AffineTransform_double_3_3'][0:9].reshape((3, 3))
-        trans = transfo_dict['AffineTransform_double_3_3'][9:12]
+        rot = transfo_dict[transfo_key][0:9].reshape((3, 3))
+        trans = transfo_dict[transfo_key][9:12]
         offset = transfo_dict['fixed']
         r_trans = (np.dot(rot, offset) - offset - trans).T * [1, 1, -1]
 

--- a/scripts/scil_search_keywords.py
+++ b/scripts/scil_search_keywords.py
@@ -62,6 +62,8 @@ def main():
 
     for script in sorted(script_dir.glob('*.py')):
         filename = script.name
+        if filename == '__init__.py':
+            continue
 
         # Skip this script
         if filename == pathlib.Path(__file__).name:


### PR DESCRIPTION
No matter the permission the `__init__.py` was giving that error when calling `scil_search_keywords.py `with the `--search_parser` option

`PermissionError: [Errno 13] Permission denied: '/home/rhef1902/Libraries/scilpy/scripts/__init__.py'`

The second change is actually a commit mistake, but it simply supports `.mat` files from ANTs for both single and double precision matrices.