### PR TITLE
Get version script

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ docopt==0.6.*
 formulaic==0.3.*
 fury==0.8.*
 future==0.18.*
+GitPython==3.1.*
 h5py==3.7.*
 joblib==1.2.*
 kiwisolver==1.4.*

--- a/scripts/scil_get_version.py
+++ b/scripts/scil_get_version.py
@@ -53,7 +53,6 @@ def main():
 
     last_commit = repo.head.commit
     print('The last commit hash is: {}'.format(_bold(last_commit.hexsha)))
-    print('The last commit author is: {}'.format(_bold(last_commit.author)))
     date = str(last_commit.committed_datetime).split()[0]
     print('The last commit date is: {}, by {}'.format(_bold(date),
           _bold(last_commit.author)))
@@ -69,16 +68,11 @@ def main():
         else:
             upstream = repo.remotes.upstream.url
 
-        last_commit = git.cmd.Git().ls_remote(upstream, heads=True).split()[0]
         count = repo.git.rev_list('--count', 'upstream/master..HEAD',
                                   '--left-right').split()
 
         print('Your upstream is set to: {}'.format(_bold(upstream)))
-        print('The last commit hash on upstream is: {}'.format(
-            _bold(last_commit)))
-
         print('You are {} commits behind upstream/master'.format(
-
             _bold(count[0])))
         print('You are {} commits ahead of upstream/master'.format(
             _bold(count[1])))

--- a/scripts/scil_get_version.py
+++ b/scripts/scil_get_version.py
@@ -19,9 +19,14 @@ import logging
 import pathlib
 import re
 import subprocess
+import pkg_resources
+import datetime
 
 import git
 import numpy as np
+import pip
+import os
+import time
 
 
 def _build_arg_parser():
@@ -30,30 +35,57 @@ def _build_arg_parser():
     return p
 
 
+def _bold(string):
+    string = str(string)
+    return '\033[1m' + string + '\033[0m'
+
+
 def main():
     parser = _build_arg_parser()
     args = parser.parse_args()
+
+    dists = [d for d in pkg_resources.working_set]
+    for dist in dists:
+        if dist.project_name == 'scilpy':
+            date = time.ctime(os.path.getctime(dist.location))
+            date = datetime.datetime.strptime(date, "%a %b %d %H:%M:%S %Y")
+            date = date.strftime('%Y-%m-%d')
+            print('You installed Scilpy with pip on {}'.format(_bold(date)))
+            print('The closest release is {}\n'.format(_bold(dist.version)))
 
     repo_dir = pathlib.Path(__file__).parent.parent
     repo = git.Repo(repo_dir)
     branch = repo.active_branch.name
     origin = repo.remotes.origin.url
     branch = repo.active_branch.name
+    print('Your Scilpy directory is: {}'.format(_bold(repo_dir)))
+    print('Your current Origin is: {}'.format(_bold(origin)))
+    print('Your repository is on branch: {}\n'.format(_bold(branch)))
+
     last_commit = repo.head.commit
-    print(last_commit.message)
-    print(last_commit.hexsha)
-    print(last_commit.committed_datetime)
+    print('The last commit hash is: {}'.format(_bold(last_commit.hexsha)))
+    print('The last commit author is: {}'.format(_bold(last_commit.author)))
+    date = str(last_commit.committed_datetime).split()[0]
+    print('The last commit date is: {}, by {}'.format(_bold(date),
+          _bold(last_commit.author)))
+    print('The last commit message is: {}'.format(_bold(last_commit.message)))
 
     if 'upstream' in repo.git.remote().split():
         upstream = repo.remotes.upstream.url
-        upstream_commit = git.cmd.Git().ls_remote(upstream, heads=True)
-        # print(upstream_commit)
-        count = repo.git.rev_list('--count', 'upstream/master..HEAD')
-        print(count)
-    # remote_heads = 
-    # import time
+        last_commit = git.cmd.Git().ls_remote(upstream, heads=True).split()[0]
+        count = repo.git.rev_list('--count', 'upstream/master..HEAD',
+                                  '--left-right').split()
 
-    # time.asctime(time.gmtime(headcommit.committed_date))
-    # time.strftime("%a, %d %b %Y %H:%M", time.gmtime(headcommit.committed_date))
+        print('Your upstream is set to: {}'.format(_bold(upstream)))
+        print('The last commit hash on upstream is: {}'.format(
+            _bold(last_commit)))
+
+        print('You are {} commits behind upstream/master'.format(
+
+            _bold(count[0])))
+        print('You are {} commits ahead of upstream/master'.format(
+            _bold(count[1])))
+
+
 if __name__ == '__main__':
     main()

--- a/scripts/scil_get_version.py
+++ b/scripts/scil_get_version.py
@@ -24,7 +24,7 @@ def _build_arg_parser():
     p = argparse.ArgumentParser(description=__doc__,
                                 formatter_class=argparse.RawTextHelpFormatter)
     p.add_argument('--show_dependencies', action='store_true',
-                   help='Show the important dependencies of Scilpy.')
+                   help='Show the dependencies of scilpy.')
     return p
 
 
@@ -63,9 +63,15 @@ def main():
         print('It is not a git repository, so we cannot give you more '
               'information.')
         return
-    branch = repo.active_branch.name
-    origin = repo.remotes.origin.url
-    branch = repo.active_branch.name
+    if not repo.head.is_detached:
+        branch = repo.active_branch
+        origin = repo.remotes.origin.url
+    else:
+        with open(os.path.join(repo_dir, '.git', 'FETCH_HEAD')) as f:
+            git_text = f.read().split()
+            branch = git_text[2].replace("'","")
+            origin = git_text[4]
+    
     print('Your Scilpy directory is: {}'.format(_bold(repo_dir)))
     print('Your current Origin is: {}'.format(_bold(origin)))
     print('Your repository is on branch: {}\n'.format(_bold(branch)))

--- a/scripts/scil_get_version.py
+++ b/scripts/scil_get_version.py
@@ -69,9 +69,9 @@ def main():
     else:
         with open(os.path.join(repo_dir, '.git', 'FETCH_HEAD')) as f:
             git_text = f.read().split()
-            branch = git_text[2].replace("'","")
+            branch = git_text[2].replace("'", "")
             origin = git_text[4]
-    
+
     print('Your Scilpy directory is: {}'.format(_bold(repo_dir)))
     print('Your current Origin is: {}'.format(_bold(origin)))
     print('Your repository is on branch: {}\n'.format(_bold(branch)))

--- a/scripts/scil_get_version.py
+++ b/scripts/scil_get_version.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Search through all of SCILPY scripts and their docstrings. The output of the
+search will be the intersection of all provided keywords, found either in the
+script name or in its docstring.
+By default, print the matching filenames and the first sentence of the
+docstring. If --verbose if provided, print the full docstring.
+
+Examples:
+    scil_search_keywords.py tractogram filtering
+    scil_search_keywords.py --search_parser tractogram filtering -v
+"""
+
+import argparse
+import ast
+import logging
+import pathlib
+import re
+import subprocess
+
+import git
+import numpy as np
+
+
+def _build_arg_parser():
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter)
+    return p
+
+
+def main():
+    parser = _build_arg_parser()
+    args = parser.parse_args()
+
+    repo_dir = pathlib.Path(__file__).parent.parent
+    repo = git.Repo(repo_dir)
+    branch = repo.active_branch.name
+    origin = repo.remotes.origin.url
+    branch = repo.active_branch.name
+    last_commit = repo.head.commit
+    print(last_commit.message)
+    print(last_commit.hexsha)
+    print(last_commit.committed_datetime)
+
+    if 'upstream' in repo.git.remote().split():
+        upstream = repo.remotes.upstream.url
+        upstream_commit = git.cmd.Git().ls_remote(upstream, heads=True)
+        # print(upstream_commit)
+        count = repo.git.rev_list('--count', 'upstream/master..HEAD')
+        print(count)
+    # remote_heads = 
+    # import time
+
+    # time.asctime(time.gmtime(headcommit.committed_date))
+    # time.strftime("%a, %d %b %Y %H:%M", time.gmtime(headcommit.committed_date))
+if __name__ == '__main__':
+    main()

--- a/scripts/scil_get_version.py
+++ b/scripts/scil_get_version.py
@@ -85,22 +85,25 @@ def main():
 
     upstream_url = ['git@github.com:scilus/scilpy.git',
                     'https://github.com/scilus/scilpy.git']
+    origin = repo.remotes.origin.url
     if 'upstream' in repo.git.remote().split() or \
             origin in upstream_url:
 
         if origin in upstream_url:
             upstream = origin
+            count = repo.git.rev_list('--count', 'origin/master..HEAD',
+                                      '--left-right').split()
         else:
             upstream = repo.remotes.upstream.url
+            count = repo.git.rev_list('--count', 'upstream/master..HEAD',
+                                      '--left-right').split()
 
-        count = repo.git.rev_list('--count', 'upstream/master..HEAD',
-                                  '--left-right').split()
-
+        remote_name = 'origin' if origin in upstream_url else 'upstream'
         print('Your upstream is set to: {}'.format(_bold(upstream)))
-        print('You are {} commits behind upstream/master'.format(
-            _bold(count[0])))
-        print('You are {} commits ahead of upstream/master'.format(
-            _bold(count[1])))
+        print('You are {} commits behind {}/master'.format(
+            _bold(count[0]), remote_name))
+        print('You are {} commits ahead of {}/master'.format(
+            _bold(count[1]), remote_name))
 
 
 if __name__ == '__main__':

--- a/scripts/scil_get_version.py
+++ b/scripts/scil_get_version.py
@@ -24,7 +24,7 @@ def _build_arg_parser():
     p = argparse.ArgumentParser(description=__doc__,
                                 formatter_class=argparse.RawTextHelpFormatter)
     p.add_argument('--show_dependencies', action='store_true',
-                   help='Show the dependencies of scilpy.')
+                   help='Show the important dependencies of Scilpy.')
     return p
 
 

--- a/scripts/scil_get_version.py
+++ b/scripts/scil_get_version.py
@@ -2,29 +2,19 @@
 # -*- coding: utf-8 -*-
 
 """
-Search through all of SCILPY scripts and their docstrings. The output of the
-search will be the intersection of all provided keywords, found either in the
-script name or in its docstring.
-By default, print the matching filenames and the first sentence of the
-docstring. If --verbose if provided, print the full docstring.
+Give you information about your current scilpy installation.
+This is useful for non-developers to give you the information
+needed to reproduce your results, or to help debugging.
 
-Examples:
-    scil_search_keywords.py tractogram filtering
-    scil_search_keywords.py --search_parser tractogram filtering -v
+If you are experiencing a bug, please run this script and
+send the output to the scilpy developers.
 """
 
 import argparse
-import ast
-import logging
-import pathlib
-import re
-import subprocess
-import pkg_resources
 import datetime
-
 import git
-import numpy as np
-import pip
+import pathlib
+import pkg_resources
 import os
 import time
 
@@ -42,7 +32,6 @@ def _bold(string):
 
 def main():
     parser = _build_arg_parser()
-    args = parser.parse_args()
 
     dists = [d for d in pkg_resources.working_set]
     for dist in dists:
@@ -70,8 +59,16 @@ def main():
           _bold(last_commit.author)))
     print('The last commit message is: {}'.format(_bold(last_commit.message)))
 
-    if 'upstream' in repo.git.remote().split():
-        upstream = repo.remotes.upstream.url
+    upstream_url = ['git@github.com:scilus/scilpy.git',
+                    'https://github.com/scilus/scilpy.git']
+    if 'upstream' in repo.git.remote().split() or \
+            origin in upstream_url:
+
+        if origin in upstream_url:
+            upstream = origin
+        else:
+            upstream = repo.remotes.upstream.url
+
         last_commit = git.cmd.Git().ls_remote(upstream, heads=True).split()[0]
         count = repo.git.rev_list('--count', 'upstream/master..HEAD',
                                   '--left-right').split()


### PR DESCRIPTION
Script to help us all debug collaborators when they are not familiar with Git.
This should be used when a collaborator was setup some time ago and we forgot how.

It will be useful in a while (when everyone is up-to-date), but I believe it will be useful.
Could also be a quick way to check 'version' when working across multiple devices/containers/clusters

It outputs:
```
You installed Scilpy with pip on 2023-04-02
The closest release is 1.5

Your Scilpy directory is: /home/frheault/Libraries/scilpy
Your current Origin is: git@github.com:frheault/scilpy.git
Your repository is on branch: get_version_script

The last commit hash is: 2414097218727a5ae4c28677cfe251fec2ec1b6e
The last commit date is: 2023-04-02, by frheault
The last commit message is: Clean pep8

Your upstream is set to: https://github.com/scilus/scilpy.git
You are 0 commits behind upstream/master
You are 3 commits ahead of upstream/master
```
