### PR TITLE
[FIX] Use numbers rather than letters in scil_gradients_modify_axes

### DIFF
--- a/scripts/scil_gradients_modify_axes.py
+++ b/scripts/scil_gradients_modify_axes.py
@@ -11,8 +11,7 @@ import os
 import numpy as np
 
 from scilpy.gradients.bvec_bval_tools import (flip_gradient_sampling,
-                                              swap_gradient_axis,
-                                              str_to_axis_index)
+                                              swap_gradient_axis)
 from scilpy.io.utils import (add_overwrite_arg, assert_inputs_exist,
                              assert_outputs_exist)
 
@@ -27,16 +26,18 @@ def _build_arg_parser():
     p.add_argument('out_gradient_sampling_file',
                    help='Where to save the flipped gradient sampling file.')
 
-    # Note: We can't ask for 3 separate nargs because -x is understood as
-    # another option -x.
-    p.add_argument('final_order',
-                   help="The final order of the axis, compared to original "
-                        "order. \n"
-                        "Choices: ['x', 'y', 'z', '-x', '-y', '-z']\n"
-                        "Ex: to only flip y: --final_order x-yz.\n"
-                        "Ex: to only swap x and y: --final_order yxz.\n"
+    # Note: We can't ask for text such as '-x' or '-xyz' because -x is
+    # understood as another option -x by the argparser. With ints, we can
+    # add a negative value. Not using 0, 1, 2 so that we can use the
+    # negative value (-0 would not work)
+    p.add_argument('final_order', type=int, nargs=3,
+                   choices=[1, 2, 3, -1, -2, -3],
+                   help="The final order of the axes, compared to original "
+                        "order: x=1 y=2 z=3.\n"
+                        "Ex: to only flip y: --final_order 1 -2 3.\n"
+                        "Ex: to only swap x and y: --final_order 2 1 3.\n"
                         "Ex: to first flip x, then permute all three axes: "
-                        "--final_order z-xy.")
+                        "--final_order 3 -1 2.")
 
     add_overwrite_arg(p)
 
@@ -57,20 +58,17 @@ def main():
                      'how to interpret.'.format(ext))
 
     # Format final order
+    # Our scripts use axes as 0, 1, 2 rather than 1, 2, 3: adding -1.
     axes_to_flip = []
     swapped_order = []
-    next_axis = ''
-    for char in args.final_order:
-        next_axis += char
-        if char != '-':
-            if next_axis in ['x', 'y', 'z']:
-                swapped_order.append(str_to_axis_index(next_axis))
-            elif next_axis in ['-x', '-y', '-z']:
-                axes_to_flip.append(str_to_axis_index(next_axis[1]))
-                swapped_order.append(str_to_axis_index(next_axis[1]))
-            else:
-                parser.error("Sorry, final_order not understood.")
-            next_axis = ''
+    for next_axis in args.final_order:
+        if next_axis in [1, 2, 3]:
+            swapped_order.append(next_axis - 1)
+        elif next_axis in [-1, -2, -3]:
+            axes_to_flip.append(abs(next_axis) - 1)
+            swapped_order.append(abs(next_axis) - 1)
+        else:
+            parser.error("Sorry, final order not understood.")
 
     # Verifying that user did not ask for, ex, -xxy
     if len(np.unique(swapped_order)) != 3:

--- a/scripts/tests/test_gradients_modify_axes.py
+++ b/scripts/tests/test_gradients_modify_axes.py
@@ -22,11 +22,11 @@ def test_execution_processing(script_runner):
     # mrtrix
     in_encoding = os.path.join(get_home(), 'processing', '1000.b')
     ret = script_runner.run('scil_gradients_modify_axes.py', in_encoding,
-                            '1000_flip.b', 'x-zy')
+                            '1000_flip.b', '-1', '3', '2')
     assert ret.success
 
     # FSL
     in_encoding = os.path.join(get_home(), 'processing', '1000.bvec')
     ret = script_runner.run('scil_gradients_modify_axes.py', in_encoding,
-                            '1000_flip.bvec', 'x-zy')
+                            '1000_flip.bvec', '1', '-3', '2')
     assert ret.success


### PR DESCRIPTION
Tentatively fixing issue #816 

We did not find a way to use letters. The arpgarser does not understand text that starts with a minus.

Choices discussed to tell script to flip the x axis:
       1. `x` is normal direction, `X` is flipped.
       2. `x` is normal direction, `x-` is flipped
       3. `x` is normal direction, `ix` is 'inversed' x.
       4. Use numbers:  negative ints are understood. But uses axes = 1, 2, 3 because with 0, 1, 2, we can't inverse 0 with -0.

We chose 4 with @karanphil. @mdesco ok for you?