### PR TITLE
OPT - map sh to sf before tracking [requires dipy 1.8.0]

### DIFF
--- a/scilpy/tracking/utils.py
+++ b/scilpy/tracking/utils.py
@@ -71,11 +71,10 @@ def add_tracking_options(p):
                          type=float, default=0.1,
                          help='Spherical function relative threshold. '
                               '[%(default)s]')
-    track_g.add_argument('--sh_to_pmf', dest='sh_to_pmf',
-                         type=bool, default=False,
-                         help='If true, map sherical harmonics to spherical '
+    track_g.add_argument('--sh_to_pmf', action='store_true',
+                         help='If set, map sherical harmonics to spherical '
                               'function (pmf) before tracking (faster, '
-                              'requires more memory) [%(default)s]')
+                              'requires more memory)')
     add_sh_basis_args(track_g)
 
     return track_g

--- a/scilpy/tracking/utils.py
+++ b/scilpy/tracking/utils.py
@@ -71,6 +71,11 @@ def add_tracking_options(p):
                          type=float, default=0.1,
                          help='Spherical function relative threshold. '
                               '[%(default)s]')
+    track_g.add_argument('--sh_to_pmf', dest='sh_to_pmf',
+                         type=bool, default=False,
+                         help='If true, map sherical harmonics to spherical '
+                              'function (pmf) before tracking (faster, '
+                              'requires more memory) [%(default)s]')
     add_sh_basis_args(track_g)
 
     return track_g
@@ -247,9 +252,8 @@ def save_tractogram(
     nib.streamlines.save(tractogram, out_tractogram, header=header)
 
 
-def get_direction_getter(
-    in_img, algo, sphere, sub_sphere, theta, sh_basis, voxel_size, sf_threshold
-):
+def get_direction_getter(in_img, algo, sphere, sub_sphere, theta, sh_basis,
+                         voxel_size, sf_threshold, sh_to_pmf):
     """ Return the direction getter object.
 
     Parameters
@@ -270,6 +274,9 @@ def get_direction_getter(
         Voxel size of the input data.
     sf_threshold: float
         Spherical function-amplitude threshold for tracking.
+    sh_to_pmf: bool
+        Map sherical harmonics to spherical function (pmf) before tracking
+        (faster, requires more memory).
 
     Return
     ------
@@ -310,7 +317,7 @@ def get_direction_getter(
             dg_class = ProbabilisticDirectionGetter
         return dg_class.from_shcoeff(
             shcoeff=img_data, max_angle=theta, sphere=sphere,
-            basis_type=sh_basis,
+            basis_type=sh_basis, sh_to_pmf=sh_to_pmf,
             relative_peak_threshold=sf_threshold, **kwargs)
     elif algo == 'eudx':
         # Code for algo EUDX. We don't use peaks_from_model

--- a/scripts/scil_tracking_local.py
+++ b/scripts/scil_tracking_local.py
@@ -228,7 +228,7 @@ def main():
             get_direction_getter(
                 args.in_odf, args.algo, args.sphere,
                 args.sub_sphere, args.theta, args.sh_basis,
-                voxel_size, args.sf_threshold),
+                voxel_size, args.sf_threshold, args.sh_to_pmf),
             BinaryStoppingCriterion(mask_data),
             seeds, np.eye(4),
             step_size=vox_step_size, max_cross=1,

--- a/scripts/tests/test_tracking_local.py
+++ b/scripts/tests/test_tracking_local.py
@@ -156,3 +156,16 @@ def test_execution_tracking_peaks(script_runner):
                             '--min_length', '20', '--max_length', '200',
                             '--algo', 'eudx')
     assert ret.success
+
+
+def test_execution_tracking_fodf_prob_pmf_mapping(script_runner):
+    os.chdir(os.path.expanduser(tmp_dir.name))
+    in_fodf = os.path.join(get_home(), 'tracking', 'fodf.nii.gz')
+    in_mask = os.path.join(get_home(), 'tracking', 'seeding_mask.nii.gz')
+
+    ret = script_runner.run('scil_tracking_local.py', in_fodf,
+                            in_mask, in_mask, 'local_prob.trk', '--nt', '100',
+                            '--compress', '0.1', '--sh_basis', 'descoteaux07',
+                            '--min_length', '20', '--max_length', '200',
+                            '--sh_to_pmf')
+    assert ret.success

--- a/scripts/tests/test_tracking_local.py
+++ b/scripts/tests/test_tracking_local.py
@@ -164,7 +164,7 @@ def test_execution_tracking_fodf_prob_pmf_mapping(script_runner):
     in_mask = os.path.join(get_home(), 'tracking', 'seeding_mask.nii.gz')
 
     ret = script_runner.run('scil_tracking_local.py', in_fodf,
-                            in_mask, in_mask, 'local_prob.trk', '--nt', '100',
+                            in_mask, in_mask, 'local_prob3.trk', '--nt', '100',
                             '--compress', '0.1', '--sh_basis', 'descoteaux07',
                             '--min_length', '20', '--max_length', '200',
                             '--sh_to_pmf')


### PR DESCRIPTION
# Quick description

Mapping the SH to SF before tracking speed up det/prob by a factor 2X and PTT by 10X.

**requires dipy 1.8.0+**

## Type of change

Check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [ ] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
