### PR TITLE
Display masks as contours in screenshots

### DIFF
--- a/scilpy/io/utils.py
+++ b/scilpy/io/utils.py
@@ -277,7 +277,14 @@ def add_nifti_screenshot_default_args(
     parser.add_argument(
         "--win_dims", nargs=2, metavar=("WIDTH", "HEIGHT"), default=(768, 768),
         type=int, help="The dimensions for the vtk window. [%(default)s]")
-
+    parser.add_argument(
+        "--display_slice_number", action="store_true",
+        help="If true, displays the slice number in the upper left corner."
+    )
+    parser.add_argument(
+        "--display_lr", action="store_true",
+        help="If true, add left and right annotations to the images."
+    )
 
 def add_nifti_screenshot_overlays_args(
     parser, labelmap_overlay=True, mask_overlay=True,

--- a/scilpy/io/utils.py
+++ b/scilpy/io/utils.py
@@ -9,6 +9,7 @@ import re
 import shutil
 import xml.etree.ElementTree as ET
 
+import nibabel as nib
 import numpy as np
 from dipy.data import SPHERE_FILES
 from dipy.io.utils import is_header_compatible
@@ -237,6 +238,80 @@ def add_sh_basis_args(parser, mandatory=False):
                         help=help_msg)
 
 
+def add_nifti_screenshot_default_args(
+    parser, slice_ids_mandatory=True, transparency_mask_mandatory=True
+):
+    _mask_prefix = "" if transparency_mask_mandatory else "--"
+    
+    _slice_ids_prefix, _slice_ids_help = "", "Slice indices to screenshot."
+    _output_help = "Name of the output image (e.g. img.jpg, img.png)."
+    if not slice_ids_mandatory:
+        _slice_ids_prefix = "--"
+        _slice_ids_help += " If None are supplied, all slices inside " \
+                           "the transparency mask are selected."
+        _output_help = "Name of the output image(s). If multiple slices are " \
+                       "provided (or none), their index will be append to " \
+                        "the name (e.g. volume.jpg, volume.png becomes " \
+                        "volume_slice_0.jpg, volume_slice_0.png)."
+
+    # Positional arguments
+    parser.add_argument(
+        "in_volume", help="Input 3D Nifti file (.nii/.nii.gz).")
+    parser.add_argument("out_fname", help=_output_help)
+
+    # Variable arguments
+    parser.add_argument(
+        f"{_mask_prefix}in_transparency_mask",
+        help="Transparency mask 3D Nifti image (.nii/.nii.gz).")
+    parser.add_argument(
+        f"{_slice_ids_prefix}slice_ids", nargs="+", type=int,
+        help=_slice_ids_help)
+
+    # Optional arguments
+    parser.add_argument(
+        "--volume_cmap_name", default=None,
+        help="Colormap name for the volume image data. [%(default)s]")
+    parser.add_argument(
+        "--axis_name", default="axial", type=str, choices=axis_name_choices,
+        help="Name of the axis to visualize. [%(default)s]")
+    parser.add_argument(
+        "--win_dims", nargs=2, metavar=("WIDTH", "HEIGHT"), default=(768, 768),
+        type=int, help="The dimensions for the vtk window. [%(default)s]")
+
+
+def add_nifti_screenshot_overlays_args(
+    parser, labelmap_overlay=True, mask_overlay=True,
+    transparency_is_overlay=False
+):
+    if labelmap_overlay:
+        parser.add_argument(
+            "--in_labelmap",  help="Labelmap 3D Nifti image (.nii/.nii.gz).")
+        parser.add_argument(
+            "--labelmap_cmap_name", default="viridis",
+            help="Colormap name for the labelmap image data. [%(default)s]")
+        parser.add_argument(
+            "--labelmap_alpha", type=ranged_type(float, 0., 1.), default=0.7,
+            help="Opacity value for the labelmap overlay. [%(default)s].")
+
+    if mask_overlay:
+        if not transparency_is_overlay:
+            parser.add_argument(
+                "--in_masks", nargs="+",
+                help="Mask 3D Nifti image (.nii/.nii.gz).")
+
+        parser.add_argument(
+            "--masks_colors", nargs="+", metavar="R G B",
+            type=ranged_type(int, 0, 255), default=None,
+            help="Colors for the mask overlay or contour")
+        parser.add_argument(
+            "--masks_as_contours", action='store_true',
+            help="Create contours from masks instead "
+                 "of overlays. [%(default)s].")
+        parser.add_argument(
+            "--masks_alpha", type=ranged_type(float, 0., 1.), default=0.7,
+            help="Opacity value for the masks overlays. [%(default)s].")
+
+
 def validate_nbr_processes(parser, args):
     """ Check if the passed number of processes arg is valid.
     Valid values are considered to be in the [0, CPU count] range:
@@ -433,6 +508,20 @@ def assert_output_dirs_exist_and_empty(parser, args, required,
     for opt_dir in optional or []:
         if opt_dir:
             check(opt_dir)
+
+
+def assert_overlay_colors(colors, overlays, parser):
+    if colors is None:
+        return
+
+    if len(colors) % 3 != 0:
+        parser.error(
+            "Masks colors must be tuples of 3 ints in the range [0, 255]")
+
+    if len(colors) > 3 and len(colors) // 3 != len(overlays):
+        parser.error(f"Bad number of colors supplied for overlays "
+                     f"({len(overlays)}). Either provide no color, a "
+                     f"single mask color or as many colors as there is masks")
 
 
 def verify_compatibility_with_reference_sft(ref_sft, files_to_verify,
@@ -675,3 +764,35 @@ def ranged_type(value_type, min_value, max_value):
 
     # Return handle to checking function
     return range_checker
+
+
+def get_default_screenshotting_data(args):
+
+    volume_img = nib.load(args.in_volume)
+
+    transparency_mask_img = None
+    if args.in_transparency_mask:
+        transparency_mask_img = nib.load(args.in_transparency_mask)
+
+    labelmap_img = None
+    if args.in_labelmap:
+        labelmap_img = nib.load(args.in_labelmap)
+
+    mask_imgs, masks_colors = None, None
+    if args.in_masks:
+        mask_imgs = [nib.load(f) for f in args.in_masks]
+
+        if args.masks_colors is not None:
+            if len(args.masks_colors) == 3:
+                masks_colors = np.repeat(
+                    [args.masks_colors], len(args.in_masks), axis=0)
+            elif len(args.masks_colors) // 3 == len(args.in_masks):
+                masks_colors = np.array(args.masks_colors).reshape((-1, 3))
+
+            masks_colors = masks_colors / 255.
+
+    return volume_img, \
+        transparency_mask_img, \
+        labelmap_img, \
+        mask_imgs, \
+        masks_colors

--- a/scilpy/viz/scene_utils.py
+++ b/scilpy/viz/scene_utils.py
@@ -663,7 +663,7 @@ def screenshot_slice(img, axis_name, slice_ids, size):
     return scene_container
 
 
-def screenshot_contour(bin_img, axis_name, slice_ids, size, color=[255, 0, 0]):
+def screenshot_contour(bin_img, axis_name, slice_ids, size):
     """Take a screenshot of the given binary image countour with the 
     appropriate slice data at the provided slice indices.
 
@@ -677,8 +677,6 @@ def screenshot_contour(bin_img, axis_name, slice_ids, size, color=[255, 0, 0]):
         Slice indices.
     size : array-like
         Size of the screenshot image (pixels).
-    color : tuple, list of int
-        Color of the contour in RGB [0, 255].
 
     Returns
     -------
@@ -698,7 +696,8 @@ def screenshot_contour(bin_img, axis_name, slice_ids, size, color=[255, 0, 0]):
     image_size_2d[ax_idx] = 1
 
     for idx in slice_ids:
-        actor = contour_actor_from_image(bin_img, ax_idx, idx, color=color)
+        actor = contour_actor_from_image(
+            bin_img, ax_idx, idx, color=[255, 255, 255])
 
         scene = create_scene([actor], axis_name, idx, image_size_2d)
         scene_arr = window.snapshot(scene, size=size)
@@ -830,7 +829,8 @@ def draw_scene_at_pos(
     mask=None,
     labelmap_overlay=None,
     mask_overlay=None,
-    mask_overlay_alpha=1.,
+    mask_overlay_alpha=0.7,
+    mask_overlay_color=(255, 0, 0),
     vol_cmap_name=None,
     labelmap_cmap_name=None,
 ):
@@ -856,6 +856,8 @@ def draw_scene_at_pos(
         Mask overlay scene data to be drawn.
     mask_overlay_alpha : float
         Alpha value for mask overlay in range [0, 1].
+    mask_overlay_color : list, optional
+        Color for the mask overlay as a list of 3 integers in range [0, 255].
     vol_cmap_name : str, optional
         Colormap name for the image scene data.
     labelmap_cmap_name : str, optional
@@ -885,9 +887,12 @@ def draw_scene_at_pos(
     # Draw the mask overlay image if any
     if mask_overlay is not None:
         for img in mask_overlay:
-            contour_img = create_image_from_scene(img, size)
-            contour_mask = create_mask_from_scene(
-                (np.sum(img, axis=-1) > 0) * mask_overlay_alpha, size)
+            contour_img = create_image_from_scene(
+                ((img > 0) * mask_overlay_color).astype(np.uint8), size, "RGB")
+
+            mask_image = (np.sum(img, axis=-1) > 0) * mask_overlay_alpha * 255
+            contour_mask = create_image_from_scene(
+                mask_image.astype(np.uint8), size, "L")
 
             canvas.paste(contour_img, (left_pos, top_pos), mask=contour_mask)
 
@@ -994,7 +999,8 @@ def compose_mosaic(
     overlap_factor=None,
     labelmap_scene_container=None,
     mask_overlay_scene_container=None,
-    mask_overlay_alpha = 1.,
+    mask_overlay_alpha = 0.7,
+    mask_overlay_color=(255, 0, 0),
     vol_cmap_name=None,
     labelmap_cmap_name=None,
 ):
@@ -1019,8 +1025,10 @@ def compose_mosaic(
         Labelmap scene data container.
     mask_overlay_scene_container : list, optional
         Mask overlay scene data container.
-    mask_overlay_alpha : float
+    mask_overlay_alpha : float, optional
         Alpha value for mask overlay in range [0, 1].
+    mask_overlay_color : list, optional
+        Color for the mask overlay as a list of 3 integers in range [0, 255].
     vol_cmap_name : str, optional
         Colormap name for the image scene data.
     labelmap_cmap_name : str, optional
@@ -1081,6 +1089,7 @@ def compose_mosaic(
             labelmap_overlay=_labelmap_arr,
             mask_overlay=_mask_overlay_arr,
             mask_overlay_alpha=mask_overlay_alpha,
+            mask_overlay_color=mask_overlay_color,
             vol_cmap_name=vol_cmap_name,
             labelmap_cmap_name=labelmap_cmap_name,
         )

--- a/scilpy/viz/scene_utils.py
+++ b/scilpy/viz/scene_utils.py
@@ -686,7 +686,6 @@ def screenshot_contour(bin_img, axis_name, slice_ids, size, color=[255, 0, 0]):
         Scene screenshot data container.
     """
     scene_container = []
-    image_size_2d = list(bin_img.shape)
 
     if axis_name == "axial":
         ax_idx = 2

--- a/scilpy/viz/scene_utils.py
+++ b/scilpy/viz/scene_utils.py
@@ -998,14 +998,18 @@ def compute_cell_topleft_pos(idx, cols, offset_h, offset_v):
 
 
 def annotate_scene(mosaic, slice_number, display_slice_number, display_lr):
-    font_size = min(mosaic.width // 10, 100)
+    font_size = mosaic.width // 10
     font = ImageFont.truetype(
         '/usr/share/fonts/truetype/freefont/FreeSans.ttf', font_size)
 
+    stroke, padding = max(mosaic.width // 200, 1), mosaic.width // 100
     img = ImageDraw.Draw(mosaic)
 
     if display_slice_number:
-        img.text((0, 0), "{}".format(slice_number), (255,255,255), font=font)
+        img.text(
+            (padding, padding), "{}".format(slice_number), (255,255,255),
+            font=font, stroke_width=stroke, stroke_fill=(0, 0, 0)
+        )
 
     if display_lr:
         l_text, r_text = "L", "R"
@@ -1013,12 +1017,12 @@ def annotate_scene(mosaic, slice_number, display_slice_number, display_lr):
             l_text, r_text = r_text, l_text
 
         img.text(
-            (0, mosaic.height // 2), l_text, (255,255,255),
-            font=font, anchor="lm"
+            (padding, mosaic.height // 2), l_text, (255,255,255),
+            font=font, anchor="lm", stroke_width=stroke, stroke_fill=(0, 0, 0)
         )
         img.text(
-            (mosaic.width, mosaic.height // 2), r_text, (255,255,255),
-            font=font, anchor="rm"
+            (mosaic.width - padding, mosaic.height // 2), r_text, (255,255,255),
+            font=font, anchor="rm", stroke_width=stroke, stroke_fill=(0, 0, 0)
         )
 
 

--- a/scilpy/viz/scene_utils.py
+++ b/scilpy/viz/scene_utils.py
@@ -830,7 +830,7 @@ def draw_scene_at_pos(
     labelmap_overlay=None,
     mask_overlay=None,
     mask_overlay_alpha=0.7,
-    mask_overlay_color=(255, 0, 0),
+    mask_overlay_color=None,
     vol_cmap_name=None,
     labelmap_cmap_name=None,
 ):
@@ -886,13 +886,16 @@ def draw_scene_at_pos(
 
     # Draw the mask overlay image if any
     if mask_overlay is not None:
-        for img in mask_overlay:
-            contour_img = create_image_from_scene(
-                ((img > 0) * mask_overlay_color).astype(np.uint8), size, "RGB")
+        if mask_overlay_color is None:
+            mask_overlay_color = distinguishable_colormap(
+                nb_colors=len(mask_overlay))
 
-            mask_image = (np.sum(img, axis=-1) > 0) * mask_overlay_alpha * 255
+        for img, color in zip(mask_overlay, mask_overlay_color):
+            contour_img = create_image_from_scene(
+                (img * color).astype(np.uint8), size, "RGB")
+
             contour_mask = create_image_from_scene(
-                mask_image.astype(np.uint8), size, "L")
+                (img * mask_overlay_alpha).astype(np.uint8), size).convert("L")
 
             canvas.paste(contour_img, (left_pos, top_pos), mask=contour_mask)
 
@@ -1000,7 +1003,7 @@ def compose_mosaic(
     labelmap_scene_container=None,
     mask_overlay_scene_container=None,
     mask_overlay_alpha = 0.7,
-    mask_overlay_color=(255, 0, 0),
+    mask_overlay_color=None,
     vol_cmap_name=None,
     labelmap_cmap_name=None,
 ):

--- a/scilpy/viz/utils.py
+++ b/scilpy/viz/utils.py
@@ -4,6 +4,13 @@ import matplotlib.pyplot as plt
 from matplotlib import colors
 
 
+RAS_AXES = {
+    "sagittal": 0,
+    "coronal": 1,
+    "axial": 2
+}
+
+
 def get_colormap(name):
     """Get a matplotlib colormap from a name or a list of named colors.
 

--- a/scripts/scil_screenshot_volume.py
+++ b/scripts/scil_screenshot_volume.py
@@ -163,7 +163,7 @@ def _get_data_from_inputs(args):
     vol_img = nib.load(args.in_vol)
 
     mask_img = None
-    if args.mask:
+    if args.in_mask:
         mask_img = nib.load(args.in_mask)
 
     labelmap_img = None

--- a/scripts/scil_screenshot_volume.py
+++ b/scripts/scil_screenshot_volume.py
@@ -202,6 +202,7 @@ def main():
     )
 
     mask_scene_container = []
+    mask_overlay_alpha = 1.
     if mask_img is not None:
         if args.mask_as_contour:
             mask_scene_container = screenshot_contour(
@@ -211,6 +212,7 @@ def main():
                 args.win_dims
             )
         else:
+            mask_overlay_alpha = 0.7
             mask_scene_container = screenshot_slice(
                 mask_img,
                 args.axis_name,
@@ -245,8 +247,9 @@ def main():
             1,
             1,
             vol_cmap_name=args.vol_cmap_name,
+            mask_overlay_alpha=mask_overlay_alpha,
             labelmap_scene_container=[label],
-            mask_contour_scene_container=[[contour]]
+            mask_overlay_scene_container=[[contour]]
         )
 
         # Save the snapshot

--- a/scripts/scil_screenshot_volume.py
+++ b/scripts/scil_screenshot_volume.py
@@ -257,9 +257,9 @@ def main():
             vol_cmap_name=args.vol_cmap_name,
             labelmap_cmap_name=args.labelmap_cmap_name,
             mask_overlay_alpha=mask_overlay_alpha,
-            mask_overlay_color=args.mask_color,
+            mask_overlay_color=[list(c // 255 for c in args.mask_color)],
             labelmap_scene_container=[label],
-            mask_overlay_scene_container=[[contour]] if contour else []
+            mask_overlay_scene_container=[[contour]] if len(contour) else []
         )
 
         # Save the snapshot

--- a/scripts/scil_screenshot_volume.py
+++ b/scripts/scil_screenshot_volume.py
@@ -170,16 +170,17 @@ def main():
     names = ["{}_slice_{}{}".format(name, s, ext) for s in slice_ids]
 
     # Compose and save each slice
-    for (volume, trans, label, contour, name) in list(
+    for (volume, trans, label, contour, name, slice_id) in list(
         zip_longest(vol_scene_container,
                     transparency_scene_container,
                     labelmap_scene_container,
                     mask_overlay_scene_container,
                     names,
+                    slice_ids,
                     fillvalue=tuple())):
 
         img = compose_mosaic(
-            [volume], args.win_dims, 1, 1,
+            [volume], args.win_dims, 1, 1, [slice_id],
             vol_cmap_name=args.volume_cmap_name,
             transparency_scene_container=[trans],
             mask_overlay_scene_container=[contour],
@@ -187,7 +188,9 @@ def main():
             mask_overlay_alpha=args.masks_alpha,
             labelmap_scene_container=[label],
             labelmap_cmap_name=args.labelmap_cmap_name,
-            labelmap_overlay_alpha=args.labelmap_alpha)
+            labelmap_overlay_alpha=args.labelmap_alpha,
+            display_slice_number=args.display_slice_number,
+            display_lr=args.display_lr)
 
         # Save the snapshot
         img.save(name)

--- a/scripts/scil_screenshot_volume.py
+++ b/scripts/scil_screenshot_volume.py
@@ -72,7 +72,8 @@ from scilpy.io.image import assert_same_resolution
 from scilpy.io.utils import (
     axis_name_choices,
     add_overwrite_arg,
-    assert_inputs_exist
+    assert_inputs_exist,
+    ranged_type
 )
 from scilpy.image.utils import check_slice_indices
 from scilpy.viz.scene_utils import (
@@ -121,6 +122,13 @@ def _build_arg_parser():
         default=(768, 768),
         type=int,
         help="The dimensions for the vtk window. [%(default)s]"
+    )
+    p.add_argument(
+        "--mask_color",
+        nargs=3,
+        type=ranged_type(int, 0, 255),
+        default=(255, 0, 0),
+        help="Color for the mask overlay or contour"
     )
     p.add_argument(
         "--vol_cmap_name",
@@ -247,9 +255,11 @@ def main():
             1,
             1,
             vol_cmap_name=args.vol_cmap_name,
+            labelmap_cmap_name=args.labelmap_cmap_name,
             mask_overlay_alpha=mask_overlay_alpha,
+            mask_overlay_color=args.mask_color,
             labelmap_scene_container=[label],
-            mask_overlay_scene_container=[[contour]]
+            mask_overlay_scene_container=[[contour]] if contour else []
         )
 
         # Save the snapshot

--- a/scripts/scil_screenshot_volume.py
+++ b/scripts/scil_screenshot_volume.py
@@ -64,21 +64,23 @@ python scil_screenshot_volume.py \
 import argparse
 
 from itertools import zip_longest
-import nibabel as nib
 import numpy as np
 from os.path import splitext
 
 from scilpy.io.image import assert_same_resolution
 from scilpy.io.utils import (
-    axis_name_choices,
+    get_default_screenshotting_data,
+    add_nifti_screenshot_default_args,
+    add_nifti_screenshot_overlays_args,
+    assert_overlay_colors,
     add_overwrite_arg,
-    assert_inputs_exist,
-    ranged_type
+    assert_inputs_exist
 )
 from scilpy.image.utils import check_slice_indices
 from scilpy.viz.scene_utils import (
     compose_mosaic, screenshot_slice, screenshot_contour
 )
+from scilpy.viz.utils import RAS_AXES
 
 
 def _build_arg_parser():
@@ -88,59 +90,8 @@ def _build_arg_parser():
         formatter_class=argparse.RawTextHelpFormatter
     )
 
-    # Positional arguments
-    p.add_argument("in_vol", help="Input volume image file.")
-    p.add_argument(
-        "out_fname",
-        help="Name of the output image(s). If multiple slices are provided "
-             "(or none), their index will be append to the name "
-             "(e.g. volume.jpg, volume.png becomes "
-             "volume_slice_0.jpg, volume_slice_0.png)."
-    )
-
-    # Optional arguments
-    p.add_argument("--in_mask", help="Input mask image file for overlay.")
-    p.add_argument("--in_labelmap",  help="Labelmap image.")
-
-    p.add_argument('--mask_as_contour', action='store_true',
-                   help='If supplied, the creates contour '
-                        'from mask. [%(default)s].')
-    p.add_argument(
-        "--slice_ids", nargs="+", type=int, help="Slice indices to screenshot."
-    )
-    p.add_argument(
-        "--axis_name",
-        default="axial",
-        type=str,
-        choices=axis_name_choices,
-        help="Name of the axis to visualize. [%(default)s]"
-    )
-    p.add_argument(
-        "--win_dims",
-        nargs=2,
-        metavar=("WIDTH", "HEIGHT"),
-        default=(768, 768),
-        type=int,
-        help="The dimensions for the vtk window. [%(default)s]"
-    )
-    p.add_argument(
-        "--mask_color",
-        nargs=3,
-        type=ranged_type(int, 0, 255),
-        default=(255, 0, 0),
-        help="Color for the mask overlay or contour"
-    )
-    p.add_argument(
-        "--vol_cmap_name",
-        default=None,
-        help="Colormap name for the volume image data. [%(default)s]"
-    )
-    p.add_argument(
-        "--labelmap_cmap_name",
-        default="viridis",
-        help="Colormap name for the labelmap image data. [%(default)s]"
-    )
-
+    add_nifti_screenshot_default_args(p, False, False)
+    add_nifti_screenshot_overlays_args(p, transparency_is_overlay=False)
     add_overwrite_arg(p)
 
     return p
@@ -152,10 +103,10 @@ def _parse_args(parser):
 
     inputs = []
 
-    inputs.append(args.in_vol)
+    inputs.append(args.in_volume)
 
-    if args.in_mask:
-        inputs.append(args.in_mask)
+    if args.in_masks:
+        inputs.extend(args.in_masks)
     if args.in_labelmap:
         inputs.append(args.in_labelmap)
 
@@ -163,43 +114,24 @@ def _parse_args(parser):
 
     assert_same_resolution(inputs)
 
+    assert_overlay_colors(args.masks_colors, args.in_masks, parser)
+
     return args
 
 
-def _get_data_from_inputs(args):
-
-    vol_img = nib.load(args.in_vol)
-
-    mask_img = None
-    if args.in_mask:
-        mask_img = nib.load(args.in_mask)
-
-    labelmap_img = None
-    if args.in_labelmap:
-        labelmap_img = nib.load(args.in_labelmap)
-
-    return vol_img, mask_img, labelmap_img
-
-
 def main():
-
     parser = _build_arg_parser()
     args = _parse_args(parser)
 
-    vol_img, mask_img, labelmap_img = _get_data_from_inputs(args)
+    vol_img, t_mask_img, labelmap_img, mask_imgs, mask_colors = \
+        get_default_screenshotting_data(args)
 
     # Check if the screenshots can be taken
     if args.slice_ids:
         check_slice_indices(vol_img, args.axis_name, args.slice_ids)
         slice_ids = args.slice_ids
     else:
-        if args.axis_name == "axial":
-            idx = 2
-        elif args.axis_name == "coronal":
-            idx = 1
-        elif args.axis_name == "sagittal":
-            idx = 0
-        slice_ids = np.arange(vol_img.shape[idx])
+        slice_ids = np.arange(vol_img.shape[RAS_AXES[args.axis_name]])
 
     # Generate the image slices
     vol_scene_container = screenshot_slice(
@@ -209,58 +141,57 @@ def main():
         args.win_dims
     )
 
-    mask_scene_container = []
-    mask_overlay_alpha = 1.
-    if mask_img is not None:
-        if args.mask_as_contour:
-            mask_scene_container = screenshot_contour(
-                mask_img,
-                args.axis_name,
-                slice_ids,
-                args.win_dims
-            )
-        else:
-            mask_overlay_alpha = 0.7
-            mask_scene_container = screenshot_slice(
-                mask_img,
-                args.axis_name,
-                slice_ids,
-                args.win_dims
-            )
+    transparency_scene_container = []
+    if t_mask_img is not None:
+        transparency_scene_container = screenshot_slice(
+            t_mask_img, args.axis_name, slice_ids, args.win_dims)
 
     labelmap_scene_container = []
     if labelmap_img:
         labelmap_scene_container = screenshot_slice(
-            labelmap_img,
-            args.axis_name,
-            slice_ids,
-            args.win_dims
-        )
+            labelmap_img, args.axis_name, slice_ids, args.win_dims)
+
+    mask_screenshotter = screenshot_slice
+    if args.masks_as_contours:
+        mask_screenshotter = screenshot_contour
+
+    mask_overlay_scene_container, mask_overlay_colors = [], []
+    if mask_imgs is not None:
+        mask_overlay_colors = mask_colors
+        for mask_img in mask_imgs:
+             mask_overlay_scene_container.append(
+                mask_screenshotter(
+                    mask_img, args.axis_name, slice_ids, args.win_dims))
+
+        mask_overlay_scene_container = np.swapaxes(
+            mask_overlay_scene_container, 0, 1)
 
     name, ext = splitext(args.out_fname)
     names = ["{}_slice_{}{}".format(name, s, ext) for s in slice_ids]
 
     # Compose and save each slice
-    for (volume, label, contour, name) in list(
+    for (volume, trans, label, contour, name) in list(
         zip_longest(vol_scene_container,
+                    transparency_scene_container,
                     labelmap_scene_container,
-                    mask_scene_container,
+                    mask_overlay_scene_container,
                     names,
                     fillvalue=tuple())):
 
         img = compose_mosaic(
-            [volume],
-            [np.ones_like(volume) * 255],
-            args.win_dims,
-            1,
-            1,
-            vol_cmap_name=args.vol_cmap_name,
-            labelmap_cmap_name=args.labelmap_cmap_name,
-            mask_overlay_alpha=mask_overlay_alpha,
-            mask_overlay_color=[list(c // 255 for c in args.mask_color)],
+            [volume], args.win_dims, 1, 1,
+            vol_cmap_name=args.volume_cmap_name,
+            transparency_scene_container=[trans],
+            mask_overlay_scene_container=[contour],
+            mask_overlay_color=mask_overlay_colors,
+            mask_overlay_alpha=args.masks_alpha,
             labelmap_scene_container=[label],
-            mask_overlay_scene_container=[[contour]] if len(contour) else []
-        )
+            labelmap_cmap_name=args.labelmap_cmap_name,
+            labelmap_overlay_alpha=args.labelmap_alpha)
 
         # Save the snapshot
         img.save(name)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/scil_screenshot_volume.py
+++ b/scripts/scil_screenshot_volume.py
@@ -1,0 +1,192 @@
+import argparse
+
+from itertools import zip_longest
+import nibabel as nib
+import numpy as np
+from os.path import splitext
+from dipy.io.utils import is_header_compatible
+
+from scilpy.io.image import assert_same_resolution
+from scilpy.io.utils import (
+    axis_name_choices,
+    add_overwrite_arg,
+    assert_inputs_exist,
+    assert_outputs_exist
+)
+from scilpy.image.utils import check_slice_indices
+from scilpy.viz.scene_utils import (
+    compose_mosaic, screenshot_slice, screenshot_contour
+)
+
+
+def _build_arg_parser():
+
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawTextHelpFormatter
+    )
+
+    # Positional arguments
+    p.add_argument("in_vol", help="Input volume image file.")
+    p.add_argument(
+        "out_fname",
+        help="Name of the output image(s). If multiple slices are provided "
+             "(or none), their index will be append to the name "
+             "(e.g. volume.jpg, volume.png becomes "
+             "volume_slice_0.jpg, volume_slice_0.png)."
+    )
+
+    # Optional arguments
+    p.add_argument("--mask", help="Input mask image file for overlay.")
+    p.add_argument("--in_labelmap",  help="Labelmap image.")
+
+    p.add_argument('--mask_as_contour', action='store_true',
+                   help='If supplied, the creates contour '
+                        'from mask. [%(default)s].')
+    p.add_argument(
+        "--slice_ids", nargs="+", type=int, help="Slice indices to screenshot."
+    )
+    p.add_argument(
+        "--axis_name",
+        default="axial",
+        type=str,
+        choices=axis_name_choices,
+        help="Name of the axis to visualize. [%(default)s]"
+    )
+    p.add_argument(
+        "--win_dims",
+        nargs=2,
+        metavar=("WIDTH", "HEIGHT"),
+        default=(768, 768),
+        type=int,
+        help="The dimensions for the vtk window. [%(default)s]"
+    )
+    p.add_argument(
+        "--vol_cmap_name",
+        default=None,
+        help="Colormap name for the volume image data. [%(default)s]"
+    )
+    p.add_argument(
+        "--labelmap_cmap_name",
+        default="viridis",
+        help="Colormap name for the labelmap image data. [%(default)s]"
+    )
+
+    add_overwrite_arg(p)
+
+    return p
+
+
+def _parse_args(parser):
+
+    args = parser.parse_args()
+
+    inputs = []
+
+    inputs.append(args.in_vol)
+
+    if args.mask:
+        inputs.append(args.mask)
+    if args.in_labelmap:
+        inputs.append(args.in_labelmap)
+
+    assert_inputs_exist(parser, inputs)
+
+    assert_same_resolution(inputs)
+
+    return args
+
+
+def _get_data_from_inputs(args):
+
+    vol_img = nib.load(args.in_vol)
+
+    mask_img = None
+    if args.mask:
+        mask_img = nib.load(args.mask)
+
+    labelmap_img = None
+    if args.in_labelmap:
+        labelmap_img = nib.load(args.in_labelmap)
+
+    return vol_img, mask_img, labelmap_img
+
+
+def main():
+
+    parser = _build_arg_parser()
+    args = _parse_args(parser)
+
+    vol_img, mask_img, labelmap_img = _get_data_from_inputs(args)
+
+    # Check if the screenshots can be taken
+    if args.slice_ids:
+        check_slice_indices(vol_img, args.axis_name, args.slice_ids)
+        slice_ids = args.slice_ids
+    else:
+        if args.axis_name == "axial":
+            idx = 2
+        elif args.axis_name == "coronal":
+            idx = 1
+        elif args.axis_name == "sagittal":
+            idx = 0
+        slice_ids = np.arange(vol_img.shape[idx])
+
+        # Generate the images
+    vol_scene_container = screenshot_slice(
+        vol_img,
+        args.axis_name,
+        slice_ids,
+        args.win_dims
+    )
+
+    mask_scene_container = []
+    if mask_img is not None:
+        if args.mask_as_contour:
+            mask_scene_container = screenshot_contour(
+                mask_img,
+                args.axis_name,
+                slice_ids,
+                args.win_dims
+            )
+        else:
+            mask_scene_container = screenshot_slice(
+                mask_img,
+                args.axis_name,
+                slice_ids,
+                args.win_dims
+            )
+
+    labelmap_scene_container = []
+    if labelmap_img:
+        labelmap_scene_container = screenshot_slice(
+            labelmap_img,
+            args.axis_name,
+            slice_ids,
+            args.win_dims,
+        )
+
+    name, ext = splitext(args.out_fname)
+    names = ["{}_slice_{}{}".format(name, s, ext) for s in slice_ids]
+
+    # Compose the mosaic
+    for (volume, label, contour, name) in list(
+        zip_longest(vol_scene_container,
+                    labelmap_scene_container,
+                    mask_scene_container,
+                    names,
+                    fillvalue=tuple())):
+
+        img = compose_mosaic(
+            [volume],
+            [np.ones_like(volume) * 255],
+            args.win_dims,
+            1,
+            1,
+            vol_cmap_name=args.vol_cmap_name,
+            labelmap_scene_container=[label],
+            mask_contour_scene_container=[[contour]]
+        )
+
+        # Save the snapshot
+        img.save(name)

--- a/scripts/scil_screenshot_volume_mosaic_overlap.py
+++ b/scripts/scil_screenshot_volume_mosaic_overlap.py
@@ -183,8 +183,8 @@ def main():
 
     # Compose the mosaic
     img = compose_mosaic(
-        vol_scene_container, args.win_dims,
-        rows, cols, args.overlap_factor,
+        vol_scene_container, args.win_dims, rows, cols, args.slice_ids,
+        overlap_factor=args.overlap_factor,
         vol_cmap_name=args.volume_cmap_name,
         transparency_scene_container=transparency_scene_container,
         labelmap_scene_container=labelmap_scene_container,

--- a/scripts/scil_screenshot_volume_mosaic_overlap.py
+++ b/scripts/scil_screenshot_volume_mosaic_overlap.py
@@ -259,7 +259,7 @@ def main():
         cols,
         args.overlap_factor,
         labelmap_scene_container=labelmap_scene_container,
-        mask_contour_scene_container=mask_contour_scene_container,
+        mask_overlay_scene_container=mask_contour_scene_container,
         vol_cmap_name=args.vol_cmap_name,
         labelmap_cmap_name=args.labelmap_cmap_name
         )

--- a/scripts/scil_screenshot_volume_mosaic_overlap.py
+++ b/scripts/scil_screenshot_volume_mosaic_overlap.py
@@ -66,7 +66,6 @@ import argparse
 
 import nibabel as nib
 import numpy as np
-from fury.colormap import distinguishable_colormap
 
 from scilpy.io.image import assert_same_resolution
 from scilpy.io.utils import (
@@ -233,18 +232,12 @@ def main():
 
     mask_contour_scene_container = []
     if contour_imgs:
-        colors = [(255, 0, 0)]
-        if len(contour_imgs) > 1:
-            colors.extend(distinguishable_colormap(
-                exclude=[(255, 0, 0)], nb_colors=len(contour_imgs) - 1))
-
-        for img, color in zip(contour_imgs, colors):
+        for img in contour_imgs:
             mask_contour_scene_container.append(np.array(screenshot_contour(
                 img,
                 args.axis_name,
                 args.slice_ids,
-                args.win_dims,
-                color
+                args.win_dims
             )))
 
         mask_contour_scene_container = [i for i in np.swapaxes(

--- a/scripts/scil_screenshot_volume_mosaic_overlap.py
+++ b/scripts/scil_screenshot_volume_mosaic_overlap.py
@@ -6,7 +6,9 @@ Compose a mosaic of screenshots of the given image volume slices along the
 requested axis. The provided transparency mask (e.g. a brain mask volume) is
 used to set the screenshot values outside the mask non-zero values to full
 transparency. Additionally, if a labelmap image is provided (e.g. a tissue
-segmentation map), it is overlaid on the volume slices.
+segmentation map), it is overlaid on the volume slices. Also, a series of 
+masks can be provided and will be used to generate contours overlaid on each 
+volume slice.
 
 A labelmap image can be provided as the image volume, without requiring it as
 the optional argument if only the former needs to be plot.
@@ -19,14 +21,14 @@ Example:
 python scil_screenshot_volume_mosaic_overlap.py \
   t1.nii.gz \
   brain_mask.nii.gz \
-  mosaic_overlap_t1.png \
+  mosaic_overlap_t1_axial.png \
   30 40 50 60 70 80 90 100 \
   1 8
 
 python scil_screenshot_volume_mosaic_overlap.py \
   t1.nii.gz \
   brain_mask.nii.gz \
-  mosaic_overlap_t1_matrix_cmap.png \
+  mosaic_overlap_t1_axial_plasma_cmap.png \
   30 40 50 60 70 80 90 100 \
   2 4 \
   --overlap_factor 0.6 0.5 \
@@ -35,7 +37,7 @@ python scil_screenshot_volume_mosaic_overlap.py \
 python scil_screenshot_volume_mosaic_overlap.py \
   tissue_map.nii.gz \
   brain_mask.nii.gz \
-  mosaic_overlap_tissue_map.png \
+  mosaic_overlap_tissue_axial_plasma_cmap.png \
   30 40 50 60 70 80 90 100 \
   2 4 \
   --vol_cmap_name plasma
@@ -43,12 +45,21 @@ python scil_screenshot_volume_mosaic_overlap.py \
 python scil_screenshot_volume_mosaic_overlap.py \
   t1.nii.gz \
   brain_mask.nii.gz \
-  mosaic_overlap_t1_tisue_map.png \
+  mosaic_overlap_t1_sagittal_tissue_viridis_cmap.png \
   30 40 50 60 70 80 90 100 \
   2 4 \
-  --in_labelmap tissue_map.nii.gz \
   --axis_name sagittal \
+  --in_labelmap tissue_map.nii.gz \
   --labelmap_cmap_name viridis
+
+python scil_screenshot_volume_mosaic_overlap.py \
+  t1.nii.gz \
+  brain_mask.nii.gz \
+  mosaic_overlap_t1_sagittal_tissue_contours.png \
+  30 40 50 60 70 80 90 100 \
+  2 4 \
+  --axis_name sagittal \
+  --in_contour_masks wm_mask.nii.gz gm_mask.nii.gz csf_mask.nii.gz
 """
 
 import argparse
@@ -63,7 +74,7 @@ from scilpy.io.utils import (
     add_overwrite_arg,
     assert_inputs_exist,
     assert_outputs_exist,
-    ranged_type,
+    ranged_type
 )
 from scilpy.image.utils import check_slice_indices
 from scilpy.viz.scene_utils import (
@@ -202,13 +213,13 @@ def main():
         vol_img,
         args.axis_name,
         args.slice_ids,
-        args.win_dims,
+        args.win_dims
     )
     mask_scene_container = screenshot_slice(
         mask_img,
         args.axis_name,
         args.slice_ids,
-        args.win_dims,
+        args.win_dims
     )
 
     labelmap_scene_container = []
@@ -217,7 +228,7 @@ def main():
             labelmap_img,
             args.axis_name,
             args.slice_ids,
-            args.win_dims,
+            args.win_dims
         )
 
     mask_contour_scene_container = []
@@ -250,7 +261,7 @@ def main():
         labelmap_scene_container=labelmap_scene_container,
         mask_contour_scene_container=mask_contour_scene_container,
         vol_cmap_name=args.vol_cmap_name,
-        labelmap_cmap_name=args.labelmap_cmap_name,
+        labelmap_cmap_name=args.labelmap_cmap_name
         )
 
     # Save the mosaic

--- a/scripts/scil_screenshot_volume_mosaic_overlap.py
+++ b/scripts/scil_screenshot_volume_mosaic_overlap.py
@@ -66,7 +66,7 @@ from scilpy.io.utils import (
 )
 from scilpy.image.utils import check_slice_indices
 from scilpy.viz.scene_utils import (
-    check_mosaic_layout, compose_mosaic, screenshot_slice,
+    check_mosaic_layout, compose_mosaic, screenshot_contour, screenshot_slice
 )
 
 
@@ -119,6 +119,11 @@ def _build_arg_parser():
         default=(768, 768),
         type=int,
         help="The dimensions for the vtk window. [%(default)s]"
+    )
+    p.add_argument(
+        '--mask_outline',
+        action='store_true',
+        help='If supplied, the generate the data mask outline. [%(default)s].'
     )
     p.add_argument(
         "--vol_cmap_name",
@@ -222,6 +227,15 @@ def main():
             args.win_dims,
         )
 
+    mask_contour_scene_container = []
+    if args.mask_outline:
+        mask_contour_scene_container = screenshot_contour(
+            mask_img,
+            args.axis_name,
+            args.slice_ids,
+            args.win_dims
+        )
+
     # Compose the mosaic
     img = compose_mosaic(
         vol_scene_container,
@@ -231,6 +245,7 @@ def main():
         cols,
         args.overlap_factor,
         labelmap_scene_container=labelmap_scene_container,
+        mask_contour_scene_container=mask_contour_scene_container,
         vol_cmap_name=args.vol_cmap_name,
         labelmap_cmap_name=args.labelmap_cmap_name,
         )

--- a/scripts/tests/test_screenshot_volume.py
+++ b/scripts/tests/test_screenshot_volume.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+
+def test_help_option(script_runner):
+
+    ret = script_runner.run(
+        "scil_screenshot_volume.py", "--help"
+    )
+    assert ret.success


### PR DESCRIPTION
Add capabilities to display mask overlays as contour instead of transparency. Integration into mosaic overlay script and new script to create multiple screenshots from one volume. Multiple examples are provided in the scripts documentation for tests.