### PR TITLE
ENH:  `scil_tractogram_math` support for TCKs

### DIFF
--- a/scripts/scil_tractogram_math.py
+++ b/scripts/scil_tractogram_math.py
@@ -116,7 +116,7 @@ def main():
     assert_inputs_exist(parser, args.in_tractograms)
     assert_outputs_exist(parser, args, args.out_tractogram,
                          optional=args.save_indices)
-    is_header_compatible_multiple_files(parser, args.in_tractograms)
+    is_header_compatible_multiple_files(parser, args.in_tractograms, args.reference)
 
     if args.operation == 'lazy_concatenate':
         logging.info('Using lazy_concatenate, no spatial or metadata related '

--- a/scripts/scil_tractogram_math.py
+++ b/scripts/scil_tractogram_math.py
@@ -116,8 +116,10 @@ def main():
     assert_inputs_exist(parser, args.in_tractograms)
     assert_outputs_exist(parser, args, args.out_tractogram,
                          optional=args.save_indices)
+
     is_header_compatible_multiple_files(
-        parser, args.in_tractograms, args.reference)
+        parser, args.in_tractograms, verbose_all_compatible=args.verbose,
+        reference=args.reference)
 
     if args.operation == 'lazy_concatenate':
         logging.info('Using lazy_concatenate, no spatial or metadata related '

--- a/scripts/scil_tractogram_math.py
+++ b/scripts/scil_tractogram_math.py
@@ -116,7 +116,8 @@ def main():
     assert_inputs_exist(parser, args.in_tractograms)
     assert_outputs_exist(parser, args, args.out_tractogram,
                          optional=args.save_indices)
-    is_header_compatible_multiple_files(parser, args.in_tractograms, args.reference)
+    is_header_compatible_multiple_files(
+        parser, args.in_tractograms, args.reference)
 
     if args.operation == 'lazy_concatenate':
         logging.info('Using lazy_concatenate, no spatial or metadata related '

--- a/scripts/scil_verify_space_attributes_compatibility.py
+++ b/scripts/scil_verify_space_attributes_compatibility.py
@@ -11,7 +11,10 @@ Spatial attributes are: affine, dimensions, voxel sizes and voxel order.
 import argparse
 
 
-from scilpy.io.utils import assert_inputs_exist, is_header_compatible_multiple_files
+from scilpy.io.utils import (
+    add_reference_arg,
+    assert_inputs_exist,
+    is_header_compatible_multiple_files)
 
 
 def _build_arg_parser():
@@ -20,7 +23,7 @@ def _build_arg_parser():
 
     p.add_argument('in_files', nargs='+',
                    help='List of file to compare (trk and nii).')
-
+    add_reference_arg(p)
     return p
 
 
@@ -30,7 +33,8 @@ def main():
 
     assert_inputs_exist(parser, args.in_files)
     is_header_compatible_multiple_files(parser, args.in_files,
-                                        verbose_all_compatible=True)
+                                        verbose_all_compatible=True,
+                                        reference=args.reference)
 
 
 if __name__ == "__main__":

--- a/scripts/scil_verify_space_attributes_compatibility.py
+++ b/scripts/scil_verify_space_attributes_compatibility.py
@@ -22,7 +22,7 @@ def _build_arg_parser():
                                 formatter_class=argparse.RawTextHelpFormatter)
 
     p.add_argument('in_files', nargs='+',
-                   help='List of file to compare (trk and nii).')
+                   help='List of file to compare (trk, tck and nii/nii.gz).')
     add_reference_arg(p)
     return p
 


### PR DESCRIPTION
The current behavior of `scil_tractogram_math` (or rather, `is_header_compatible_multiple_files`) does not allow for tractogram operations on TCKs.  This fixes this behavior by comparing the TCK's reference or, in the case of two TCKs, bypassing the comparison as they will  use the same reference.

Fixed some pep8 warnings also. 

edit: Added `--reference` parameter to `scil_verify_space_attributes_compatibility.py` too. It can be considered not useful as the reference used for loading the validated tck could just be passed to the script, but I say why not.