### PR TITLE
BUG: Allow tractogram math script to run as such

### DIFF
--- a/scripts/scil_tractogram_math.py
+++ b/scripts/scil_tractogram_math.py
@@ -187,3 +187,7 @@ def main():
                                                        args.out_tractogram))
     save_tractogram(new_sft[indices], args.out_tractogram,
                     bbox_valid_check=args.bbox_check)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Allow tractogram math script to run as such: without the
```
if __name__ == "__main__":
    main()
```

block, the script does simply not call `main` and does not perform any computation.