### PR TITLE
Working Scilpy development container for VS Code

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+{
+    "name": "Scilpy development container",
+    "image": "scilus/scilus:latest",
+    "forwardPorts": [3000],
+    "workspaceMount": "source=${localWorkspaceFolder},target=/scilpy,type=bind,consistency=cached",
+    "workspaceFolder": "/scilpy",
+    "onCreateCommand": "bash .devcontainer/setup_container.sh",
+    "features": {
+        "ghcr.io/devcontainers/features/git:1": {},
+        "ghcr.io/devcontainers/features/github-cli:1": {},
+        "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "GitHub.vscode-pull-request-github",
+                "ms-azuretools.vscode-docker",
+                "ms-python.isort",
+                "ms-python.vscode-pylance",
+                "ms-vscode.cmake-tools",
+                "ms-vscode.cpptools",
+                "ms-vscode.cpptools-extension-pack",
+                "ms-vscode.cpptools-themes",
+                "ms-vscode.makefile-tools",
+                "twxs.cmake",
+                "yzhang.markdown-all-in-one"
+            ]
+        }
+    }
+}

--- a/.devcontainer/setup_container.sh
+++ b/.devcontainer/setup_container.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+echo "Rebind development Scilpy to Python"
+pip install -e .

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Set the default behavior to checkout and commit LF,  
+# otherwise devcontainers commit invalid EOL symbols
+
+* text eol=lf

--- a/docs/source/documentation/devcontainer.rst
+++ b/docs/source/documentation/devcontainer.rst
@@ -1,0 +1,32 @@
+Using development containers with Visual Studio Code
+====================================================
+
+Scilpy comes pre-equiped with a development container recipe for Visual Studio Code. You can use it to develop Scilpy on any platform (Windows, Linux, Mac) without having to install any dependencies on your host machine. 
+
+
+Prerequisites
+-------------
+
+The only requirement is to have `Docker <https://docs.docker.com/get-docker>`__ and `Visual Studio Code <https://code.visualstudio.com/download>`__ installed, with the `Dev Containers extension <https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers>`__ activated.
+
+
+Launching the container
+-----------------------
+
+1. Clone the Scilpy repository locally with Visual Studio Code and open it.
+
+2. Open the command palette (Ctrl+Shift+P) and select `Remote-Containers: Reopen in Container`.
+
+3. Wait for the container to build and start. You can monitor the progress in the bottom left corner of the window.
+
+
+Using the container
+-------------------
+
+Once the container is running, you can use Visual Studio Code as you would normally. The only difference is that the code is running inside the container, so you can use all the tools and dependencies that are installed in it, such as *ANTs*, *FSL* and *mrtrix*. The container is also equiped with *offscreen rendering* capabilities, so scripts generating figures should work.
+
+.. note::
+    The only accessible path from outside the container is the Scilpy repository. If you want to access other files, you will have to mount them in the container. See `this page <https://code.visualstudio.com/remote/advancedcontainers/add-local-file-mount>`__ for more information.
+
+.. note::
+    The container is running as a non-root user, so you might have to change the permissions of some files and folders to be able to write to them.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,3 +13,4 @@ Welcome to the scilpy documentation!
     :caption: Documentation
 
     documentation/tractogram_registration
+    documentation/devcontainer


### PR DESCRIPTION
PR adding to the repository the necessary files to enable the creation of a development container in VS Code. Once merged, users will be able to automatically create a development environment through VS Code, that contains the whole Scilus development stack (ANTs, FSL, Mrtrix, etc.), and develop Scilpy in it.

In addition to VS Code, this requires Docker, to create the development container - spawning the containers takes a few minutes (depending on the user's internet speed). The containers comes pre-equiped with Git and several VS Code extensions to streamline development, and is connected to docker outside the container (so it can build images as well).

Once created, VS Code opens an IDE inside the container, where Scilpy is installed. The user can then develop Scilpy, interact with repositories through Git, run tests inside the container and modify its content (the user has read/write permissions), and much more.

As of now, the only binding between the local machine and the container is through the Scilpy repository directory. We could consider adding other bindings, but this needs a bit of research.

Marche-à-suivre to test the container creation :
- Launch VS Code and open your workspace in the Scilpy repository directory
- In the extensions market (in the left menu strip), install the **Dev Containers** extension
- Click on the blue button in the lower left corner to open the **Remoting** menu
- Select **Reopen in container**
