### PR TITLE
Fix bug with new .gitattributes

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,6 @@
+FROM scilus/scilus:latest
+
+RUN apt update && apt install -y \
+        git \
+        wget \
+    && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Scilpy development container",
-    "image": "scilus/scilus:latest",
+    "build": { "dockerfile": "Dockerfile" },
     "forwardPorts": [3000],
     "workspaceMount": "source=${localWorkspaceFolder},target=/scilpy,type=bind,consistency=cached",
     "workspaceFolder": "/scilpy",

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+###############################
+# Git Line Endings            #
+###############################
+
+# Set default behaviour to automatically normalize line endings.
+* text=auto
+
+# Force batch scripts to always use CRLF line endings so that if a repo is accessed
+# in Windows via a file share from Linux, the scripts will work.
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf
+
+# Force bash scripts to always use LF line endings so that if a repo is accessed
+# in Unix via a file share from Windows, the scripts will work.
+*.sh text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,0 @@
-# Set the default behavior to checkout and commit LF,  
-# otherwise devcontainers commit invalid EOL symbols
-
-* text eol=lf


### PR DESCRIPTION
This PR needs to be merged fast, it contains a hotfix for the new .gitattributes file.

The new .gitattributes that fixes line endings on clones and checkouts as too broad and caused checkout errors. This makes it more granular, so that correct files have correct line endings, based on their extension.

Steps to reproduce bug :
1) Create a new virtual environment
2) Run : pip install git+https://github.com/scilus/scilpy.git@1.4.0

Correct behavior (using my fork which does not have the .gitattributes file) :
1) Create a new virtual environment
2) Run : pip install git+https://github.com/AlexVCaron/scilpy.git@1.4.0

I updated devcontainers as well, an update to the feature system made it impossible to build a container directly on top of scilus:latest (no git, nor wget/curl was present).