### PR TITLE
BF - metadata version when using editable install

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include README.md
 include LICENSE
 include requirements.txt
+include .python-version
 
 recursive-include scilpy *.c
 recursive-include scilpy *.cpp

--- a/scilpy/io/deprecator.py
+++ b/scilpy/io/deprecator.py
@@ -5,7 +5,7 @@ from functools import wraps
 from packaging.version import parse
 import warnings
 
-import scilpy.version
+from scilpy import version
 
 
 class ScilpyExpiredDeprecation(ExpiredDeprecationError):
@@ -60,8 +60,8 @@ def _raise_warning(header, footer, func, *args, **kwargs):
 def deprecate_script(script, message, from_version):
     from_version = parse(from_version)
     expiration_minor = from_version.minor + DEFAULT_DEPRECATION_WINDOW
-    expiration_version = f"{from_version.major}.{expiration_minor}.0"
-    current_version = scilpy.version.__version__
+    expiration_version = f"{from_version.major}.{expiration_minor}"
+    current_version = f"{version._version_major}.{version._version_minor}"
 
     def _deprecation_decorator(func):
         @wraps(func)

--- a/scilpy/io/deprecator.py
+++ b/scilpy/io/deprecator.py
@@ -2,9 +2,10 @@
 
 from dipy.utils.deprecator import cmp_pkg_version, ExpiredDeprecationError
 from functools import wraps
-from importlib import metadata
 from packaging.version import parse
 import warnings
+
+import scilpy.version
 
 
 class ScilpyExpiredDeprecation(ExpiredDeprecationError):
@@ -60,7 +61,7 @@ def deprecate_script(script, message, from_version):
     from_version = parse(from_version)
     expiration_minor = from_version.minor + DEFAULT_DEPRECATION_WINDOW
     expiration_version = f"{from_version.major}.{expiration_minor}.0"
-    current_version = metadata.version('scilpy')
+    current_version = scilpy.version.__version__
 
     def _deprecation_decorator(func):
         @wraps(func)

--- a/scilpy/version.py
+++ b/scilpy/version.py
@@ -27,24 +27,6 @@ CLASSIFIERS = ["Development Status :: 3 - Alpha",
                "Programming Language :: Python",
                "Topic :: Scientific/Engineering"]
 
-PYTHON_VERSION = ""
-with open('.python-version') as f:
-    py_version = f.readline().strip("\n").split(".")
-    py_major = py_version[0]
-    py_minor = py_version[1]
-    py_micro = "*"
-    py_extra = None
-    if len(py_version) > 2:
-        py_micro = py_version[2]
-    if len(py_version) > 3:
-        py_extra = py_version[3]
-
-    PYTHON_VERSION = ".".join([py_major, py_minor, py_micro])
-    if py_extra:
-        PYTHON_VERSION = ".".join([PYTHON_VERSION, py_extra])
-
-    PYTHON_VERSION = "".join(["==", PYTHON_VERSION])
-
 # Description should be a one-liner:
 description = "Scilpy: diffusion MRI tools and utilities"
 # Long description will go up on the pypi page
@@ -89,4 +71,4 @@ LEGACY_SCRIPTS = filter(lambda s: not os.path.basename(s) == "__init__.py",
 SCRIPTS = filter(lambda s: not os.path.basename(s) == "__init__.py",
                  glob.glob("scripts/*.py"))
 
-PREVIOUS_MAINTAINERS=["Jean-Christophe Houde"]
+PREVIOUS_MAINTAINERS = ["Jean-Christophe Houde"]

--- a/setup.py
+++ b/setup.py
@@ -48,10 +48,30 @@ class CustomBuildExtCommand(build_ext):
         build_ext.run(self)
 
 
+# Get the requiered python version
+PYTHON_VERSION = ""
+with open('.python-version') as f:
+    py_version = f.readline().strip("\n").split(".")
+    py_major = py_version[0]
+    py_minor = py_version[1]
+    py_micro = "*"
+    py_extra = None
+    if len(py_version) > 2:
+        py_micro = py_version[2]
+    if len(py_version) > 3:
+        py_extra = py_version[3]
+
+    PYTHON_VERSION = ".".join([py_major, py_minor, py_micro])
+    if py_extra:
+        PYTHON_VERSION = ".".join([PYTHON_VERSION, py_extra])
+
+    PYTHON_VERSION = "".join(["==", PYTHON_VERSION])
+
 # Get version and release info, which is all stored in scilpy/version.py
 ver_file = os.path.join('scilpy', 'version.py')
 with open(ver_file) as f:
     exec(f.read())
+
 opts = dict(name=NAME,
             maintainer=MAINTAINER,
             maintainer_email=MAINTAINER_EMAIL,


### PR DESCRIPTION
`importlib.metadata.version` doesn't work for package not installed with pip, i.e. when using a local editable version (https://github.com/python/importlib_metadata/issues/364)

The problem is solved by calling  `scilpy.version`  instead of  `metadata.version`. 

@arnaudbore @AlexVCaron do you see a problem with this change?