### PR TITLE
RF - changed tracking default sphere from symmetric724 to repulsion724

### DIFF
--- a/scilpy/io/utils.py
+++ b/scilpy/io/utils.py
@@ -167,7 +167,7 @@ def add_reference_arg(parser, arg_name=None):
                                  'support (.nii or .nii.gz).')
 
 
-def add_sphere_arg(parser, symmetric_only=False, default='symmetric724'):
+def add_sphere_arg(parser, symmetric_only=False, default='repulsion724'):
     spheres = sorted(SPHERE_FILES.keys())
     if symmetric_only:
         spheres = [s for s in spheres if 'symmetric' in s]

--- a/scilpy/tracking/tracker.py
+++ b/scilpy/tracking/tracker.py
@@ -13,6 +13,7 @@ from tqdm import tqdm
 
 import numpy as np
 from dipy.data import get_sphere
+from dipy.core.sphere import HemiSphere
 from dipy.io.stateful_tractogram import Space
 from dipy.reconst.shm import sh_to_sf_matrix
 from dipy.tracking.streamlinespeed import compress_streamlines
@@ -502,11 +503,13 @@ class GPUTacker():
         If True, only forward tracking is performed.
     rng_seed : int, optional
         Seed for random number generator.
+    sphere : int, optional
+        Sphere to use for the tracking.
     """
     def __init__(self, sh, mask, seeds, step_size, max_nbr_pts,
                  theta=20.0, sf_threshold=0.1, sh_interp='trilinear',
                  sh_basis='descoteaux07', batch_size=100000,
-                 forward_only=False, rng_seed=None):
+                 forward_only=False, rng_seed=None, sphere=None):
         if not have_opencl:
             raise ImportError('pyopencl is not installed. In order to use'
                               'GPU tracker, you need to install it first.')
@@ -521,6 +524,11 @@ class GPUTacker():
 
         self.seed_batches =\
             np.array_split(seeds + 0.5, np.ceil(len(seeds)/batch_size))
+
+        if sphere is None:
+            self.sphere = get_sphere("repulsion724")
+        else:
+            self.sphere = sphere
 
         # tracking step_size and number of points
         self.step_size = step_size
@@ -554,9 +562,6 @@ class GPUTacker():
         """
         t0 = perf_counter()
 
-        # TODO: Take as class parameter
-        sphere = get_sphere('symmetric724')
-
         # Convert theta to cos(theta)
         max_cos_theta = np.cos(np.deg2rad(self.theta))
 
@@ -567,7 +572,7 @@ class GPUTacker():
         cl_kernel.set_define('IM_Y_DIM', self.sh.shape[1])
         cl_kernel.set_define('IM_Z_DIM', self.sh.shape[2])
         cl_kernel.set_define('IM_N_COEFFS', self.sh.shape[3])
-        cl_kernel.set_define('N_DIRS', len(sphere.vertices))
+        cl_kernel.set_define('N_DIRS', len(self.sphere.vertices))
 
         cl_kernel.set_define('N_THETAS', len(self.theta))
         cl_kernel.set_define('STEP_SIZE', '{:.8f}f'.format(self.step_size))
@@ -587,10 +592,10 @@ class GPUTacker():
         # Input buffers
         # Constant input buffers
         cl_manager.add_input_buffer(0, self.sh)
-        cl_manager.add_input_buffer(1, sphere.vertices)
+        cl_manager.add_input_buffer(1, self.sphere.vertices)
 
         sh_order = find_order_from_nb_coeff(self.sh)
-        B_mat = sh_to_sf_matrix(sphere, sh_order, self.sh_basis,
+        B_mat = sh_to_sf_matrix(self.sphere, sh_order, self.sh_basis,
                                 return_inv=False)
         cl_manager.add_input_buffer(2, B_mat)
 

--- a/scripts/scil_compute_local_tracking.py
+++ b/scripts/scil_compute_local_tracking.py
@@ -371,7 +371,7 @@ def main():
         # data volume
         odf_sh = odf_sh_img.get_fdata(dtype=np.float32)
 
-        #GPU tracking needs the full sphere
+        # GPU tracking needs the full sphere
         sphere = get_sphere(args.sphere).subdivide(args.sub_sphere)
 
         streamlines_generator = GPUTacker(

--- a/scripts/scil_compute_local_tracking.py
+++ b/scripts/scil_compute_local_tracking.py
@@ -22,7 +22,7 @@ implementations:
     * Algo: For the GPU implementation, the only available algorithm is
         Algo 'prob'.
     * Tracking sphere: The only sphere available for GPU tracking is
-        `symmetric724` and `--sub_sphere` is not available for GPU tracking.
+        `repulsion724` and `--sub_sphere` is not available for GPU tracking.
     * SH interpolation: For GPU tracking, SH interpolation can be set to either
         nearest neighbour or trilinear (default). With DIPY, the only available
         method is trilinear.
@@ -76,7 +76,7 @@ from scilpy.tracking.tracker import GPUTacker
 DEFAULT_BATCH_SIZE = 10000
 DEFAULT_SH_INTERP = 'trilinear'
 DEFAULT_FWD_ONLY = False
-DEFAULT_GPU_SPHERE = 'symmetric724'
+DEFAULT_GPU_SPHERE = 'repulsion724'
 
 
 def _build_arg_parser():
@@ -90,7 +90,7 @@ def _build_arg_parser():
     track_g.add_argument('--algo', default='prob',
                          choices=['det', 'prob', 'eudx'],
                          help='Algorithm to use. [%(default)s]')
-    add_sphere_arg(track_g, symmetric_only=True)
+    add_sphere_arg(track_g, symmetric_only=False)
     track_g.add_argument('--sub_sphere',
                          type=int, default=0,
                          help='Subdivides each face of the sphere into 4^s new'
@@ -276,7 +276,7 @@ def main():
                          'Set --algo to `prob` for GPU tracking.'
                          .format(args.algo))
         if args.sphere != DEFAULT_GPU_SPHERE:
-            parser.error('Cannot use sphere `{}`. Only symmetric724 is '
+            parser.error('Cannot use sphere `{}`. Only repulsion724 is '
                          'available for GPU tracking.'.format(args.sphere))
         if args.sub_sphere:
             parser.error('Invalid argument --sub_sphere. Not implemented '

--- a/scripts/scil_compute_local_tracking.py
+++ b/scripts/scil_compute_local_tracking.py
@@ -275,12 +275,6 @@ def main():
             parser.error('Algo `{}` not supported for GPU tracking. '
                          'Set --algo to `prob` for GPU tracking.'
                          .format(args.algo))
-        if args.sphere != DEFAULT_GPU_SPHERE:
-            parser.error('Cannot use sphere `{}`. Only repulsion724 is '
-                         'available for GPU tracking.'.format(args.sphere))
-        if args.sub_sphere:
-            parser.error('Invalid argument --sub_sphere. Not implemented '
-                         'for GPU.')
     else:
         if args.batch_size is not None:
             parser.error('Invalid argument --batch_size. '
@@ -377,6 +371,9 @@ def main():
         # data volume
         odf_sh = odf_sh_img.get_fdata(dtype=np.float32)
 
+        #GPU tracking needs the full sphere
+        sphere = get_sphere(args.sphere).subdivide(args.sub_sphere)
+
         streamlines_generator = GPUTacker(
             odf_sh, mask_data, seeds,
             vox_step_size, max_strl_len,
@@ -386,7 +383,8 @@ def main():
             sh_basis=args.sh_basis,
             batch_size=batch_size,
             forward_only=forward_only,
-            rng_seed=args.seed)
+            rng_seed=args.seed,
+            sphere=sphere)
 
     # dump streamlines on-the-fly to file
     _save_tractogram(streamlines_generator, tracts_format,

--- a/scripts/scil_compute_local_tracking.py
+++ b/scripts/scil_compute_local_tracking.py
@@ -21,8 +21,6 @@ implementations:
         GPU implementation uses an in-house OpenCL implementation.
     * Algo: For the GPU implementation, the only available algorithm is
         Algo 'prob'.
-    * Tracking sphere: The only sphere available for GPU tracking is
-        `repulsion724` and `--sub_sphere` is not available for GPU tracking.
     * SH interpolation: For GPU tracking, SH interpolation can be set to either
         nearest neighbour or trilinear (default). With DIPY, the only available
         method is trilinear.


### PR DESCRIPTION
The `symmetric724` sphere is suboptimal for probabilistic tractography because the vertices density is higher at the poles. 

- Change default sphere to `repulsion724`. This change affects all scripts with input spheres.
- Change the default sphere for GPU tracking. 