### PR TITLE
Adding tolerance argument to fodf msmt

### DIFF
--- a/scripts/scil_fodf_msmt.py
+++ b/scripts/scil_fodf_msmt.py
@@ -64,6 +64,10 @@ def _build_arg_parser():
         '--mask', metavar='',
         help='Path to a binary mask. Only the data inside the '
              'mask will be used for computations and reconstruction.')
+    p.add_argument(
+        '--tolerance', type=int, default=20,
+        help='The tolerated gap between the b-values to '
+            'extract and the current b-value. [%(default)s]')
 
     add_force_b0_arg(p)
     add_sh_basis_args(p)
@@ -136,6 +140,7 @@ def main():
         if mask.shape != data.shape[:-1]:
             raise ValueError("Mask is not the same shape as data.")
 
+    tol = args.tolerance
     sh_order = args.sh_order
 
     # Checking data and sh_order
@@ -165,9 +170,10 @@ def main():
     if not csf_frf.shape[1] == 4:
         raise ValueError('CSF frf file did not contain 4 elements. '
                          'Invalid or deprecated FRF format')
-    ubvals = unique_bvals_tolerance(bvals, tol=20)
+    ubvals = unique_bvals_tolerance(bvals, tol=tol)
     msmt_response = multi_shell_fiber_response(sh_order, ubvals,
-                                               wm_frf, gm_frf, csf_frf)
+                                               wm_frf, gm_frf, csf_frf, 
+                                               tol=tol)
 
     # Loading spheres
     reg_sphere = get_sphere('symmetric362')

--- a/scripts/scil_fodf_msmt.py
+++ b/scripts/scil_fodf_msmt.py
@@ -67,7 +67,7 @@ def _build_arg_parser():
     p.add_argument(
         '--tolerance', type=int, default=20,
         help='The tolerated gap between the b-values to '
-            'extract and the current b-value. [%(default)s]')
+             'extract and the current b-value. [%(default)s]')
 
     add_force_b0_arg(p)
     add_sh_basis_args(p)
@@ -172,7 +172,7 @@ def main():
                          'Invalid or deprecated FRF format')
     ubvals = unique_bvals_tolerance(bvals, tol=tol)
     msmt_response = multi_shell_fiber_response(sh_order, ubvals,
-                                               wm_frf, gm_frf, csf_frf, 
+                                               wm_frf, gm_frf, csf_frf,
                                                tol=tol)
 
     # Loading spheres


### PR DESCRIPTION
Addressing issue #830 from @mdesco , I added a tolerance argument to `scil_fodf_msmt.py`. It was simply hardcoded to tol=20 in one function, and set to default (20) in another. This was in fact a potential breaking point even if it ran. I just had to give the option.

@mdesco could you try to run it again on your setup? Thanks!