### PR TITLE
Adding import matplotlib to assign_custom_color_to_tractogram

### DIFF
--- a/scripts/scil_assign_custom_color_to_tractogram.py
+++ b/scripts/scil_assign_custom_color_to_tractogram.py
@@ -42,6 +42,7 @@ import logging
 from dipy.io.streamline import save_tractogram
 import nibabel as nib
 import numpy as np
+import matplotlib.pyplot as plt
 from scipy.ndimage import map_coordinates
 
 from scilpy.io.streamlines import load_tractogram_with_reference


### PR DESCRIPTION
Somehow `import matplotlib.pyplot as plt` was removed from the `scil_assign_custom_color_to_tractogram.py` script, so the `save_colorbar` function did not work. I guess that the colorbar option is rarely used so that went under the radar...

Fixed it!

@frheault 