### PR TITLE
Adding options for normalization in scil_assign_custom_color_to_tractogram

### DIFF
--- a/scripts/scil_assign_custom_color_to_tractogram.py
+++ b/scripts/scil_assign_custom_color_to_tractogram.py
@@ -133,8 +133,8 @@ def transform_data(args, data):
         data[data > 0] = np.log10(data[data > 0])
 
     # normalize data between 0 and 1
-    data -= np.min(data)
-    data = data / np.max(data) if np.max(data) > 0 else data
+    data -= lbound
+    data = data / ubound if ubound > 0 else data
     return data, lbound, ubound
 
 

--- a/scripts/scil_assign_custom_color_to_tractogram.py
+++ b/scripts/scil_assign_custom_color_to_tractogram.py
@@ -102,6 +102,10 @@ def _build_arg_parser():
                     help='Set the minimum value when using dps/dpp/anatomy.')
     g2.add_argument('--max_range', type=float,
                     help='Set the maximum value when using dps/dpp/anatomy.')
+    g2.add_argument('--min_cmap', type=float,
+                    help='Set the minimum value of the colormap.')
+    g2.add_argument('--max_cmap', type=float,
+                    help='Set the maximum value of the colormap.')
     g2.add_argument('--log', action='store_true',
                     help='Apply a base 10 logarithm for colored trk (dps/dpp).')
     g2.add_argument('--LUT', metavar='FILE',
@@ -126,8 +130,14 @@ def transform_data(args, data):
         data = np.clip(data, args.min_range, args.max_range)
 
     # get data values range
-    lbound = np.min(data)
-    ubound = np.max(data)
+    if args.min_cmap is not None:
+        lbound = args.min_cmap
+    else:
+        lbound = np.min(data)
+    if args.max_cmap is not None:
+        ubound = args.max_cmap
+    else:
+        ubound = np.max(data)
 
     if args.log:
         data[data > 0] = np.log10(data[data > 0])


### PR DESCRIPTION
Here is a small fix from Stan to add some options for manually choosing the colormap bounds in `scil_assign_custom_color_to_tractogram.py`. @frheault 

Added note : Stanislas also tested these changes on his setup and it works.