### PR TITLE
Custom ROI surface rendering for Laurent

### DIFF
--- a/scilpy/viz/screenshot.py
+++ b/scilpy/viz/screenshot.py
@@ -8,7 +8,8 @@ from scilpy.io.utils import snapshot
 def display_slices(volume_actor, slices,
                    output_filename, axis_name,
                    view_position, focal_point,
-                   peaks_actor=None, streamlines_actor=None):
+                   peaks_actor=None, streamlines_actor=None,
+                   roi_actors=None):
     # Setting for the slice of interest
     if axis_name == 'sagittal':
         volume_actor.display(slices[0], None, None)
@@ -33,6 +34,10 @@ def display_slices(volume_actor, slices,
         scene.add(streamlines_actor)
     elif peaks_actor:
         scene.add(peaks_actor)
+
+    if roi_actors:
+        for roi_actor in roi_actors:
+            scene.add(roi_actor)
     scene.set_camera(position=view_position,
                      view_up=view_up_vector,
                      focal_point=focal_point)


### PR DESCRIPTION
Simple features for Laurent that allow you to add ROI (and colors) to the screenshot tools.
It is called like this: `scil_screenshot_bundle.py atlas/pop_average/AF_L.trk mni_masked.nii.gz  --roi a.nii 255 0 0 --roi b.nii 0 255 0 --roi c.nii 0 0 255  -f`



![sagittal_3d](https://github.com/scilus/scilpy/assets/10820351/37f55a87-3a59-45a9-b74a-dc78113dae06)

There is 3 mode, the simplest shows the ROI as white, but if you specify RGB or RGBA after you can pick the color
```
For the --roi argument: If 1 value is provided, the ROI will be white,
if 4 values are provided, the ROI will be colored with the RGB values
provided, if 5 values are provided, it is RGBA (values from 0-255).
```

If the user use the wrong number of value (1, 4 or 5 is accepted) you get `--roi must be used either with PATH or with PATH R G B  or PATH R G B A`