### PR TITLE
uint8 in compute_density when possible

### DIFF
--- a/scripts/scil_compute_seed_density_map.py
+++ b/scripts/scil_compute_seed_density_map.py
@@ -86,13 +86,16 @@ def main():
     for seed in seeds:
         # Set value at mask, either binary or increment
         seed_voxel = np.round(seed).astype(int)
+        dtype_to_use = np.int32
         if args.binary is not None:
+            if args.binary == 1:
+                dtype_to_use = np.uint8
             seed_density[tuple(seed_voxel)] = args.binary
         else:
             seed_density[tuple(seed_voxel)] += 1
 
     # Save seed density map
-    dm_img = Nifti1Image(seed_density.astype(np.int32), affine)
+    dm_img = Nifti1Image(seed_density.astype(dtype_to_use), affine)
     dm_img.to_filename(args.seed_density_filename)
 
 

--- a/scripts/scil_compute_seed_density_map.py
+++ b/scripts/scil_compute_seed_density_map.py
@@ -29,10 +29,10 @@ def _build_arg_parser():
                    help='Output seed density filename. Format must be Nifti.')
     p.add_argument('--binary',
                    metavar='FIXED_VALUE', type=int, nargs='?', const=1,
-                   help='If set, will store the same value for all '
-                        'intersected voxels, creating a binary map.\nWhen set '
-                        'without a value, 1 is used.\n If a value is given, '
-                        'will be used as the stored value.')
+                   help='If set, will store the same value for all intersected'
+                        ' voxels, creating a binary map.\n'
+                        'When set without a value, 1 is used (and dtype uint8).\n'
+                        'If a value is given, will be used as the stored value.')
     add_overwrite_arg(p)
 
     return p

--- a/scripts/scil_compute_streamlines_density_map.py
+++ b/scripts/scil_compute_streamlines_density_map.py
@@ -60,10 +60,13 @@ def main():
 
     streamline_count = compute_tract_counts_map(streamlines, dimensions)
 
+    dtype_to_use = np.int32
     if args.binary is not None:
+        if args.binary == 1:
+            dtype_to_use = np.uint8
         streamline_count[streamline_count > 0] = args.binary
 
-    nib.save(nib.Nifti1Image(streamline_count.astype(np.int16), transformation),
+    nib.save(nib.Nifti1Image(streamline_count.astype(dtype_to_use), transformation),
              args.out_img)
 
 

--- a/scripts/scil_compute_streamlines_density_map.py
+++ b/scripts/scil_compute_streamlines_density_map.py
@@ -31,9 +31,9 @@ def _build_arg_parser():
     p.add_argument('--binary', metavar='FIXED_VALUE', type=int,
                    nargs='?', const=1,
                    help='If set, will store the same value for all intersected'
-                   ' voxels, creating a binary map.\n'
-                   'When set without a value, 1 is used.\n'
-                   'If a value is given, will be used as the stored value.')
+                        ' voxels, creating a binary map.\n'
+                        'When set without a value, 1 is used (and dtype uint8).\n'
+                        'If a value is given, will be used as the stored value.')
     add_reference_arg(p)
     add_overwrite_arg(p)
     return p


### PR DESCRIPTION
Uses uint8 if args.binary ==  1

This is the default in scilpy and MI-Brain for binary mask (0/1)