### PR TITLE
Make stopping criteria  more obvious + more similar to dipy.

### DIFF
--- a/scilpy/tracking/tracker.py
+++ b/scilpy/tracking/tracker.py
@@ -80,8 +80,8 @@ class Tracker(object):
         verbose: bool
             Display tracking progression.
         append_last_point: bool
-            Wheter to add the last point (once out of the tracking mask) to the
-            streamline or not. Note that points obtained after an invalid
+            Whether to add the last point (once out of the tracking mask) to
+            the streamline or not. Note that points obtained after an invalid
             direction (based on the propagator's definition of invalid; ex
             when angle is too sharp of sh_threshold not reached) are never
             added.

--- a/scilpy/tracking/tracker.py
+++ b/scilpy/tracking/tracker.py
@@ -35,7 +35,8 @@ class Tracker(object):
                  max_nbr_pts, max_invalid_dirs, compression_th=0.1,
                  nbr_processes=1, save_seeds=False,
                  mmap_mode: Union[str, None] = None, rng_seed=1234,
-                 track_forward_only=False, skip=0, verbose=False):
+                 track_forward_only=False, skip=0, verbose=False,
+                 append_last_point=True):
         """
         Parameters
         ----------
@@ -78,6 +79,12 @@ class Tracker(object):
             skip 1,000,000.
         verbose: bool
             Display tracking progression.
+        append_last_point: bool
+            Wheter to add the last point (once out of the tracking mask) to the
+            streamline or not. Note that points obtained after an invalid
+            direction (based on the propagator's definition of invalid; ex
+            when angle is too sharp of sh_threshold not reached) are never
+            added.
         """
         self.propagator = propagator
         self.mask = mask
@@ -91,6 +98,7 @@ class Tracker(object):
         self.mmap_mode = mmap_mode
         self.rng_seed = rng_seed
         self.track_forward_only = track_forward_only
+        self.append_last_point = append_last_point
         self.skip = skip
 
         self.origin = self.propagator.origin
@@ -428,33 +436,24 @@ class Tracker(object):
             new_pos, new_tracking_info, is_direction_valid = \
                 self.propagator.propagate(line, tracking_info)
 
-            # Verifying and appending
+            # Verifying if direction is valid
+            # If invalid: break. Else, verify tracking mask.
             if is_direction_valid:
                 invalid_direction_count = 0
             else:
                 invalid_direction_count += 1
-            propagation_can_continue = self._verify_stopping_criteria(
-                invalid_direction_count, new_pos)
-            if propagation_can_continue:
+                if invalid_direction_count > self.max_invalid_dirs:
+                    break
+
+            propagation_can_continue = self._verify_stopping_criteria(new_pos)
+            if propagation_can_continue or self.append_last_point:
                 line.append(new_pos)
 
             tracking_info = new_tracking_info
 
-        # Possible last step.
-        final_pos = self.propagator.finalize_streamline(line[-1],
-                                                        tracking_info)
-        if (final_pos is not None and
-                not np.array_equal(final_pos, line[-1]) and
-                self.mask.is_coordinate_in_bound(
-                    *final_pos, space=self.space, origin=self.origin)):
-            line.append(final_pos)
         return line
 
-    def _verify_stopping_criteria(self, invalid_direction_count, last_pos):
-
-        # Checking number of consecutive invalid directions
-        if invalid_direction_count > self.max_invalid_dirs:
-            return False
+    def _verify_stopping_criteria(self, last_pos):
 
         # Checking if out of bound
         if not self.mask.is_coordinate_in_bound(

--- a/scilpy/tracking/utils.py
+++ b/scilpy/tracking/utils.py
@@ -22,7 +22,9 @@ def add_mandatory_options_tracking(p):
                    help='Seeding mask (.nii.gz).')
     p.add_argument('in_mask',
                    help='Tracking mask (.nii.gz).\n'
-                        'Tracking will stop outside this mask.')
+                        'Tracking will stop outside this mask. The last point '
+                        'of each \nstreamline (triggering the stopping '
+                        'criteria) IS added to the streamline.')
     p.add_argument('out_tractogram',
                    help='Tractogram output file (must be .trk or .tck).')
 
@@ -40,7 +42,9 @@ def add_tracking_options(p):
                          help='Maximum length of a streamline in mm. '
                               '[%(default)s]')
     track_g.add_argument('--theta', type=float,
-                         help='Maximum angle between 2 steps.\n'
+                         help='Maximum angle between 2 steps. If the angle is '
+                              'too big, streamline is \nstopped and the '
+                              'following point is NOT included.\n'
                               '["eudx"=60, "det"=45, "prob"=20]')
     track_g.add_argument('--sfthres', dest='sf_threshold', metavar='sf_th',
                          type=float, default=0.1,

--- a/scripts/scil_compute_local_tracking_dev.py
+++ b/scripts/scil_compute_local_tracking_dev.py
@@ -113,13 +113,13 @@ def _build_arg_parser():
                          help="Mask interpolation: nearest-neighbor or "
                               "trilinear. [%(default)s]")
     track_g.add_argument(
-        '--do_not_append_last_point', dest='append_last_point',
-        action='store_false',
-        help="Do not add the last point (once out of the tracking mask) to \n"
-             "the streamline. Default: append them. This is the default in \n"
-             "Dipy too. Note that points obtained after an invalid direction \n"
-             "(based on the propagator's definition of invalid; ex when \n"
-             "angle is too sharp of sh_threshold not reached) are never added.")
+        '--discard_last_out_point', action='store_true',
+        help="If set, discard the last point (once out of the tracking mask) "
+             "of \nthe streamline. Default: append them. This is the default "
+             " in \nDipy too. Note that points obtained after an invalid "
+             "direction \n(based on the propagator's definition of invalid; "
+             "ex when \nangle is too sharp of sh_threshold not reached) are "
+             "never added.")
 
     add_seeding_options(p)
 
@@ -236,6 +236,7 @@ def main():
         space=our_space, origin=our_origin)
 
     logging.debug("Instantiating tracker.")
+    append_last_point = not args.discard_last_out_point
     tracker = Tracker(propagator, mask, seed_generator, nbr_seeds, min_nbr_pts,
                       max_nbr_pts, args.max_invalid_nb_points,
                       compression_th=args.compress,
@@ -243,7 +244,7 @@ def main():
                       save_seeds=args.save_seeds,
                       mmap_mode='r+', rng_seed=args.rng_seed,
                       track_forward_only=args.forward_only,
-                      skip=args.skip, append_last_point=args.append_last_point,
+                      skip=args.skip, append_last_point=append_last_point,
                       verbose=args.verbose)
 
     start = time.time()

--- a/scripts/scil_compute_local_tracking_dev.py
+++ b/scripts/scil_compute_local_tracking_dev.py
@@ -70,11 +70,6 @@ from scilpy.tracking.utils import (add_mandatory_options_tracking,
                                    verify_streamline_length_options,
                                    verify_seed_options)
 
-# A decision should be made as if we should keep the last point (out of the
-# tracking mask). Currently keeping this as in Dipy, i.e. True. Could be
-# an option for the user.
-APPEND_LAST_POINT = True
-
 
 def _build_arg_parser():
     p = argparse.ArgumentParser(
@@ -117,6 +112,14 @@ def _build_arg_parser():
                          choices=['nearest', 'trilinear'],
                          help="Mask interpolation: nearest-neighbor or "
                               "trilinear. [%(default)s]")
+    track_g.add_argument(
+        '--do_not_append_last_point', dest='append_last_point',
+        action='store_false',
+        help="Do not add the last point (once out of the tracking mask) to \n"
+             "the streamline. Default: append them. This is the default in \n"
+             "Dipy too. Note that points obtained after an invalid direction \n"
+             "(based on the propagator's definition of invalid; ex when \n"
+             "angle is too sharp of sh_threshold not reached) are never added.")
 
     add_seeding_options(p)
 
@@ -240,7 +243,7 @@ def main():
                       save_seeds=args.save_seeds,
                       mmap_mode='r+', rng_seed=args.rng_seed,
                       track_forward_only=args.forward_only,
-                      skip=args.skip, append_last_point=APPEND_LAST_POINT,
+                      skip=args.skip, append_last_point=args.append_last_point,
                       verbose=args.verbose)
 
     start = time.time()


### PR DESCRIPTION
In the tracking dev, manage the stopping criteria as in Dipy:

- If direction is invalid (angle or ODF threshold): do not add the next point.
     - (Previous usage was to add an additional straight point instead)
- Else, if out of tracking mask: the point is added, and *then* the streamline is stopped.
    - (Was already like that, but out of the for loop).


Add this choice to doc so that it is more obvious for the user.