### PR TITLE
Unit test tractogram operations

### DIFF
--- a/scilpy/io/fetcher.py
+++ b/scilpy/io/fetcher.py
@@ -169,4 +169,5 @@ def fetch_data(files_dict, keys=None):
                                           "with a zip file.")
 
         else:
+            # toDo. Verify that data on disk is the right one.
             logging.warning("Not fetching data; already on disk.")

--- a/scilpy/tractograms/tests/tests_tractogram_operations.py
+++ b/scilpy/tractograms/tests/tests_tractogram_operations.py
@@ -1,0 +1,150 @@
+# -*- coding: utf-8 -*-
+import logging
+import os
+import tempfile
+
+import numpy as np
+from dipy.io.streamline import load_tractogram
+
+from scilpy.io.fetcher import fetch_data, get_testing_files_dict, get_home
+from scilpy.tractograms.tractogram_operations import flip_sft, \
+    shuffle_streamlines, _perform_tractogram_operation, intersection, union, \
+    difference, intersection_robust, difference_robust, union_robust, \
+    concatenate_sft, perform_tractogram_operation
+
+# Prepare SFT
+fetch_data(get_testing_files_dict(), keys='surface_vtk_fib.zip')
+tmp_dir = tempfile.TemporaryDirectory()
+in_sft = os.path.join(get_home(), 'surface_vtk_fib', 'gyri_fanning.trk')
+
+# Loading and keeping only a few streamlines for faster testing.
+sft = load_tractogram(in_sft, 'same')[0:4]
+
+# Faking data_per_streamline
+sft.data_per_streamline['test'] = [1] * len(sft)
+sft.data_per_point['test2'] = [[[1, 2, 3]] * len(s) for s in sft.streamlines]
+
+
+def test_shuffle_streamlines():
+    # Shuffling pretty straightforward, not testing.
+    # Verifying that initial SFT is not modified.
+    sft2 = shuffle_streamlines(sft)
+    assert not sft2 == sft
+
+
+def test_flip_sft():
+    # Flip x, verify that y and z are the same.
+    x, y, z = sft.streamlines[0][0]
+    sft2 = flip_sft(sft, ['x'])
+    x2, y2, z2 = sft2.streamlines[0][0]
+    assert (not x == x2) and y == y2 and z == z2
+
+    # Flip x and y, verify that z is the same.
+    sft2 = flip_sft(sft, ['x', 'y'])
+    x2, y2, z2 = sft2.streamlines[0][0]
+    assert (not x == x2) and (not y == y2) and z == z2
+
+
+def test_operations():
+    same = sft.streamlines[0]
+    different = np.asarray([[1., 0., 0.],
+                            [1., 0., 0.],
+                            [1., 0., 0.]])
+    similar = same + 0.0001
+    compared = [same, different, similar]
+
+    # Intersection: should find 2 similar.
+    output, indices = _perform_tractogram_operation(
+        intersection, [[same], compared])
+    assert len(output) == 1
+
+    # Intersection less precise. Should find 3 similar.
+    # (but can't be tested now; returns the rounded unique streamline)
+    output, indices = _perform_tractogram_operation(
+        intersection, [[same], compared], precision=1)
+    assert len(output) == 1
+
+    # Difference: A - B: should return 0
+    output, indices = _perform_tractogram_operation(
+        difference, [[same], compared])
+    assert len(output) == 0
+
+    # Difference: B - A: should return 2
+    output, indices = _perform_tractogram_operation(
+        difference, [compared, [same]])
+    assert len(output) == 2
+
+    # Difference: B - A less precise: should return 1
+    output, indices = _perform_tractogram_operation(
+        difference, [compared, [same]], precision=1)
+    assert len(output) == 1
+
+    # Union: should combine the two same,
+    output, indices = _perform_tractogram_operation(
+        union, [[same], compared])
+    assert len(output) == 3
+
+    # Union less precise: should combine the similar too
+    output, indices = _perform_tractogram_operation(
+        union, [[same], compared], precision=1)
+    assert len(output) == 2
+
+
+def test_robust_operations():
+
+    # Recommended in scil_tractogram_math: use precision 0 to manage shifted
+    # tractograms. Testing here.
+    precision_shifted = 0
+
+    same = sft.streamlines[0]
+    shifted_same = same.copy() + 0.5
+    different = np.asarray([[1., 0., 0.],
+                            [1., 0., 0.],
+                            [1., 0., 0.]])
+    compared = [same, shifted_same, different]
+
+    # Intersection: same/shifted
+    output, indices = _perform_tractogram_operation(
+        intersection_robust, [[same], compared], precision=precision_shifted)
+    assert np.array_equal(indices, [0])
+    assert len(output) == 1
+
+    # Difference: different
+    output, indices = _perform_tractogram_operation(
+        difference_robust, [compared, [same]], precision=precision_shifted)
+    logging.warning(indices)
+    assert np.array_equal(indices, [2])
+    assert len(output) == 1
+
+    # Union: 4 (different, similar/same/shited)
+    output, indices = _perform_tractogram_operation(
+        union_robust, [compared, [same]], precision=precision_shifted)
+    logging.warning(indices)
+    assert len(output) == 2
+    assert (indices == [0, 2]).all()
+
+
+def test_concatenate_sft():
+    # Testing with different metadata
+    sft2 = sft.from_sft(sft.streamlines, sft)
+    sft2.data_per_point['test2_different'] = [[['a', 'b', 'c']] * len(s)
+                                              for s in sft.streamlines]
+
+    failed = False
+    try:
+        total = concatenate_sft([sft, sft2])
+    except ValueError:
+        failed = True
+    assert failed
+
+    total = concatenate_sft([sft, sft])
+    assert len(total) == len(sft) * 2
+    assert len(total.data_per_streamline['test']) == 2 * len(sft)
+    assert len(total.data_per_point['test2']) == 2 * len(sft)
+
+
+def test_combining_sft():
+    # todo
+    perform_tractogram_operation('union', [sft, sft], precision=None,
+                                 fake_metadata=False, no_metadata=False)
+

--- a/scilpy/tractograms/tractogram_operations.py
+++ b/scilpy/tractograms/tractogram_operations.py
@@ -191,10 +191,6 @@ def perform_tractogram_operation(op_name, sft_list, precision,
         OPERATIONS[op_name], streamlines_list, precision=precision)
 
     # Concatenating only the necessary streamlines, with the metadata
-    sft_list = [sft for sft in sft_list if len(sft) > 0]
-    cum_nb_str = np.cumsum([len(sft.streamlines) for sft in sft_list])
-    cum_nb_str_0 = np.insert(cum_nb_str, 0, 0)
-
     indices_per_sft = []
     streamlines_len_cumsum = [len(sft) for sft in sft_list]
     start = 0

--- a/scripts/scil_tractogram_math.py
+++ b/scripts/scil_tractogram_math.py
@@ -27,11 +27,11 @@ threshold for similarity. A precision of 1 represents 10**(-1), so a
 maximum distance of 0.1mm is allowed. If the streamlines are identical, the
 default value of 3 (or 0.001mm distance) should work.
 
-If there is a 0.5mm shift, use a precision of 0 (or 1mm distance) the --robust
+If there is a 0.5mm shift, use a precision of 0 (or 1mm distance), the --robust
 option should make it work, but slightly slower.
 
 The metadata (data per point, data per streamline) of the streamlines that
-are kept in the output will preserved. This requires that all input files
+are kept in the output will be preserved. This requires that all input files
 share the same type of metadata. If this is not the case, use the option
 --no_metadata to strip the metadata from the output. Or --fake_metadata to
 initialize dummy metadata in the file missing them.
@@ -78,7 +78,9 @@ def _build_arg_parser():
         formatter_class=argparse.RawTextHelpFormatter,
         description=__doc__)
 
-    p.add_argument('operation', choices=OPERATIONS.keys(), metavar='OPERATION',
+    p.add_argument('operation', metavar='OPERATION',
+                   choices=['difference', 'intersection', 'union',
+                            'concatenate', 'lazy_concatenate'],
                    help='The type of operation to be performed on the '
                         'streamlines. Must\nbe one of the following: '
                         '%(choices)s.')

--- a/scripts/tests/test_compute_pca.py
+++ b/scripts/tests/test_compute_pca.py
@@ -13,8 +13,7 @@ tmp_dir = tempfile.TemporaryDirectory()
 
 
 def test_help_option(script_runner):
-    ret = script_runner.run('scil_compute_pca.py',
-                            '--help')
+    ret = script_runner.run('scil_compute_pca.py', '--help')
     assert ret.success
 
 
@@ -22,9 +21,9 @@ def test_execution_pca(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
     input_folder = os.path.join(get_home(), 'stats/pca')
     output_folder = os.path.join(get_home(), 'stats/pca_out')
-    ids = os.path.join(get_home(), 'stats/pca',
-                       'list_id.txt')
-    ret = script_runner.run('scil_compute_pca.py', input_folder, output_folder, '--metrics', 'ad',
-                            'fa', 'md', 'rd', 'nufo', 'afd_total', 'afd_fixel', '--list_ids',
-                            ids, '-f')
+    ids = os.path.join(get_home(), 'stats/pca', 'list_id.txt')
+    ret = script_runner.run(
+        'scil_compute_pca.py', input_folder, output_folder, '--metrics', 'ad',
+        'fa', 'md', 'rd', 'nufo', 'afd_total', 'afd_fixel', '--list_ids',
+        ids, '-f')
     assert ret.success

--- a/scripts/tests/test_tractogram_math.py
+++ b/scripts/tests/test_tractogram_math.py
@@ -9,6 +9,7 @@ from scilpy.io.fetcher import fetch_data, get_home, get_testing_files_dict
 # If they already exist, this only takes 5 seconds (check md5sum)
 fetch_data(get_testing_files_dict(), keys=['others.zip'])
 tmp_dir = tempfile.TemporaryDirectory()
+trk_path = os.path.join(get_home(), 'others')
 
 
 def test_help_option(script_runner):
@@ -18,10 +19,8 @@ def test_help_option(script_runner):
 
 def test_execution_lazy_concatenate_no_color(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
-    in_tracto_1 = os.path.join(get_home(), 'others',
-                               'fibercup_bundles.trk')
-    in_tracto_2 = os.path.join(get_home(), 'others',
-                               'fibercup_bundle_0.trk')
+    in_tracto_1 = os.path.join(trk_path, 'fibercup_bundles.trk')
+    in_tracto_2 = os.path.join(trk_path, 'fibercup_bundle_0.trk')
     ret = script_runner.run('scil_tractogram_math.py', 'lazy_concatenate',
                             in_tracto_1, in_tracto_2,
                             'lazy_concatenate.trk')
@@ -30,10 +29,8 @@ def test_execution_lazy_concatenate_no_color(script_runner):
 
 def test_execution_lazy_concatenate_mix(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
-    in_tracto_1 = os.path.join(get_home(), 'others',
-                               'fibercup_bundles_color.trk')
-    in_tracto_2 = os.path.join(get_home(), 'others',
-                               'fibercup_bundle_0.trk')
+    in_tracto_1 = os.path.join(trk_path, 'fibercup_bundles_color.trk')
+    in_tracto_2 = os.path.join(trk_path, 'fibercup_bundle_0.trk')
     ret = script_runner.run('scil_tractogram_math.py', 'lazy_concatenate',
                             in_tracto_1, in_tracto_2,
                             'lazy_concatenate_mix.trk')
@@ -42,10 +39,8 @@ def test_execution_lazy_concatenate_mix(script_runner):
 
 def test_execution_union_no_color(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
-    in_tracto_1 = os.path.join(get_home(), 'others',
-                               'fibercup_bundles.trk')
-    in_tracto_2 = os.path.join(get_home(), 'others',
-                               'fibercup_bundle_0.trk')
+    in_tracto_1 = os.path.join(trk_path, 'fibercup_bundles.trk')
+    in_tracto_2 = os.path.join(trk_path, 'fibercup_bundle_0.trk')
     ret = script_runner.run('scil_tractogram_math.py', 'union',
                             in_tracto_1, in_tracto_2, 'union.trk')
     assert ret.success
@@ -53,10 +48,8 @@ def test_execution_union_no_color(script_runner):
 
 def test_execution_intersection_no_color(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
-    in_tracto_1 = os.path.join(get_home(), 'others',
-                               'fibercup_bundles.trk')
-    in_tracto_2 = os.path.join(get_home(), 'others',
-                               'fibercup_bundle_0.trk')
+    in_tracto_1 = os.path.join(trk_path, 'fibercup_bundles.trk')
+    in_tracto_2 = os.path.join(trk_path, 'fibercup_bundle_0.trk')
     ret = script_runner.run('scil_tractogram_math.py', 'intersection',
                             in_tracto_1, in_tracto_2, 'intersection.trk')
     assert ret.success
@@ -64,10 +57,8 @@ def test_execution_intersection_no_color(script_runner):
 
 def test_execution_difference_no_color(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
-    in_tracto_1 = os.path.join(get_home(), 'others',
-                               'fibercup_bundles.trk')
-    in_tracto_2 = os.path.join(get_home(), 'others',
-                               'fibercup_bundle_0.trk')
+    in_tracto_1 = os.path.join(trk_path, 'fibercup_bundles.trk')
+    in_tracto_2 = os.path.join(trk_path, 'fibercup_bundle_0.trk')
     ret = script_runner.run('scil_tractogram_math.py', 'difference',
                             in_tracto_1, in_tracto_2, 'difference.trk')
     assert ret.success
@@ -75,10 +66,8 @@ def test_execution_difference_no_color(script_runner):
 
 def test_execution_concatenate_no_color(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
-    in_tracto_1 = os.path.join(get_home(), 'others',
-                               'fibercup_bundles.trk')
-    in_tracto_2 = os.path.join(get_home(), 'others',
-                               'fibercup_bundle_0.trk')
+    in_tracto_1 = os.path.join(trk_path, 'fibercup_bundles.trk')
+    in_tracto_2 = os.path.join(trk_path, 'fibercup_bundle_0.trk')
     ret = script_runner.run('scil_tractogram_math.py', 'concatenate',
                             in_tracto_1, in_tracto_2, 'concatenate.trk')
     assert ret.success
@@ -86,10 +75,8 @@ def test_execution_concatenate_no_color(script_runner):
 
 def test_execution_union_no_color_robust(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
-    in_tracto_1 = os.path.join(get_home(), 'others',
-                               'fibercup_bundles.trk')
-    in_tracto_2 = os.path.join(get_home(), 'others',
-                               'fibercup_bundle_0.trk')
+    in_tracto_1 = os.path.join(trk_path, 'fibercup_bundles.trk')
+    in_tracto_2 = os.path.join(trk_path, 'fibercup_bundle_0.trk')
     ret = script_runner.run('scil_tractogram_math.py', 'union',
                             in_tracto_1, in_tracto_2, 'union_r.trk',
                             '--robust')
@@ -98,10 +85,8 @@ def test_execution_union_no_color_robust(script_runner):
 
 def test_execution_intersection_no_color_robust(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
-    in_tracto_1 = os.path.join(get_home(), 'others',
-                               'fibercup_bundles.trk')
-    in_tracto_2 = os.path.join(get_home(), 'others',
-                               'fibercup_bundle_0.trk')
+    in_tracto_1 = os.path.join(trk_path, 'fibercup_bundles.trk')
+    in_tracto_2 = os.path.join(trk_path, 'fibercup_bundle_0.trk')
     ret = script_runner.run('scil_tractogram_math.py', 'intersection',
                             in_tracto_1, in_tracto_2, 'intersection_r.trk',
                             '--robust')
@@ -110,10 +95,8 @@ def test_execution_intersection_no_color_robust(script_runner):
 
 def test_execution_difference_no_color_robust(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
-    in_tracto_1 = os.path.join(get_home(), 'others',
-                               'fibercup_bundles.trk')
-    in_tracto_2 = os.path.join(get_home(), 'others',
-                               'fibercup_bundle_0.trk')
+    in_tracto_1 = os.path.join(trk_path, 'fibercup_bundles.trk')
+    in_tracto_2 = os.path.join(trk_path, 'fibercup_bundle_0.trk')
     ret = script_runner.run('scil_tractogram_math.py', 'difference',
                             in_tracto_1, in_tracto_2, 'difference_r.trk',
                             '--robust')
@@ -122,10 +105,8 @@ def test_execution_difference_no_color_robust(script_runner):
 
 def test_execution_union_color(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
-    in_tracto_1 = os.path.join(get_home(), 'others',
-                               'fibercup_bundles_color.trk')
-    in_tracto_2 = os.path.join(get_home(), 'others',
-                               'fibercup_bundle_0_color.trk')
+    in_tracto_1 = os.path.join(trk_path, 'fibercup_bundles_color.trk')
+    in_tracto_2 = os.path.join(trk_path, 'fibercup_bundle_0_color.trk')
     ret = script_runner.run('scil_tractogram_math.py', 'union',
                             in_tracto_1, in_tracto_2, 'union_color.trk')
     assert ret.success
@@ -133,10 +114,8 @@ def test_execution_union_color(script_runner):
 
 def test_execution_intersection_color(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
-    in_tracto_1 = os.path.join(get_home(), 'others',
-                               'fibercup_bundles_color.trk')
-    in_tracto_2 = os.path.join(get_home(), 'others',
-                               'fibercup_bundle_0_color.trk')
+    in_tracto_1 = os.path.join(trk_path, 'fibercup_bundles_color.trk')
+    in_tracto_2 = os.path.join(trk_path, 'fibercup_bundle_0_color.trk')
     ret = script_runner.run('scil_tractogram_math.py', 'intersection',
                             in_tracto_1, in_tracto_2, 'intersection_color.trk')
     assert ret.success
@@ -144,10 +123,8 @@ def test_execution_intersection_color(script_runner):
 
 def test_execution_difference_color(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
-    in_tracto_1 = os.path.join(get_home(), 'others',
-                               'fibercup_bundles_color.trk')
-    in_tracto_2 = os.path.join(get_home(), 'others',
-                               'fibercup_bundle_0_color.trk')
+    in_tracto_1 = os.path.join(trk_path, 'fibercup_bundles_color.trk')
+    in_tracto_2 = os.path.join(trk_path, 'fibercup_bundle_0_color.trk')
     ret = script_runner.run('scil_tractogram_math.py', 'difference',
                             in_tracto_1, in_tracto_2, 'difference_color.trk')
     assert ret.success
@@ -155,10 +132,8 @@ def test_execution_difference_color(script_runner):
 
 def test_execution_concatenate_color(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
-    in_tracto_1 = os.path.join(get_home(), 'others',
-                               'fibercup_bundles_color.trk')
-    in_tracto_2 = os.path.join(get_home(), 'others',
-                               'fibercup_bundle_0_color.trk')
+    in_tracto_1 = os.path.join(trk_path, 'fibercup_bundles_color.trk')
+    in_tracto_2 = os.path.join(trk_path, 'fibercup_bundle_0_color.trk')
     ret = script_runner.run('scil_tractogram_math.py', 'concatenate',
                             in_tracto_1, in_tracto_2, 'concatenate_color.trk')
     assert ret.success
@@ -167,10 +142,8 @@ def test_execution_concatenate_color(script_runner):
 def test_execution_union_mix(script_runner):
     # This is intentionally failing
     os.chdir(os.path.expanduser(tmp_dir.name))
-    in_tracto_1 = os.path.join(get_home(), 'others',
-                               'fibercup_bundles_color.trk')
-    in_tracto_2 = os.path.join(get_home(), 'others',
-                               'fibercup_bundle_0.trk')
+    in_tracto_1 = os.path.join(trk_path, 'fibercup_bundles_color.trk')
+    in_tracto_2 = os.path.join(trk_path, 'fibercup_bundle_0.trk')
     ret = script_runner.run('scil_tractogram_math.py', 'union',
                             in_tracto_1, in_tracto_2, 'union_mix.trk')
     assert not ret.success
@@ -178,10 +151,8 @@ def test_execution_union_mix(script_runner):
 
 def test_execution_intersection_mix_fake(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
-    in_tracto_1 = os.path.join(get_home(), 'others',
-                               'fibercup_bundles_color.trk')
-    in_tracto_2 = os.path.join(get_home(), 'others',
-                               'fibercup_bundle_0.trk')
+    in_tracto_1 = os.path.join(trk_path, 'fibercup_bundles_color.trk')
+    in_tracto_2 = os.path.join(trk_path, 'fibercup_bundle_0.trk')
     ret = script_runner.run('scil_tractogram_math.py', 'intersection',
                             in_tracto_1, in_tracto_2, 'intersection_mix.trk',
                             '--fake_metadata')
@@ -190,10 +161,8 @@ def test_execution_intersection_mix_fake(script_runner):
 
 def test_execution_difference_empty_result(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
-    in_tracto_1 = os.path.join(get_home(), 'others',
-                               'fibercup_bundle_0.trk')
-    in_tracto_2 = os.path.join(get_home(), 'others',
-                               'fibercup_bundle_0_color.trk')
+    in_tracto_1 = os.path.join(trk_path, 'fibercup_bundle_0.trk')
+    in_tracto_2 = os.path.join(trk_path, 'fibercup_bundle_0_color.trk')
     ret = script_runner.run('scil_tractogram_math.py', 'difference',
                             in_tracto_1, in_tracto_2,
                             'difference_empty_results.trk', '--no_metadata')
@@ -202,10 +171,8 @@ def test_execution_difference_empty_result(script_runner):
 
 def test_execution_difference_empty_input_1(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
-    in_tracto_1 = os.path.join(get_home(), 'others',
-                               'empty.trk')
-    in_tracto_2 = os.path.join(get_home(), 'others',
-                               'fibercup_bundle_0_color.trk')
+    in_tracto_1 = os.path.join(trk_path, 'empty.trk')
+    in_tracto_2 = os.path.join(trk_path, 'fibercup_bundle_0_color.trk')
     ret = script_runner.run('scil_tractogram_math.py', 'difference',
                             in_tracto_1, in_tracto_2, 'difference_empty_1.trk',
                             '--no_metadata')
@@ -214,10 +181,8 @@ def test_execution_difference_empty_input_1(script_runner):
 
 def test_execution_difference_empty_input_2(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
-    in_tracto_1 = os.path.join(get_home(), 'others',
-                               'fibercup_bundle_0_color.trk')
-    in_tracto_2 = os.path.join(get_home(), 'others',
-                               'empty.trk')
+    in_tracto_1 = os.path.join(trk_path, 'fibercup_bundle_0_color.trk')
+    in_tracto_2 = os.path.join(trk_path, 'empty.trk')
     ret = script_runner.run('scil_tractogram_math.py', 'difference',
                             in_tracto_1, in_tracto_2, 'difference_empty_2.trk',
                             '--no_metadata')


### PR DESCRIPTION
[WIP] Need to check if other tests are needed.

Some fixes from testing:

- In the script scil_tractogram_math: to use a robust operation, you're supposed to send operation 'difference' and option --robust. But if you send operation 'difference_robust', it was accepted. You could end up with operation 'difference_robust_robust'. Modifying accepted operations in argparser.

- If you want to do, example, intersection of many big files: it was concatenating all files (doubling eveything in memory) and then keeping only the few accepted streamlines. Inversing: First filtering the sft, (freeing memory), then concatenating. Encapsulated that step out of the main code to be able to test it.

- Robust intersection seemed buggy to me.  Lines `if not union_mode or not difference_mode` are always true, so this was not correctly testing that we are doing intersection_mode. It should have been AND. Also changed a bit the code to make it clearer, but plase double-check me.

Unit tests passing locally, not sure why the deploy step doesn't work here.