### PR TITLE
FIX: bug in scil_score_bundles.py

### DIFF
--- a/scripts/scil_score_bundles.py
+++ b/scripts/scil_score_bundles.py
@@ -167,7 +167,7 @@ def load_and_verify_everything(parser, args):
             ib_names.append(os.path.basename(bundle))
             sft = load_tractogram(bundle, 'same',
                                   bbox_valid_check=args.bbox_check)
-            ib_sft_list.append(ref_sft)
+            ib_sft_list.append(sft)
             if ref_sft is None:
                 ref_sft = sft
     else:


### PR DESCRIPTION
There was a bug in scil_score_bundles where the invalid bundles were incorrectly loaded if --compute_ic was used in scil_score_tractogram.

The bug caused the same tractogram to be loaded for each invalid bundle, which itself was not necessarily an invalid bundle, messing up the results.