### PR TITLE
ENH: Verbose tracking

### DIFF
--- a/scilpy/tracking/tracker.py
+++ b/scilpy/tracking/tracker.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from contextlib import nullcontext
 import itertools
 import logging
 import multiprocessing
@@ -265,7 +266,7 @@ class Tracker(object):
         self.propagator.reset_data(np.load(
             init_args['data_file_name'], mmap_mode=init_args['mmap_mode']))
 
-    def _get_streamlines(self, chunk_id, lock):
+    def _get_streamlines(self, chunk_id, lock=None):
         """
         Tracks the n streamlines associates with current process (identified by
         chunk_id). The number n is the total number of seeds / the number of
@@ -277,7 +278,8 @@ class Tracker(object):
         chunk_id: int
             This process ID.
         lock: Lock
-            The multiprocessing lock
+            The multiprocessing lock for verbose printing (optional with
+            single processing).
 
         Returns
         -------
@@ -303,6 +305,8 @@ class Tracker(object):
         tqdm_text = "#" + "{}".format(chunk_id).zfill(3)
 
         if self.verbose:
+            if lock is None:
+                lock = nullcontext()
             with lock:
                 # Note. Option miniters does not work with manual pbar update.
                 # Will verify manually, lower.

--- a/scilpy/tracking/tracker.py
+++ b/scilpy/tracking/tracker.py
@@ -561,7 +561,7 @@ class GPUTacker():
         # Convert theta to cos(theta)
         max_cos_theta = np.cos(np.deg2rad(self.theta))
 
-        cl_kernel = CLKernel('main', 'tracking', 'local_tracking.cl')
+        cl_kernel = CLKernel('tracker', 'tracking', 'local_tracking.cl')
 
         # Set tracking parameters
         cl_kernel.set_define('IM_X_DIM', self.sh.shape[0])

--- a/scilpy/tracking/tracker.py
+++ b/scilpy/tracking/tracker.py
@@ -8,6 +8,7 @@ from tempfile import TemporaryDirectory
 from time import perf_counter
 import traceback
 from typing import Union
+from tqdm import tqdm
 
 import numpy as np
 from dipy.data import get_sphere
@@ -32,8 +33,8 @@ class Tracker(object):
                  seed_generator: SeedGenerator, nbr_seeds, min_nbr_pts,
                  max_nbr_pts, max_invalid_dirs, compression_th=0.1,
                  nbr_processes=1, save_seeds=False,
-                 mmap_mode: Union[str, None] = None,
-                 rng_seed=1234, track_forward_only=False, skip=0):
+                 mmap_mode: Union[str, None] = None, rng_seed=1234,
+                 track_forward_only=False, skip=0, verbose=False):
         """
         Parameters
         ----------
@@ -74,6 +75,8 @@ class Tracker(object):
             tractogram with a fixed rng_seed. Ex: If tractogram_1 was created
             with nbr_seeds=1,000,000, you can create tractogram_2 with
             skip 1,000,000.
+        verbose: bool
+            Display tracking progression.
         """
         self.propagator = propagator
         self.mask = mask
@@ -113,6 +116,7 @@ class Tracker(object):
         self.nbr_processes = self._set_nbr_processes(nbr_processes)
 
         self.printing_frequency = 1000
+        self.verbose = verbose
 
     def track(self):
         """
@@ -133,11 +137,14 @@ class Tracker(object):
             # Each process will use get_streamlines_at_seeds
             chunk_ids = np.arange(self.nbr_processes)
             with TemporaryDirectory() as tmpdir:
+                # Lock for logging
+                lock = multiprocessing.Manager().Lock()
+                zipped_chunks = zip(chunk_ids, [lock] * self.nbr_processes)
 
                 pool = self._prepare_multiprocessing_pool(tmpdir)
 
                 lines_per_process, seeds_per_process = zip(*pool.map(
-                    self._get_streamlines_sub, chunk_ids))
+                    self._get_streamlines_sub, zipped_chunks))
                 pool.close()
                 # Make sure all worker processes have exited before leaving
                 # context manager.
@@ -216,7 +223,7 @@ class Tracker(object):
         multiprocess_init_args = init_args
         return
 
-    def _get_streamlines_sub(self, chunk_id):
+    def _get_streamlines_sub(self, params):
         """
         multiprocessing.pool.map input function. Calls the main tracking
         method (_get_streamlines) with correct initialization arguments
@@ -224,19 +231,21 @@ class Tracker(object):
 
         Parameters
         ----------
-        chunk_id: int
-            This processes's id.
+        params: Tuple[chunk_id, Lock]
+            chunk_id: int, this processes's id.
+            Lock: the multiprocessing lock.
 
         Return
         -------
         lines: list
             List of list of 3D positions (streamlines).
         """
+        chunk_id, lock = params
         global multiprocess_init_args
 
         self._reload_data_for_new_process(multiprocess_init_args)
         try:
-            streamlines, seeds = self._get_streamlines(chunk_id)
+            streamlines, seeds = self._get_streamlines(chunk_id, lock)
             return streamlines, seeds
         except Exception as e:
             logging.error("Operation _get_streamlines_sub() failed.")
@@ -256,7 +265,7 @@ class Tracker(object):
         self.propagator.reset_data(np.load(
             init_args['data_file_name'], mmap_mode=init_args['mmap_mode']))
 
-    def _get_streamlines(self, chunk_id):
+    def _get_streamlines(self, chunk_id, lock):
         """
         Tracks the n streamlines associates with current process (identified by
         chunk_id). The number n is the total number of seeds / the number of
@@ -267,6 +276,8 @@ class Tracker(object):
         ----------
         chunk_id: int
             This process ID.
+        lock: Lock
+            The multiprocessing lock
 
         Returns
         -------
@@ -289,11 +300,19 @@ class Tracker(object):
             chunk_size += self.nbr_seeds % self.nbr_processes
 
         # Getting streamlines
-        for s in range(chunk_size):
-            if s % self.printing_frequency == 0:
-                logging.info("Process {} (id {}): {} / {}"
-                             .format(chunk_id, os.getpid(), s, chunk_size))
+        tqdm_text = "#" + "{}".format(chunk_id).zfill(3)
 
+        if self.verbose:
+            with lock:
+                # Note. Option miniters does not work with manual pbar update.
+                # Will verify manually, lower.
+                # Fixed choice of value rather than a percentage of the chunk
+                # size because our tracker is quite slow.
+                miniters = 100
+                p = tqdm(total=chunk_size, desc=tqdm_text, position=chunk_id+1,
+                         leave=False)
+
+        for s in range(chunk_size):
             seed = self.seed_generator.get_next_pos(
                 random_generator, indices, first_seed_of_chunk + s)
 
@@ -319,6 +338,13 @@ class Tracker(object):
                 if self.save_seeds:
                     seeds.append(np.asarray(seed, dtype='float32'))
 
+            if self.verbose and (s + 1) % miniters == 0:
+                with lock:
+                    p.update(miniters)
+
+        if self.verbose:
+            with lock:
+                p.close()
         return streamlines, seeds
 
     def _get_line_both_directions(self, seeding_pos):
@@ -535,7 +561,7 @@ class GPUTacker():
         # Convert theta to cos(theta)
         max_cos_theta = np.cos(np.deg2rad(self.theta))
 
-        cl_kernel = CLKernel('tracker', 'tracking', 'local_tracking.cl')
+        cl_kernel = CLKernel('main', 'tracking', 'local_tracking.cl')
 
         # Set tracking parameters
         cl_kernel.set_define('IM_X_DIM', self.sh.shape[0])

--- a/scripts/scil_compute_local_tracking.py
+++ b/scripts/scil_compute_local_tracking.py
@@ -251,16 +251,14 @@ def main():
         filtered_streamlines, seeds = \
             zip(*((s, p) for s, p in tqdm_if_verbose(
                 streamlines_generator, verbose=args.verbose,
-                total=total_nb_seeds, ncols=100,
-                miniters=int(total_nb_seeds / 100))
+                total=total_nb_seeds, miniters=int(total_nb_seeds / 100))
                   if scaled_min_length <= length(s) <= scaled_max_length))
         data_per_streamlines = {'seeds': lambda: seeds}
     else:
         filtered_streamlines = \
             (s for s in tqdm_if_verbose(
                 streamlines_generator, verbose=args.verbose,
-                total=total_nb_seeds, ncols=100,
-                miniters=int(total_nb_seeds / 100))
+                total=total_nb_seeds, miniters=int(total_nb_seeds / 100))
              if scaled_min_length <= length(s) <= scaled_max_length)
         data_per_streamlines = {}
 

--- a/scripts/scil_compute_local_tracking.py
+++ b/scripts/scil_compute_local_tracking.py
@@ -170,6 +170,7 @@ def main():
     verify_compression_th(args.compress)
     verify_seed_options(parser, args)
 
+    logging.debug("Loading masks and finding seeds.")
     mask_img = nib.load(args.in_mask)
     mask_data = get_data_as_mask(mask_img, dtype=bool)
 
@@ -211,6 +212,7 @@ def main():
         random_seed=args.seed)
 
     # Tracking is performed in voxel space
+    logging.debug("Starting tracking.")
     max_steps = int(args.max_length / args.step_size) + 1
     streamlines_generator = LocalTracking(
         _get_direction_getter(args),
@@ -255,6 +257,7 @@ def main():
     header = create_tractogram_header(filetype, *reference)
 
     # Use generator to save the streamlines on-the-fly
+    logging.debug("Results will be saved in {}".format(args.out_tractogram))
     nib.streamlines.save(tractogram, args.out_tractogram, header=header)
 
 

--- a/scripts/scil_compute_local_tracking.py
+++ b/scripts/scil_compute_local_tracking.py
@@ -34,8 +34,10 @@ from dipy.tracking.stopping_criterion import BinaryStoppingCriterion
 from dipy.tracking.streamlinespeed import length, compress_streamlines
 from dipy.tracking import utils as track_utils
 import nibabel as nib
+from nibabel.streamlines import detect_format, TrkFile
 from nibabel.streamlines.tractogram import LazyTractogram
 import numpy as np
+from tqdm import tqdm
 
 from scilpy.reconst.utils import (find_order_from_nb_coeff,
                                   get_b_matrix, get_maximas)
@@ -169,6 +171,14 @@ def main():
     verify_streamline_length_options(parser, args)
     verify_compression_th(args.compress)
     verify_seed_options(parser, args)
+
+    tracts_format = detect_format(args.out_tractogram)
+    if tracts_format is not TrkFile:
+        logging.warning("You have selected option --save_seeds but you are "
+                        "not saving your tractogram as a .trk file. \n"
+                        "Data_per_point information CANNOT be saved.\n"
+                        "Ignoring.")
+        args.save_seeds = False
 
     logging.debug("Loading masks and finding seeds.")
     mask_img = nib.load(args.in_mask)

--- a/scripts/scil_compute_local_tracking_dev.py
+++ b/scripts/scil_compute_local_tracking_dev.py
@@ -234,7 +234,7 @@ def main():
                       save_seeds=args.save_seeds,
                       mmap_mode='r+', rng_seed=args.rng_seed,
                       track_forward_only=args.forward_only,
-                      skip=args.skip)
+                      skip=args.skip, verbose=args.verbose)
 
     start = time.time()
     logging.debug("Tracking...")

--- a/scripts/scil_compute_local_tracking_dev.py
+++ b/scripts/scil_compute_local_tracking_dev.py
@@ -53,6 +53,7 @@ from dipy.io.stateful_tractogram import StatefulTractogram, Space, \
                                         set_sft_logger_level
 from dipy.io.stateful_tractogram import Origin
 from dipy.io.streamline import save_tractogram
+from nibabel.streamlines import detect_format, TrkFile
 
 from scilpy.io.image import assert_same_resolution
 from scilpy.io.utils import (add_processes_arg, add_sphere_arg,
@@ -151,6 +152,14 @@ def main():
     verify_streamline_length_options(parser, args)
     verify_compression_th(args.compress)
     verify_seed_options(parser, args)
+
+    tracts_format = detect_format(args.out_tractogram)
+    if tracts_format is not TrkFile:
+        logging.warning("You have selected option --save_seeds but you are "
+                        "not saving your tractogram as a .trk file. \n"
+                        "Data_per_point information CANNOT be saved.\n"
+                        "Ignoring.")
+        args.save_seeds = False
 
     theta = gm.math.radians(get_theta(args.theta, args.algo))
 


### PR DESCRIPTION
Just for a better user experience. Previously, option -v in scil_compute_local_tracking did not output any verbose at all. No way to know if the code has even started.

Using TQDM, with a refresh rate of 1% of the total number of seeds (only with option -v).

Also sneeking in a verification of the format with save_seed option.

Example of output:
![image](https://user-images.githubusercontent.com/4967417/234333879-f8bb09cb-90a0-4201-a639-21e5025a8592.png)
