### PR TITLE
Clarify b0 threshold

### DIFF
--- a/scilpy/gradients/bvec_bval_tools.py
+++ b/scilpy/gradients/bvec_bval_tools.py
@@ -102,7 +102,7 @@ def check_b0_threshold(min_bval, b0_thr, skip_b0_check):
             return min_bval
         else:
             raise ValueError(
-                'The minimal bvalue ({}) is is above the threshold ({})\n'
+                'The minimal bvalue ({}) is above the threshold ({})\n'
                 'No b0 volumes can be found.\n'
                 'Please check your data to ensure everything is correct.\n'
                 'You may also increase the threshold or use '

--- a/scilpy/gradients/bvec_bval_tools.py
+++ b/scilpy/gradients/bvec_bval_tools.py
@@ -55,7 +55,7 @@ def normalize_bvecs(bvecs):
     return bvecs
 
 
-def check_b0_threshold(min_bval, args, b0_arg='b0_threshold'):
+def check_b0_threshold(min_bval, args, b0_thr=None):
     """
     Check if the minimal bvalue is under the threshold. If not, raise an
     error to ask user to update the b0_thr.
@@ -72,8 +72,11 @@ def check_b0_threshold(min_bval, args, b0_arg='b0_threshold'):
             args.skip_b0_validation: bool
                 If True, and no b0 is found, only print a warning, do not raise
                 an error.
-            args.b0_threshold: float  (or args[b0_arg])
+            args.b0_threshold: float
                 Maximum bvalue considered as a b0.
+    b0_thr: float
+        If set, we will use this value instead of args.b0_threshold as a
+        threshold.
 
     Raises
     ------
@@ -81,13 +84,13 @@ def check_b0_threshold(min_bval, args, b0_arg='b0_threshold'):
         If the minimal bvalue is over the threshold (and skip_b0_validation is
         False).
     """
-    b0_thr = vars(args)[b0_arg]  # Converting Namespace to dict to allow access
+    b0_thr = b0_thr or args.b0_threshold
 
     if b0_thr > DEFAULT_B0_THRESHOLD:
         logging.warning(
             'Warning: Your defined b0 threshold (option --{}) is {}. This is '
             'suspicious. We recommend using volumes with bvalues no higher '
-            'than {} as b0s.'.format(b0_arg, b0_thr, DEFAULT_B0_THRESHOLD))
+            'than {} as b0s.'.format(b0_thr, b0_thr, DEFAULT_B0_THRESHOLD))
 
     if min_bval < 0:
         logging.warning(
@@ -102,7 +105,7 @@ def check_b0_threshold(min_bval, args, b0_arg='b0_threshold'):
                 'defined with --{}: {}.\n'
                 'Since --skip_b0_validation was specified, the script will'
                 'proceed with a b0 threshold of {}.'
-                .format(min_bval, b0_arg, b0_thr, min_bval))
+                .format(min_bval, b0_thr, b0_thr, min_bval))
             return min_bval
         else:
             raise ValueError(
@@ -111,7 +114,7 @@ def check_b0_threshold(min_bval, args, b0_arg='b0_threshold'):
                 'Please check your data to ensure everything is correct.\n'
                 'You may also increase the threshold or use '
                 '--skip_b0_validation'
-                .format(min_bval, b0_arg, b0_thr, min_bval))
+                .format(min_bval, b0_thr, b0_thr, min_bval))
     return b0_thr
 
 

--- a/scilpy/gradients/bvec_bval_tools.py
+++ b/scilpy/gradients/bvec_bval_tools.py
@@ -55,7 +55,7 @@ def normalize_bvecs(bvecs):
     return bvecs
 
 
-def check_b0_threshold(min_bval, args):
+def check_b0_threshold(min_bval, b0_threshold, skip_b0_check):
     """
     Check if the minimal bvalue is under the threshold. If not, raise an
     error to ask user to update the b0_thr.
@@ -67,13 +67,11 @@ def check_b0_threshold(min_bval, args):
     ----------
     min_bval : float
         Minimum bvalue.
-    args: Namespace
-        The argparse arguments. Should contain at least:
-            args.skip_b0_validation: bool
-                If True, and no b0 is found, only print a warning, do not raise
-                an error.
-            args.b0_threshold: float
-                Maximum bvalue considered as a b0.
+    b0_threshold: float
+        Maximum bvalue considered as a b0.
+    skip_b0_check: bool
+        If True, and no b0 is found, only print a warning, do not raise
+        an error.
 
     Raises
     ------

--- a/scilpy/gradients/bvec_bval_tools.py
+++ b/scilpy/gradients/bvec_bval_tools.py
@@ -55,7 +55,7 @@ def normalize_bvecs(bvecs):
     return bvecs
 
 
-def check_b0_threshold(min_bval, args, b0_thr=None):
+def check_b0_threshold(min_bval, args):
     """
     Check if the minimal bvalue is under the threshold. If not, raise an
     error to ask user to update the b0_thr.
@@ -74,9 +74,6 @@ def check_b0_threshold(min_bval, args, b0_thr=None):
                 an error.
             args.b0_threshold: float
                 Maximum bvalue considered as a b0.
-    b0_thr: float
-        If set, we will use this value instead of args.b0_threshold as a
-        threshold.
 
     Raises
     ------
@@ -84,8 +81,7 @@ def check_b0_threshold(min_bval, args, b0_thr=None):
         If the minimal bvalue is over the threshold (and skip_b0_validation is
         False).
     """
-    b0_thr = b0_thr or args.b0_threshold
-
+    b0_thr = args.b0_threshold
     if b0_thr > DEFAULT_B0_THRESHOLD:
         logging.warning(
             'Warning: Your defined b0 threshold (option --{}) is {}. This is '

--- a/scilpy/gradients/bvec_bval_tools.py
+++ b/scilpy/gradients/bvec_bval_tools.py
@@ -84,33 +84,33 @@ def check_b0_threshold(min_bval, args):
     b0_thr = args.b0_threshold
     if b0_thr > DEFAULT_B0_THRESHOLD:
         logging.warning(
-            'Warning: Your defined b0 threshold (option --{}) is {}. This is '
-            'suspicious. We recommend using volumes with bvalues no higher '
-            'than {} as b0s.'.format(b0_thr, b0_thr, DEFAULT_B0_THRESHOLD))
+            'Your defined b0 threshold is {}. This is suspicious. We '
+            'recommend using volumes with bvalues no higher than {} as b0s'
+            .format(b0_thr, DEFAULT_B0_THRESHOLD))
 
     if min_bval < 0:
         logging.warning(
             'Warning: Your dataset contains negative b-values (minimal bvalue '
-            'of {}). This is suspicious. We recommend you check your data.')
+            'of {}). This is suspicious. We recommend you check your data.'
+            .format(min_bval))
 
     if min_bval > b0_thr:
         if args.skip_b0_validation:
             logging.warning("GOT {} > {}".format(min_bval, b0_thr))
             logging.warning(
-                'Warning: Your minimal bvalue ({}), is above the threshold '
-                'defined with --{}: {}.\n'
-                'Since --skip_b0_validation was specified, the script will'
+                'Your minimal bvalue ({}), is above the threshold ({})\n'
+                'Since --skip_b0_validation was specified, the script will '
                 'proceed with a b0 threshold of {}.'
-                .format(min_bval, b0_thr, b0_thr, min_bval))
+                .format(min_bval, b0_thr, min_bval))
             return min_bval
         else:
             raise ValueError(
-                'The minimal bvalue ({}) is is above the threshold '
-                'defined with --{}: {}.\n.No b0 volumes can be found.\n'
+                'The minimal bvalue ({}) is is above the threshold ({})\n'
+                'No b0 volumes can be found.\n'
                 'Please check your data to ensure everything is correct.\n'
                 'You may also increase the threshold or use '
                 '--skip_b0_validation'
-                .format(min_bval, b0_thr, b0_thr, min_bval))
+                .format(min_bval, b0_thr))
     return b0_thr
 
 

--- a/scilpy/gradients/bvec_bval_tools.py
+++ b/scilpy/gradients/bvec_bval_tools.py
@@ -55,58 +55,62 @@ def normalize_bvecs(bvecs):
     return bvecs
 
 
-def check_b0_threshold(
-        force_b0_threshold, bvals_min, b0_thr=DEFAULT_B0_THRESHOLD
-):
-    """Check if the minimal bvalue is under zero or over the threshold.
-    If `force_b0_threshold` is true, don't raise an error even if the minimum
-    bvalue is over the threshold.
+def check_b0_threshold(min_bval, args, b0_arg='b0_threshold'):
+    """
+    Check if the minimal bvalue is under the threshold. If not, raise an
+    error to ask user to update the b0_thr.
+
+    Also verifies if the b0_thr is suspicious (should be included in range
+    [0, DEFAULT_B0_THRESHOLD]).
 
     Parameters
     ----------
-    force_b0_threshold : bool
-        If True, don't raise an error.
-    bvals_min : float
+    min_bval : float
         Minimum bvalue.
-    b0_thr : float
-        Maximum bvalue considered as a b0.
+    args: Namespace
+        The argparse arguments. Should contain at least:
+            args.skip_b0_validation: bool
+                If True, and no b0 is found, only print a warning, do not raise
+                an error.
+            args.b0_threshold: float  (or args[b0_arg])
+                Maximum bvalue considered as a b0.
 
     Raises
     ------
     ValueError
-        If the minimal bvalue is over the threshold, and
-        `force_b0_threshold` is False.
+        If the minimal bvalue is over the threshold (and skip_b0_validation is
+        False).
     """
+    b0_thr = args[b0_arg]
+
     if b0_thr > DEFAULT_B0_THRESHOLD:
         logging.warning(
-            'Warning: Your defined threshold is {}. This is suspicious. We '
-            'recommend using volumes with bvalues no higher '
-            'than {} as b0s.'.format(b0_thr, DEFAULT_B0_THRESHOLD)
-        )
+            'Warning: Your defined b0 threshold (option --{}) is {}. This is '
+            'suspicious. We recommend using volumes with bvalues no higher '
+            'than {} as b0s.'.format(b0_arg, b0_thr, DEFAULT_B0_THRESHOLD))
 
-    if bvals_min < 0:
+    if min_bval < 0:
         logging.warning(
-            'Warning: Your dataset contains negative b-values (minimal '
-            'bvalue of {}). This is suspicious. We recommend you check '
-            'your data.')
+            'Warning: Your dataset contains negative b-values (minimal bvalue '
+            'of {}). This is suspicious. We recommend you check your data.')
 
-    if bvals_min > b0_thr:
-        if force_b0_threshold:
+    if min_bval > b0_thr:
+        if args.skip_b0_validation:
             logging.warning(
-                'Warning: Your minimal bvalue is {}, but the threshold '
-                'is set to {}. Since --force_b0_threshold was specified, '
-                'the script will proceed with a threshold of {}'
-                '.'.format(bvals_min, b0_thr, bvals_min))
-            return bvals_min
-        else:
-            raise ValueError('The minimal bvalue ({}) is greater than the '
-                             'threshold ({}). No b0 volumes can be found.\n'
-                             'Please check your data to ensure everything '
-                             'is correct.\n'
-                             'Use --force_b0_threshold to execute '
-                             'regardless.'
-                             .format(bvals_min, b0_thr))
-
+                'Warning: Your minimal bvalue ({}), is above the threshold '
+                'defined with --{}: {}.\n'
+                'Since --skip_b0_validation was specified, the script will'
+                'proceed with a b0 threshold of {}.'
+                .format(min_bval, b0_arg, b0_thr, min_bval))
+            return min_bval
+    else:
+        raise ValueError(
+            'The minimal bvalue ({}) is is above the threshold '
+            'defined with --{}: {}.\n. '
+            'No b0 volumes can be found.\n'
+            'Please check your data to ensure everything is correct.\n'
+            'You may also increase the threshold or use --skip_b0_validation'
+            .format(min_bval, b0_arg, b0_thr, min_bval))
     return b0_thr
 
 

--- a/scilpy/gradients/bvec_bval_tools.py
+++ b/scilpy/gradients/bvec_bval_tools.py
@@ -55,7 +55,7 @@ def normalize_bvecs(bvecs):
     return bvecs
 
 
-def check_b0_threshold(min_bval, b0_threshold, skip_b0_check):
+def check_b0_threshold(min_bval, b0_thr, skip_b0_check):
     """
     Check if the minimal bvalue is under the threshold. If not, raise an
     error to ask user to update the b0_thr.
@@ -67,7 +67,7 @@ def check_b0_threshold(min_bval, b0_threshold, skip_b0_check):
     ----------
     min_bval : float
         Minimum bvalue.
-    b0_threshold: float
+    b0_thr: float
         Maximum bvalue considered as a b0.
     skip_b0_check: bool
         If True, and no b0 is found, only print a warning, do not raise
@@ -76,10 +76,9 @@ def check_b0_threshold(min_bval, b0_threshold, skip_b0_check):
     Raises
     ------
     ValueError
-        If the minimal bvalue is over the threshold (and skip_b0_validation is
+        If the minimal bvalue is over the threshold (and skip_b0_check is
         False).
     """
-    b0_thr = args.b0_threshold
     if b0_thr > DEFAULT_B0_THRESHOLD:
         logging.warning(
             'Your defined b0 threshold is {}. This is suspicious. We '
@@ -93,11 +92,11 @@ def check_b0_threshold(min_bval, b0_threshold, skip_b0_check):
             .format(min_bval))
 
     if min_bval > b0_thr:
-        if args.skip_b0_validation:
+        if skip_b0_check:
             logging.warning("GOT {} > {}".format(min_bval, b0_thr))
             logging.warning(
                 'Your minimal bvalue ({}), is above the threshold ({})\n'
-                'Since --skip_b0_validation was specified, the script will '
+                'Since --skip_b0_check was specified, the script will '
                 'proceed with a b0 threshold of {}.'
                 .format(min_bval, b0_thr, min_bval))
             return min_bval
@@ -107,7 +106,7 @@ def check_b0_threshold(min_bval, b0_threshold, skip_b0_check):
                 'No b0 volumes can be found.\n'
                 'Please check your data to ensure everything is correct.\n'
                 'You may also increase the threshold or use '
-                '--skip_b0_validation'
+                '--skip_b0_check'
                 .format(min_bval, b0_thr))
     return b0_thr
 

--- a/scilpy/gradients/bvec_bval_tools.py
+++ b/scilpy/gradients/bvec_bval_tools.py
@@ -73,6 +73,13 @@ def check_b0_threshold(min_bval, b0_thr, skip_b0_check):
         If True, and no b0 is found, only print a warning, do not raise
         an error.
 
+    Returns
+    -------
+    b0_thr: float
+        Either the unmodified b0_thr, or, in the case where the minimal b-value
+        is larger than b0_thr, and skip_b0_check is set to True, then returns
+        min_bval.
+
     Raises
     ------
     ValueError
@@ -93,7 +100,6 @@ def check_b0_threshold(min_bval, b0_thr, skip_b0_check):
 
     if min_bval > b0_thr:
         if skip_b0_check:
-            logging.warning("GOT {} > {}".format(min_bval, b0_thr))
             logging.warning(
                 'Your minimal bvalue ({}), is above the threshold ({})\n'
                 'Since --skip_b0_check was specified, the script will '

--- a/scilpy/gradients/bvec_bval_tools.py
+++ b/scilpy/gradients/bvec_bval_tools.py
@@ -81,7 +81,7 @@ def check_b0_threshold(min_bval, args, b0_arg='b0_threshold'):
         If the minimal bvalue is over the threshold (and skip_b0_validation is
         False).
     """
-    b0_thr = args[b0_arg]
+    b0_thr = vars(args)[b0_arg]  # Converting Namespace to dict to allow access
 
     if b0_thr > DEFAULT_B0_THRESHOLD:
         logging.warning(
@@ -96,6 +96,7 @@ def check_b0_threshold(min_bval, args, b0_arg='b0_threshold'):
 
     if min_bval > b0_thr:
         if args.skip_b0_validation:
+            logging.warning("GOT {} > {}".format(min_bval, b0_thr))
             logging.warning(
                 'Warning: Your minimal bvalue ({}), is above the threshold '
                 'defined with --{}: {}.\n'
@@ -103,14 +104,14 @@ def check_b0_threshold(min_bval, args, b0_arg='b0_threshold'):
                 'proceed with a b0 threshold of {}.'
                 .format(min_bval, b0_arg, b0_thr, min_bval))
             return min_bval
-    else:
-        raise ValueError(
-            'The minimal bvalue ({}) is is above the threshold '
-            'defined with --{}: {}.\n. '
-            'No b0 volumes can be found.\n'
-            'Please check your data to ensure everything is correct.\n'
-            'You may also increase the threshold or use --skip_b0_validation'
-            .format(min_bval, b0_arg, b0_thr, min_bval))
+        else:
+            raise ValueError(
+                'The minimal bvalue ({}) is is above the threshold '
+                'defined with --{}: {}.\n.No b0 volumes can be found.\n'
+                'Please check your data to ensure everything is correct.\n'
+                'You may also increase the threshold or use '
+                '--skip_b0_validation'
+                .format(min_bval, b0_arg, b0_thr, min_bval))
     return b0_thr
 
 

--- a/scilpy/gradients/tests/test_bvec_bval_tools.py
+++ b/scilpy/gradients/tests/test_bvec_bval_tools.py
@@ -2,9 +2,9 @@
 import numpy as np
 
 from scilpy.gradients.bvec_bval_tools import (
-    identify_shells, is_normalized_bvecs, flip_gradient_sampling,
-    normalize_bvecs, round_bvals_to_shell, str_to_axis_index,
-    swap_gradient_axis)
+    check_b0_threshold, identify_shells, is_normalized_bvecs,
+    flip_gradient_sampling, normalize_bvecs, round_bvals_to_shell,
+    str_to_axis_index, swap_gradient_axis)
 
 bvecs = np.asarray([[1.0, 1.0, 1.0],
                     [1.0, 0.0, 1.0],
@@ -23,8 +23,16 @@ def test_normalize_bvecs():
 
 
 def test_check_b0_threshold():
-    # toDo To be modified (see PR#867).
-    pass
+    assert check_b0_threshold(min_bval=0, b0_thr=0, skip_b0_check=False) == 0
+    assert check_b0_threshold(min_bval=0, b0_thr=20, skip_b0_check=False) == 20
+    assert check_b0_threshold(min_bval=20, b0_thr=0, skip_b0_check=True) == 20
+
+    error_raised = False
+    try:
+        _ = check_b0_threshold(min_bval=20, b0_thr=0, skip_b0_check=False)
+    except ValueError:
+        error_raised = True
+    assert error_raised
 
 
 def test_identify_shells():

--- a/scilpy/io/btensor.py
+++ b/scilpy/io/btensor.py
@@ -113,7 +113,7 @@ def generate_btensor_input(in_dwis, in_bvals, in_bvecs, in_bdeltas,
         if inputf:  # verifies if the input file exists
             vol = nib.load(inputf)
             bvals, bvecs = read_bvals_bvecs(bvalsf, bvecsf)
-            _ = check_b0_threshold(bvals.min(), b0_threshold=tol,
+            _ = check_b0_threshold(bvals.min(), b0_thr=tol,
                                    skip_b0_check=skip_b0_check)
             if np.sum([bvals > tol]) != 0:
                 bvals = np.round(bvals)

--- a/scilpy/io/btensor.py
+++ b/scilpy/io/btensor.py
@@ -54,7 +54,9 @@ def generate_btensor_input(in_dwis, in_bvals, in_bvecs, in_bdeltas,
     """Generate b-tensor input from an ensemble of data, bvals and bvecs files.
     This generated input is mandatory for all scripts using b-tensor encoding
     data. Also generate the powder-averaged (PA) data if set.
-    toDo. Add a way to include a different b0_threshold than the tolerance.
+
+    For the moment, this does not enable the use of a b0_threshold different
+    than the tolerance.
 
     Parameters
     ----------

--- a/scilpy/io/btensor.py
+++ b/scilpy/io/btensor.py
@@ -54,6 +54,7 @@ def generate_btensor_input(in_dwis, in_bvals, in_bvecs, in_bdeltas,
     """Generate b-tensor input from an ensemble of data, bvals and bvecs files.
     This generated input is mandatory for all scripts using b-tensor encoding
     data. Also generate the powder-averaged (PA) data if set.
+    toDo. Add a way to include a different b0_threshold than the tolerance.
 
     Parameters
     ----------
@@ -156,7 +157,7 @@ def generate_btensor_input(in_dwis, in_bvals, in_bvecs, in_bdeltas,
         gtab_infos[3] = acq_index_full
         if np.sum([ubvals_full < tol]) < acq_index - 1:
             gtab_infos[3] *= 0
-        return(pa_signals, gtab_infos)
+        return pa_signals, gtab_infos
     # Removing the duplicate b0s from ubvals_full
     duplicate_b0_ind = np.union1d(np.argwhere(ubvals_full == min(ubvals_full)),
                                   np.argwhere(ubvals_full > tol))
@@ -185,4 +186,4 @@ def generate_btensor_input(in_dwis, in_bvals, in_bvecs, in_bdeltas,
                                b0_threshold=bvals_full.min(),
                                btens=b_shapes)
 
-    return(gtab_full, data_full, ubvals_full, ub_deltas_full)
+    return gtab_full, data_full, ubvals_full, ub_deltas_full

--- a/scilpy/io/utils.py
+++ b/scilpy/io/utils.py
@@ -215,14 +215,47 @@ def add_overwrite_arg(parser):
         help='Force overwriting of the output files.')
 
 
-def add_skip_b0_check_arg(parser, will_overwrite_with_min: bool,
+def add_tolerance_arg(parser):
+    parser.add_argument(
+        '--tolerance', type=int, default=20,
+        help='The tolerated gap between the b-values to extract and the '
+             'current b-value.\n'
+             'We would expect to find at least one b-value in the range '
+             '[0, tolerance], acting as a b0.\n'
+             'To skip this check, use --skip_b0_check.\n'
+             '[Default: %(default)s]')
+
+
+def add_b0_thresh_arg(parser):
+    parser.add_argument(
+        '--b0_threshold', type=float, default=DEFAULT_B0_THRESHOLD,
+        help='Threshold under which b-values are considered to be b0s.\n'
+             'We would expect to find at least one b-value in the range '
+             '[0, b0_threshold], acting as a b0.\n'
+             'To skip this check, use --skip_b0_check.\n'
+             'Default if not set is {}.'.format(DEFAULT_B0_THRESHOLD))
+
+
+def add_skip_b0_check_arg(parser, will_overwrite_with_min,
                           b0_tol_name='--b0_threshold'):
+    """
+    Parameters
+    ----------
+    parser: argparse.ArgumentParser object
+        Parser.
+    will_overwrite_with_min: bool
+        If true, the help message will explain that b0_threshold could be
+        overwritten.
+    b0_tol_name: str
+        Name of the argparse parameter acting as b0_threshold. Should probably
+        be either '--b0_threshold' or '--tolerance'.
+    """
     msg = ('By default, we supervise that at least one b0 exists in your '
            'data\n'
            '(i.e. b-values below the default {}). Use this option to '
-          'allow continuing \n'
+           'allow continuing \n'
            'even if the minimum b-value is suspiciously high.\n'
-          .format(b0_tol_name))
+           .format(b0_tol_name))
     if will_overwrite_with_min:
         msg += ('If no b-value is found below the threshold, the script will '
                 'continue \nwith your minimal b-value as new {}.\n'
@@ -231,13 +264,6 @@ def add_skip_b0_check_arg(parser, will_overwrite_with_min: bool,
 
     parser.add_argument(
         '--skip_b0_check', action='store_true', help=msg)
-
-
-def add_b0_thresh_arg(parser):
-    parser.add_argument(
-        '--b0_threshold', type=float, default=DEFAULT_B0_THRESHOLD,
-        help='Threshold under which b-values are considered to be b0s.\n'
-             'Default if not set is {}.'.format(DEFAULT_B0_THRESHOLD))
 
 
 def add_verbose_arg(parser):

--- a/scilpy/io/utils.py
+++ b/scilpy/io/utils.py
@@ -217,23 +217,24 @@ def add_overwrite_arg(parser):
 
 def add_tolerance_arg(parser):
     parser.add_argument(
-        '--tolerance', type=int, default=20,
+        '--tolerance', type=int, default=20, metavar='tol',
         help='The tolerated gap between the b-values to extract and the '
              'current b-value.\n'
-             'We would expect to find at least one b-value in the range '
-             '[0, tolerance], acting as a b0.\n'
-             'To skip this check, use --skip_b0_check.\n'
-             '[Default: %(default)s]')
+             '[Default: %(default)s]\n'
+             '* Note. We would expect to find at least one b-value in the \n'
+             '  range [0, tolerance]. To skip this check, use '
+             '--skip_b0_check.')
 
 
 def add_b0_thresh_arg(parser):
     parser.add_argument(
         '--b0_threshold', type=float, default=DEFAULT_B0_THRESHOLD,
+        metavar='thr',
         help='Threshold under which b-values are considered to be b0s.\n'
-             'We would expect to find at least one b-value in the range '
-             '[0, b0_threshold], acting as a b0.\n'
-             'To skip this check, use --skip_b0_check.\n'
-             'Default if not set is {}.'.format(DEFAULT_B0_THRESHOLD))
+             '[Default: %(default)s] \n'
+             '* Note. We would expect to find at least one b-value in the \n'
+             '  range [0, b0_threshold]. To skip this check, use '
+             '--skip_b0_check.')
 
 
 def add_skip_b0_check_arg(parser, will_overwrite_with_min,
@@ -252,10 +253,9 @@ def add_skip_b0_check_arg(parser, will_overwrite_with_min,
     """
     msg = ('By default, we supervise that at least one b0 exists in your '
            'data\n'
-           '(i.e. b-values below the default {}). Use this option to '
-           'allow continuing \n'
-           'even if the minimum b-value is suspiciously high.\n'
-           .format(b0_tol_name))
+           '(i.e. b-values below the default {}). Use this option to \n'
+           'allow continuing even if the minimum b-value is suspiciously '
+           'high.\n'.format(b0_tol_name))
     if will_overwrite_with_min:
         msg += ('If no b-value is found below the threshold, the script will '
                 'continue \nwith your minimal b-value as new {}.\n'

--- a/scilpy/io/utils.py
+++ b/scilpy/io/utils.py
@@ -215,14 +215,22 @@ def add_overwrite_arg(parser):
         help='Force overwriting of the output files.')
 
 
-def add_skip_b0_validation_arg(parser, b0_tol_name='--b0_threshold'):
+def add_skip_b0_check_arg(parser, will_overwrite_with_min: bool,
+                          b0_tol_name='--b0_threshold'):
+    msg = ('By default, we supervise that at least one b0 exists in your '
+           'data\n'
+           '(i.e. b-values below the default {}). Use this option to '
+          'allow continuing \n'
+           'even if the minimum b-value is suspiciously high.\n'
+          .format(b0_tol_name))
+    if will_overwrite_with_min:
+        msg += ('If no b-value is found below the threshold, the script will '
+                'continue \nwith your minimal b-value as new {}.\n'
+                .format(b0_tol_name))
+    msg += 'Use with care, and only if you understand your data.'
+
     parser.add_argument(
-        '--skip_b0_validation', action='store_true',
-        help='By default, we supervise that at least one b0 exists in your '
-             'data \n(i.e. b-values below the default {}). Use this option to '
-             'allow continuing even if the minimum \nbvalue is suspiciously '
-             'high.\nUse with care, and only if you understand your data.'
-             .format(b0_tol_name))
+        '--skip_b0_check', action='store_true', help=msg)
 
 
 def add_b0_thresh_arg(parser):

--- a/scilpy/io/utils.py
+++ b/scilpy/io/utils.py
@@ -215,11 +215,21 @@ def add_overwrite_arg(parser):
         help='Force overwriting of the output files.')
 
 
-def add_force_b0_arg(parser):
-    parser.add_argument('--force_b0_threshold', action='store_true',
-                        help='If set, the script will continue even if the '
-                             'minimum bvalue is suspiciously high ( > {})'
-                        .format(DEFAULT_B0_THRESHOLD))
+def add_skip_b0_validation_arg(parser, b0_tol_name='--b0_threshold'):
+    parser.add_argument(
+        '--skip_b0_validation', action='store_true',
+        help='By default, we supervise that at least one b0 exists in your '
+             'data \n(i.e. b-values below the default {}). Use this option to '
+             'allow continuing even if the minimum \nbvalue is suspiciously '
+             'high.\nUse with care, and only if you understand your data.'
+             .format(b0_tol_name))
+
+
+def add_b0_thresh_arg(parser):
+    parser.add_argument(
+        '--b0_threshold', type=float, default=DEFAULT_B0_THRESHOLD,
+        help='Threshold under which b-values are considered to be b0s.\n'
+             'Default if not set is {}.'.format(DEFAULT_B0_THRESHOLD))
 
 
 def add_verbose_arg(parser):

--- a/scilpy/reconst/frf.py
+++ b/scilpy/reconst/frf.py
@@ -150,9 +150,14 @@ def compute_msmt_frf(data, bvals, bvecs, btens=None, data_dti=None,
         1D bvals array with shape (N,)
     bvecs : ndarray
         2D bvecs array with shape (N, 3)
-    btens: ?
-    data_dti: ?
-    bvals_dti: ?
+    btens: ndarray 1D
+	btens array with shape (N,), describing the btensor shape of every
+        pair of bval/bvec.
+    data_dti: ndarray 4D
+        Input diffusion volume with shape (X, Y, Z, M), where M is the number
+        of DTI directions.
+    bvals_dti: ndarray 1D
+        bvals array with shape (M,)
     bvecs_dti: ?
     btens_dti: ?
     mask : ndarray, optional

--- a/scilpy/reconst/frf.py
+++ b/scilpy/reconst/frf.py
@@ -10,12 +10,13 @@ from dipy.segment.mask import applymask
 import numpy as np
 
 from scilpy.gradients.bvec_bval_tools import (check_b0_threshold,
-                                              is_normalized_bvecs, normalize_bvecs)
+                                              is_normalized_bvecs,
+                                              normalize_bvecs)
 
 
-def compute_ssst_frf(data, bvals, bvecs, mask=None, mask_wm=None,
-                     fa_thresh=0.7, min_fa_thresh=0.5, min_nvox=300,
-                     roi_radii=10, roi_center=None, force_b0_threshold=False):
+def compute_ssst_frf(data, bvals, bvecs, b0_threshold,
+                     mask=None, mask_wm=None, fa_thresh=0.7, min_fa_thresh=0.5,
+                     min_nvox=300, roi_radii=10, roi_center=None):
     """Compute a single-shell (under b=1500), single-tissue single Fiber
     Response Function from a DWI volume.
     A DTI fit is made, and voxels containing a single fiber population are
@@ -29,6 +30,8 @@ def compute_ssst_frf(data, bvals, bvecs, mask=None, mask_wm=None,
         1D bvals array with shape (N,)
     bvecs : ndarray
         2D bvecs array with shape (N, 3)
+    b0_threshold: float
+        Value under which bvals are considered b0s.
     mask : ndarray, optional
         3D mask with shape (X,Y,Z)
         Binary mask. Only the data inside the mask will be used for
@@ -55,8 +58,6 @@ def compute_ssst_frf(data, bvals, bvecs, mask=None, mask_wm=None,
     roi_center : tuple(3), optional
         Use this center to span the roi of size roi_radius (center of the
         3D volume).
-    force_b0_threshold : bool, optional
-        If set, will continue even if the minimum bvalue is suspiciously high.
 
     Returns
     -------
@@ -78,9 +79,7 @@ def compute_ssst_frf(data, bvals, bvecs, mask=None, mask_wm=None,
         logging.warning("Your b-vectors do not seem normalized... Normalizing")
         bvecs = normalize_bvecs(bvecs)
 
-    b0_thr = check_b0_threshold(force_b0_threshold, bvals.min(), bvals.min())
-
-    gtab = gradient_table(bvals, bvecs, b0_threshold=b0_thr)
+    gtab = gradient_table(bvals, bvecs, b0_threshold=b0_threshold)
 
     if mask is not None:
         data = applymask(data, mask)

--- a/scilpy/reconst/frf.py
+++ b/scilpy/reconst/frf.py
@@ -11,10 +11,11 @@ import numpy as np
 
 from scilpy.gradients.bvec_bval_tools import (check_b0_threshold,
                                               is_normalized_bvecs,
-                                              normalize_bvecs)
+                                              normalize_bvecs,
+                                              DEFAULT_B0_THRESHOLD)
 
 
-def compute_ssst_frf(data, bvals, bvecs, b0_threshold,
+def compute_ssst_frf(data, bvals, bvecs, b0_threshold=DEFAULT_B0_THRESHOLD,
                      mask=None, mask_wm=None, fa_thresh=0.7, min_fa_thresh=0.5,
                      min_nvox=300, roi_radii=10, roi_center=None):
     """Compute a single-shell (under b=1500), single-tissue single Fiber
@@ -151,8 +152,8 @@ def compute_msmt_frf(data, bvals, bvecs, btens=None, data_dti=None,
     bvecs : ndarray
         2D bvecs array with shape (N, 3)
     btens: ndarray 1D
-	btens array with shape (N,), describing the btensor shape of every
-        pair of bval/bvec.
+        btens array with shape (N,), describing the btensor shape of every
+            pair of bval/bvec.
     data_dti: ndarray 4D
         Input diffusion volume with shape (X, Y, Z, M), where M is the number
         of DTI directions.
@@ -227,10 +228,10 @@ def compute_msmt_frf(data, bvals, bvecs, btens=None, data_dti=None,
         logging.warning('Your b-vectors do not seem normalized...')
         bvecs = normalize_bvecs(bvecs)
 
-    # toDo. Using a fake b0_threshold here because currently, the
-    #  gtab.b0s_mask is not used. Below, we use the tolerance only in dipy.
-    #  An issue has been added in dipy too.
-    gtab = gradient_table(bvals, bvecs, btens=btens, b0_threshold=bvals.min())
+    # Note. Using the tolerance here because currently, the gtab.b0s_mask is
+    # not used. Below, we use the tolerance only (in dipy).
+    # An issue has been added in dipy too.
+    gtab = gradient_table(bvals, bvecs, btens=btens, b0_threshold=tol)
 
     if data_dti is None and bvals_dti is None and bvecs_dti is None:
         logging.warning(

--- a/scilpy/reconst/frf.py
+++ b/scilpy/reconst/frf.py
@@ -136,8 +136,7 @@ def compute_msmt_frf(data, bvals, bvecs, btens=None, data_dti=None,
                      mask=None, mask_wm=None, mask_gm=None, mask_csf=None,
                      fa_thr_wm=0.7, fa_thr_gm=0.2, fa_thr_csf=0.1,
                      md_thr_gm=0.0007, md_thr_csf=0.003, min_nvox=300,
-                     roi_radii=10, roi_center=None, tol=20,
-                     force_b0_threshold=False):
+                     roi_radii=10, roi_center=None, tol=20):
     """Compute a multi-shell, multi-tissue single Fiber
     Response Function from a DWI volume.
     A DTI fit is made, and voxels containing a single fiber population are
@@ -151,6 +150,11 @@ def compute_msmt_frf(data, bvals, bvecs, btens=None, data_dti=None,
         1D bvals array with shape (N,)
     bvecs : ndarray
         2D bvecs array with shape (N, 3)
+    btens: ?
+    data_dti: ?
+    bvals_dti: ?
+    bvecs_dti: ?
+    btens_dti: ?
     mask : ndarray, optional
         3D mask with shape (X,Y,Z)
         Binary mask. Only the data inside the mask will be used for
@@ -199,8 +203,6 @@ def compute_msmt_frf(data, bvals, bvecs, btens=None, data_dti=None,
         3D volume).
     tol : int
         tolerance gap for b-values clustering. Defaults to 20
-    force_b0_threshold : bool, optional
-        If set, will continue even if the minimum bvalue is suspiciously high.
 
     Returns
     -------
@@ -220,9 +222,10 @@ def compute_msmt_frf(data, bvals, bvecs, btens=None, data_dti=None,
         logging.warning('Your b-vectors do not seem normalized...')
         bvecs = normalize_bvecs(bvecs)
 
-    b0_thr = check_b0_threshold(force_b0_threshold, bvals.min(), bvals.min())
-
-    gtab = gradient_table(bvals, bvecs, btens=btens, b0_threshold=b0_thr)
+    # toDo. Using a fake b0_threshold here because currently, the
+    #  gtab.b0s_mask is not used. Below, we use the tolerance only in dipy.
+    #  An issue has been added in dipy too.
+    gtab = gradient_table(bvals, bvecs, btens=btens, b0_threshold=bvals.min())
 
     if data_dti is None and bvals_dti is None and bvecs_dti is None:
         logging.warning(
@@ -243,7 +246,6 @@ def compute_msmt_frf(data, bvals, bvecs, btens=None, data_dti=None,
             logging.warning('Your b-vectors do not seem normalized...')
             bvecs_dti = normalize_bvecs(bvecs_dti)
 
-        check_b0_threshold(force_b0_threshold, bvals_dti.min())
         gtab_dti = gradient_table(bvals_dti, bvecs_dti, btens=btens_dti)
 
         wm_frf_mask, gm_frf_mask, csf_frf_mask \

--- a/scilpy/reconst/frf.py
+++ b/scilpy/reconst/frf.py
@@ -153,14 +153,16 @@ def compute_msmt_frf(data, bvals, bvecs, btens=None, data_dti=None,
         2D bvecs array with shape (N, 3)
     btens: ndarray 1D
         btens array with shape (N,), describing the btensor shape of every
-            pair of bval/bvec.
+        pair of bval/bvec.
     data_dti: ndarray 4D
         Input diffusion volume with shape (X, Y, Z, M), where M is the number
         of DTI directions.
     bvals_dti: ndarray 1D
         bvals array with shape (M,)
-    bvecs_dti: ?
-    btens_dti: ?
+    bvecs_dti: ndarray 2D
+        bvals array with shape (M, 3)
+    btens_dti: ndarray 1D
+        bvals array with shape (M,)
     mask : ndarray, optional
         3D mask with shape (X,Y,Z)
         Binary mask. Only the data inside the mask will be used for

--- a/scilpy/reconst/sh.py
+++ b/scilpy/reconst/sh.py
@@ -10,18 +10,17 @@ from dipy.reconst.odf import gfa
 from dipy.reconst.shm import (sh_to_sf_matrix, order_from_ncoef, sf_to_sh,
                               sph_harm_ind_list)
 
-from scilpy.gradients.bvec_bval_tools import (check_b0_threshold,
-                                              identify_shells,
+from scilpy.gradients.bvec_bval_tools import (identify_shells,
                                               is_normalized_bvecs,
                                               normalize_bvecs)
 from scilpy.dwi.operations import compute_dwi_attenuation
 
 
-def compute_sh_coefficients(dwi, gradient_table, sh_order=4,
+def compute_sh_coefficients(dwi, gradient_table, b0_threshold, sh_order=4,
                             basis_type='descoteaux07', smooth=0.006,
-                            use_attenuation=False, force_b0_threshold=False,
-                            mask=None, sphere=None):
+                            use_attenuation=False, mask=None, sphere=None):
     """Fit a diffusion signal with spherical harmonics coefficients.
+    Data must come from a single shell acquisition.
 
     Parameters
     ----------
@@ -29,6 +28,9 @@ def compute_sh_coefficients(dwi, gradient_table, sh_order=4,
         Diffusion signal as weighted images (4D).
     gradient_table : GradientTable
         Dipy object that contains all bvals and bvecs.
+    b0_threshold: float
+        Threshold for the b0 values. Used to validate that the data contains
+        single shell signal.
     sh_order : int, optional
         SH order to fit, by default 4.
     smooth : float, optional
@@ -37,8 +39,6 @@ def compute_sh_coefficients(dwi, gradient_table, sh_order=4,
         Either 'tournier07' or 'descoteaux07'
     use_attenuation: bool, optional
         If true, we will use DWI attenuation. [False]
-    force_b0_threshold : bool, optional
-        If set, will continue even if the minimum bvalue is suspiciously high.
     mask: nib.Nifti1Image object, optional
         Binary mask. Only data inside the mask will be used for computations
         and reconstruction.
@@ -61,8 +61,6 @@ def compute_sh_coefficients(dwi, gradient_table, sh_order=4,
     if not is_normalized_bvecs(bvecs):
         logging.warning("Your b-vectors do not seem normalized...")
         bvecs = normalize_bvecs(bvecs)
-
-    b0_threshold = check_b0_threshold(force_b0_threshold, bvals.min())
 
     # Ensure that this is on a single shell.
     shell_values, _ = identify_shells(bvals)

--- a/scilpy/reconst/sh.py
+++ b/scilpy/reconst/sh.py
@@ -12,11 +12,13 @@ from dipy.reconst.shm import (sh_to_sf_matrix, order_from_ncoef, sf_to_sh,
 
 from scilpy.gradients.bvec_bval_tools import (identify_shells,
                                               is_normalized_bvecs,
-                                              normalize_bvecs)
+                                              normalize_bvecs,
+                                              DEFAULT_B0_THRESHOLD)
 from scilpy.dwi.operations import compute_dwi_attenuation
 
 
-def compute_sh_coefficients(dwi, gradient_table, b0_threshold, sh_order=4,
+def compute_sh_coefficients(dwi, gradient_table,
+                            b0_threshold=DEFAULT_B0_THRESHOLD, sh_order=4,
                             basis_type='descoteaux07', smooth=0.006,
                             use_attenuation=False, mask=None, sphere=None):
     """Fit a diffusion signal with spherical harmonics coefficients.

--- a/scripts/scil_btensor_metrics.py
+++ b/scripts/scil_btensor_metrics.py
@@ -50,8 +50,8 @@ from scilpy.image.utils import extract_affine
 from scilpy.io.btensor import generate_btensor_input
 from scilpy.io.image import get_data_as_mask
 from scilpy.io.utils import (add_overwrite_arg, assert_inputs_exist,
-                             assert_outputs_exist, add_force_b0_arg,
-                             add_processes_arg, add_verbose_arg)
+                             assert_outputs_exist, add_processes_arg,
+                             add_verbose_arg)
 from scilpy.reconst.divide import fit_gamma, gamma_fit2metrics
 
 
@@ -110,7 +110,6 @@ def _build_arg_parser():
         '--fa',
         help='Path to a FA map. Needed for calculating the OP.')
 
-    add_force_b0_arg(p)
     add_processes_arg(p)
     add_verbose_arg(p)
     add_overwrite_arg(p)
@@ -181,6 +180,10 @@ def main():
     # Loading
     affine = extract_affine(args.in_dwis)
 
+    # Note. This script does not currently allow using a separate b0_threshold
+    # for the b0s. Using the tolerance. To change this, we would have to
+    # change generate_btensor_input. Not doing any verification on the
+    # bvals. Typically, we would use check_b0_threshold(bvals.min(), args)
     data, gtab_infos = generate_btensor_input(args.in_dwis,
                                               args.in_bvals,
                                               args.in_bvecs,

--- a/scripts/scil_btensor_metrics.py
+++ b/scripts/scil_btensor_metrics.py
@@ -51,7 +51,8 @@ from scilpy.io.btensor import generate_btensor_input
 from scilpy.io.image import get_data_as_mask
 from scilpy.io.utils import (add_overwrite_arg, assert_inputs_exist,
                              assert_outputs_exist, add_processes_arg,
-                             add_verbose_arg, add_skip_b0_check_arg)
+                             add_verbose_arg, add_skip_b0_check_arg,
+                             add_tolerance_arg)
 from scilpy.reconst.divide import fit_gamma, gamma_fit2metrics
 
 
@@ -77,10 +78,7 @@ def _build_arg_parser():
         '--mask',
         help='Path to a binary mask. Only the data inside the '
              'mask will be used for computations and reconstruction.')
-    p.add_argument(
-        '--tolerance', type=int, default=20,
-        help='The tolerated gap between the b-values to '
-             'extract\nand the current b-value. [%(default)s]')
+    add_tolerance_arg(p)
     add_skip_b0_check_arg(p, will_overwrite_with_min=False,
                           b0_tol_name='--tolerance')
     p.add_argument(

--- a/scripts/scil_btensor_metrics.py
+++ b/scripts/scil_btensor_metrics.py
@@ -51,7 +51,7 @@ from scilpy.io.btensor import generate_btensor_input
 from scilpy.io.image import get_data_as_mask
 from scilpy.io.utils import (add_overwrite_arg, assert_inputs_exist,
                              assert_outputs_exist, add_processes_arg,
-                             add_verbose_arg)
+                             add_verbose_arg, add_skip_b0_check_arg)
 from scilpy.reconst.divide import fit_gamma, gamma_fit2metrics
 
 
@@ -81,6 +81,8 @@ def _build_arg_parser():
         '--tolerance', type=int, default=20,
         help='The tolerated gap between the b-values to '
              'extract\nand the current b-value. [%(default)s]')
+    add_skip_b0_check_arg(p, will_overwrite_with_min=False,
+                          b0_tol_name='--tolerance')
     p.add_argument(
         '--fit_iters', type=int, default=1,
         help='The number of time the gamma fit will be done [%(default)s]')
@@ -182,14 +184,14 @@ def main():
 
     # Note. This script does not currently allow using a separate b0_threshold
     # for the b0s. Using the tolerance. To change this, we would have to
-    # change generate_btensor_input. Not doing any verification on the
-    # bvals. Typically, we would use check_b0_threshold(bvals.min(), args)
+    # change generate_btensor_input.
     data, gtab_infos = generate_btensor_input(args.in_dwis,
                                               args.in_bvals,
                                               args.in_bvecs,
                                               args.in_bdeltas,
                                               do_pa_signals=True,
-                                              tol=args.tolerance)
+                                              tol=args.tolerance,
+                                              skip_b0_check=args.skip_b0_check)
 
     gtab_infos[0] *= 1e6  # getting bvalues to SI units
 

--- a/scripts/scil_dki_metrics.py
+++ b/scripts/scil_dki_metrics.py
@@ -60,9 +60,10 @@ from scilpy.io.image import get_data_as_mask
 from scilpy.io.utils import (add_overwrite_arg, add_skip_b0_validation_arg,
                              add_verbose_arg, assert_inputs_exist,
                              assert_outputs_exist, )
-from scilpy.gradients.bvec_bval_tools import (is_normalized_bvecs,
+from scilpy.gradients.bvec_bval_tools import (check_b0_threshold,
+                                              is_normalized_bvecs,
                                               identify_shells,
-                                              normalize_bvecs, check_b0_threshold)
+                                              normalize_bvecs)
 
 
 def _build_arg_parser():

--- a/scripts/scil_dki_metrics.py
+++ b/scripts/scil_dki_metrics.py
@@ -59,7 +59,7 @@ from scilpy.image.volume_operations import smooth_to_fwhm
 from scilpy.io.image import get_data_as_mask
 from scilpy.io.utils import (add_overwrite_arg, add_skip_b0_check_arg,
                              add_verbose_arg, assert_inputs_exist,
-                             assert_outputs_exist, )
+                             assert_outputs_exist, add_tolerance_arg, )
 from scilpy.gradients.bvec_bval_tools import (check_b0_threshold,
                                               is_normalized_bvecs,
                                               identify_shells,
@@ -82,14 +82,7 @@ def _build_arg_parser():
                         'Only data inside the mask will be used for '
                         'computations and reconstruction.\n[Default: None]')
 
-    p.add_argument('--tolerance', '-t',
-                   metavar='INT', type=int, default=20,
-                   help='The tolerated distance between the b-values to '
-                   'extract\nand the actual b-values.\n'
-                   'We would expect to find at least one b-value in the range '
-                   '[0, tolerance], acting as a b0.\n'
-                   'To skip this check, use --skip_b0_validation.\n'
-                   '[Default: %(default)s]')
+    add_tolerance_arg(p)
     add_skip_b0_check_arg(p, will_overwrite_with_min=False,
                           b0_tol_name='--tolerance')
 

--- a/scripts/scil_dki_metrics.py
+++ b/scripts/scil_dki_metrics.py
@@ -57,7 +57,7 @@ from dipy.core.gradients import gradient_table
 from scilpy.dwi.operations import compute_residuals
 from scilpy.image.volume_operations import smooth_to_fwhm
 from scilpy.io.image import get_data_as_mask
-from scilpy.io.utils import (add_overwrite_arg, add_skip_b0_validation_arg,
+from scilpy.io.utils import (add_overwrite_arg, add_skip_b0_check_arg,
                              add_verbose_arg, assert_inputs_exist,
                              assert_outputs_exist, )
 from scilpy.gradients.bvec_bval_tools import (check_b0_threshold,
@@ -90,7 +90,8 @@ def _build_arg_parser():
                    '[0, tolerance], acting as a b0.\n'
                    'To skip this check, use --skip_b0_validation.\n'
                    '[Default: %(default)s]')
-    add_skip_b0_validation_arg(p, b0_tol_name='--tolerance')
+    add_skip_b0_check_arg(p, will_overwrite_with_min=False,
+                          b0_tol_name='--tolerance')
 
     p.add_argument('--min_k', type=float, default=0.0,
                    help='Minimum kurtosis value in the output maps '
@@ -204,9 +205,9 @@ def main():
     #  https://github.com/dipy/dipy/issues/3015
     # b0_threshold option in gradient_table probably unused, except below with
     # option dki_residual.
-    args.b0_threshold = args.tolerance
-    args.b0_threshold = check_b0_threshold(bvals.min(), args)
-    gtab = gradient_table(bvals, bvecs, b0_threshold=args.b0_threshold)
+    _ = check_b0_threshold(bvals.min(), b0_threshold=args.tolerance,
+                           skip_b0_check=args.skip_b0_check)
+    gtab = gradient_table(bvals, bvecs, b0_threshold=args.tolerance)
 
     # Processing
 

--- a/scripts/scil_dki_metrics.py
+++ b/scripts/scil_dki_metrics.py
@@ -198,7 +198,7 @@ def main():
     #  https://github.com/dipy/dipy/issues/3015
     # b0_threshold option in gradient_table probably unused, except below with
     # option dki_residual.
-    _ = check_b0_threshold(bvals.min(), b0_threshold=args.tolerance,
+    _ = check_b0_threshold(bvals.min(), b0_thr=args.tolerance,
                            skip_b0_check=args.skip_b0_check)
     gtab = gradient_table(bvals, bvecs, b0_threshold=args.tolerance)
 

--- a/scripts/scil_dti_metrics.py
+++ b/scripts/scil_dti_metrics.py
@@ -45,7 +45,7 @@ from scilpy.dwi.operations import compute_residuals, \
     compute_residuals_statistics
 from scilpy.io.image import get_data_as_mask
 from scilpy.io.utils import (add_b0_thresh_arg, add_overwrite_arg,
-                             add_skip_b0_validation_arg, add_verbose_arg,
+                             add_skip_b0_check_arg, add_verbose_arg,
                              assert_inputs_exist, assert_outputs_exist)
 from scilpy.io.tensor import convert_tensor_from_dipy_format, \
     supported_tensor_formats, tensor_format_description
@@ -142,7 +142,7 @@ def _build_arg_parser():
         help='Output filename for the map of the residual of the tensor fit.')
 
     add_b0_thresh_arg(p)
-    add_skip_b0_validation_arg(p)
+    add_skip_b0_check_arg(p, will_overwrite_with_min=True)
     add_verbose_arg(p)
 
     return p
@@ -273,7 +273,9 @@ def main():
     #         method .fit().
     # 2) But we do use this information below, with options p_i_signal,
     #    pulsation and residual.
-    args.b0_threshold = check_b0_threshold(bvals.min(), args)
+    args.b0_threshold = check_b0_threshold(bvals.min(),
+                                           b0_threshold=args.b0_threshold,
+                                           skip_b0_check=args.skip_b0_check)
     gtab = gradient_table(bvals, bvecs, b0_threshold=args.b0_threshold)
 
     # Processing

--- a/scripts/scil_dti_metrics.py
+++ b/scripts/scil_dti_metrics.py
@@ -274,7 +274,7 @@ def main():
     # 2) But we do use this information below, with options p_i_signal,
     #    pulsation and residual.
     args.b0_threshold = check_b0_threshold(bvals.min(),
-                                           b0_threshold=args.b0_threshold,
+                                           b0_thr=args.b0_threshold,
                                            skip_b0_check=args.skip_b0_check)
     gtab = gradient_table(bvals, bvecs, b0_threshold=args.b0_threshold)
 

--- a/scripts/scil_dti_metrics.py
+++ b/scripts/scil_dti_metrics.py
@@ -273,7 +273,7 @@ def main():
     #         method .fit().
     # 2) But we do use this information below, with options p_i_signal,
     #    pulsation and residual.
-    check_b0_threshold(bvals.min(), args)
+    args.b0_threshold = check_b0_threshold(bvals.min(), args)
     gtab = gradient_table(bvals, bvecs, b0_threshold=args.b0_threshold)
 
     # Processing

--- a/scripts/scil_dti_metrics.py
+++ b/scripts/scil_dti_metrics.py
@@ -46,12 +46,12 @@ from scilpy.dwi.operations import compute_residuals, \
 from scilpy.io.image import get_data_as_mask
 from scilpy.io.utils import (add_b0_thresh_arg, add_overwrite_arg,
                              add_skip_b0_validation_arg, add_verbose_arg,
-                             assert_inputs_exist,assert_outputs_exist)
+                             assert_inputs_exist, assert_outputs_exist)
 from scilpy.io.tensor import convert_tensor_from_dipy_format, \
     supported_tensor_formats, tensor_format_description
-from scilpy.gradients.bvec_bval_tools import (normalize_bvecs,
+from scilpy.gradients.bvec_bval_tools import (check_b0_threshold,
                                               is_normalized_bvecs,
-                                              check_b0_threshold)
+                                              normalize_bvecs)
 from scilpy.utils.filenames import add_filename_suffix, split_name_with_nii
 
 logger = logging.getLogger("DTI_Metrics")

--- a/scripts/scil_dwi_detect_volume_outliers.py
+++ b/scripts/scil_dwi_detect_volume_outliers.py
@@ -8,7 +8,7 @@ If the angles or correlations to neighbors are below the shell average (by
 args.std_scale x STD) it will flag the volume as a potential outlier.
 
 This script supports multi-shells, but each shell is independant and detected
-using the args.b0_threshold parameter.
+using the --b0_threshold parameter.
 
 This script can be run before any processing to identify potential problem
 before launching pre-processing.
@@ -20,9 +20,10 @@ import logging
 from dipy.io.gradients import read_bvals_bvecs
 import nibabel as nib
 
+
 from scilpy.dwi.operations import detect_volume_outliers
-from scilpy.io.utils import (add_b0_thresh_arg, add_skip_b0_validation_arg,
-                             add_verbose_arg, assert_inputs_exist,)
+from scilpy.io.utils import (add_b0_thresh_arg, add_skip_b0_check_arg,
+                             add_verbose_arg, assert_inputs_exist, )
 from scilpy.gradients.bvec_bval_tools import (check_b0_threshold,
                                               normalize_bvecs)
 
@@ -44,7 +45,7 @@ def _build_arg_parser():
                         'considered an outlier. [%(default)s]')
 
     add_b0_thresh_arg(p)
-    add_skip_b0_validation_arg(p)
+    add_skip_b0_check_arg(p, will_overwrite_with_min=True)
     add_verbose_arg(p)
 
     return p
@@ -63,7 +64,9 @@ def main():
     bvals, bvecs = read_bvals_bvecs(args.in_bval, args.in_bvec)
     data = nib.load(args.in_dwi).get_fdata()
 
-    args.b0_threshold = check_b0_threshold(bvals.min(), args)
+    args.b0_threshold = check_b0_threshold(bvals.min(),
+                                           b0_threshold=args.b0_threshold,
+                                           skip_b0_check=args.skip_b0_check)
     bvecs = normalize_bvecs(bvecs)
 
     # Not using the result. Only printing on screen. This is why the logging

--- a/scripts/scil_dwi_detect_volume_outliers.py
+++ b/scripts/scil_dwi_detect_volume_outliers.py
@@ -8,7 +8,7 @@ If the angles or correlations to neighbors are below the shell average (by
 args.std_scale x STD) it will flag the volume as a potential outlier.
 
 This script supports multi-shells, but each shell is independant and detected
-using the args.b0_thr parameter.
+using the args.b0_threshold parameter.
 
 This script can be run before any processing to identify potential problem
 before launching pre-processing.
@@ -21,9 +21,8 @@ from dipy.io.gradients import read_bvals_bvecs
 import nibabel as nib
 
 from scilpy.dwi.operations import detect_volume_outliers
-from scilpy.io.utils import (assert_inputs_exist,
-                             add_force_b0_arg,
-                             add_verbose_arg)
+from scilpy.io.utils import (add_b0_thresh_arg, add_skip_b0_validation_arg,
+                             add_verbose_arg, assert_inputs_exist,)
 from scilpy.gradients.bvec_bval_tools import (check_b0_threshold,
                                               normalize_bvecs)
 
@@ -40,15 +39,12 @@ def _build_arg_parser():
     p.add_argument('in_bvec',
                    help='The b-vectors files in FSL format (.bvec).')
 
-    p.add_argument('--b0_thr', type=float, default=20.0,
-                   help='All b-values with values less than or equal '
-                        'to b0_thr are considered as b0s i.e. without '
-                        'diffusion weighting. [%(default)s]')
     p.add_argument('--std_scale', type=float, default=2.0,
                    help='How many deviation from the mean are required to be '
                         'considered an outlier. [%(default)s]')
 
-    add_force_b0_arg(p)
+    add_b0_thresh_arg(p)
+    add_skip_b0_validation_arg(p)
     add_verbose_arg(p)
 
     return p
@@ -67,13 +63,13 @@ def main():
     bvals, bvecs = read_bvals_bvecs(args.in_bval, args.in_bvec)
     data = nib.load(args.in_dwi).get_fdata()
 
-    b0_thr = check_b0_threshold(args.force_b0_threshold,
-                                bvals.min(), args.b0_thr)
+    args.b0_threshold = check_b0_threshold(bvals.min(), args)
     bvecs = normalize_bvecs(bvecs)
 
     # Not using the result. Only printing on screen. This is why the logging
     # level can never be set higher than INFO.
-    detect_volume_outliers(data, bvals, bvecs, args.std_scale, b0_thr)
+    detect_volume_outliers(data, bvals, bvecs, args.std_scale,
+                           args.b0_threshold)
 
 
 if __name__ == "__main__":

--- a/scripts/scil_dwi_detect_volume_outliers.py
+++ b/scripts/scil_dwi_detect_volume_outliers.py
@@ -65,7 +65,7 @@ def main():
     data = nib.load(args.in_dwi).get_fdata()
 
     args.b0_threshold = check_b0_threshold(bvals.min(),
-                                           b0_threshold=args.b0_threshold,
+                                           b0_thr=args.b0_threshold,
                                            skip_b0_check=args.skip_b0_check)
     bvecs = normalize_bvecs(bvecs)
 

--- a/scripts/scil_dwi_extract_b0.py
+++ b/scripts/scil_dwi_extract_b0.py
@@ -61,8 +61,8 @@ def _build_arg_parser():
 
     p.add_argument('--single-image', action='store_true',
                    help='If output b0 volume has multiple time points, only '
-                        'outputs a single image instead of a numbered series '
-                        'of images.')
+                        'outputs a single \nimage instead of a numbered '
+                        'series of images.')
 
     add_b0_thresh_arg(p)
     add_skip_b0_check_arg(p, will_overwrite_with_min=True)
@@ -96,7 +96,7 @@ def main():
     bvals, bvecs = read_bvals_bvecs(args.in_bval, args.in_bvec)
 
     args.b0_threshold = check_b0_threshold(bvals.min(),
-                                           b0_threshold=args.b0_threshold,
+                                           b0_thr=args.b0_threshold,
                                            skip_b0_check=args.skip_b0_check)
     gtab = gradient_table(bvals, bvecs, b0_threshold=args.b0_threshold)
     b0_idx = np.where(gtab.b0s_mask)[0]

--- a/scripts/scil_dwi_extract_b0.py
+++ b/scripts/scil_dwi_extract_b0.py
@@ -21,7 +21,7 @@ import numpy as np
 
 from scilpy.dwi.utils import extract_b0
 from scilpy.io.utils import (add_b0_thresh_arg, add_overwrite_arg,
-                             add_skip_b0_validation_arg, add_verbose_arg,
+                             add_skip_b0_check_arg, add_verbose_arg,
                              assert_inputs_exist)
 from scilpy.gradients.bvec_bval_tools import (check_b0_threshold,
                                               B0ExtractionStrategy)
@@ -65,7 +65,7 @@ def _build_arg_parser():
                         'of images.')
 
     add_b0_thresh_arg(p)
-    add_skip_b0_validation_arg(p)
+    add_skip_b0_check_arg(p, will_overwrite_with_min=True)
     add_verbose_arg(p)
     add_overwrite_arg(p)
 
@@ -95,7 +95,9 @@ def main():
 
     bvals, bvecs = read_bvals_bvecs(args.in_bval, args.in_bvec)
 
-    check_b0_threshold(bvals.min(), args)
+    args.b0_threshold = check_b0_threshold(bvals.min(),
+                                           b0_threshold=args.b0_threshold,
+                                           skip_b0_check=args.skip_b0_check)
     gtab = gradient_table(bvals, bvecs, b0_threshold=args.b0_threshold)
     b0_idx = np.where(gtab.b0s_mask)[0]
 

--- a/scripts/scil_dwi_extract_b0.py
+++ b/scripts/scil_dwi_extract_b0.py
@@ -20,8 +20,9 @@ import nibabel as nib
 import numpy as np
 
 from scilpy.dwi.utils import extract_b0
-from scilpy.io.utils import (assert_inputs_exist, add_force_b0_arg,
-                             add_verbose_arg, add_overwrite_arg)
+from scilpy.io.utils import (add_b0_thresh_arg, add_overwrite_arg,
+                             add_skip_b0_validation_arg, add_verbose_arg,
+                             assert_inputs_exist)
 from scilpy.gradients.bvec_bval_tools import (check_b0_threshold,
                                               B0ExtractionStrategy)
 from scilpy.utils.filenames import split_name_with_nii
@@ -40,10 +41,6 @@ def _build_arg_parser():
                    help='b-values filename, in FSL format (.bvec).')
     p.add_argument('out_b0',
                    help='Output b0 file(s).')
-    p.add_argument('--b0_thr', type=float, default=0.0,
-                   help='All b-values with values less than or equal '
-                        'to b0_thr are considered as b0s i.e. without '
-                        'diffusion weighting. [%(default)s]')
 
     group_ = p.add_argument_group("Options in the case of multiple b0s.")
     group = group_.add_mutually_exclusive_group()
@@ -67,8 +64,9 @@ def _build_arg_parser():
                         'outputs a single image instead of a numbered series '
                         'of images.')
 
+    add_b0_thresh_arg(p)
+    add_skip_b0_validation_arg(p)
     add_verbose_arg(p)
-    add_force_b0_arg(p)
     add_overwrite_arg(p)
 
     return p
@@ -97,10 +95,8 @@ def main():
 
     bvals, bvecs = read_bvals_bvecs(args.in_bval, args.in_bvec)
 
-    b0_threshold = check_b0_threshold(
-        args.force_b0_threshold, bvals.min(), args.b0_thr)
-
-    gtab = gradient_table(bvals, bvecs, b0_threshold=b0_threshold)
+    check_b0_threshold(bvals.min(), args)
+    gtab = gradient_table(bvals, bvecs, b0_threshold=args.b0_threshold)
     b0_idx = np.where(gtab.b0s_mask)[0]
 
     logger.info('Number of b0 images in the data: {}'.format(len(b0_idx)))

--- a/scripts/scil_dwi_to_sh.py
+++ b/scripts/scil_dwi_to_sh.py
@@ -72,7 +72,7 @@ def main():
 
     # gtab.b0s_mask in used in compute_sh_coefficients to get the b0s.
     args.b0_threshold = check_b0_threshold(bvals.min(),
-                                           b0_threshold=args.b0_threshold,
+                                           b0_thr=args.b0_threshold,
                                            skip_b0_check=args.skip_b0_check)
     gtab = gradient_table(bvals, bvecs, b0_threshold=args.b0_threshold)
 

--- a/scripts/scil_dwi_to_sh.py
+++ b/scripts/scil_dwi_to_sh.py
@@ -18,7 +18,7 @@ import numpy as np
 from scilpy.gradients.bvec_bval_tools import check_b0_threshold
 from scilpy.io.image import get_data_as_mask
 from scilpy.io.utils import (add_b0_thresh_arg, add_overwrite_arg,
-                             add_sh_basis_args, add_skip_b0_validation_arg,
+                             add_sh_basis_args, add_skip_b0_check_arg,
                              add_verbose_arg, assert_inputs_exist,
                              assert_outputs_exist)
 from scilpy.reconst.sh import compute_sh_coefficients
@@ -50,7 +50,7 @@ def _build_arg_parser():
                         'will be used for computations and reconstruction ')
 
     add_b0_thresh_arg(p)
-    add_skip_b0_validation_arg(p)
+    add_skip_b0_check_arg(p, will_overwrite_with_min=True)
     add_verbose_arg(p)
     add_overwrite_arg(p)
 
@@ -71,7 +71,9 @@ def main():
     bvals, bvecs = read_bvals_bvecs(args.in_bval, args.in_bvec)
 
     # gtab.b0s_mask in used in compute_sh_coefficients to get the b0s.
-    args.b0_threshold = check_b0_threshold(bvals.min(), args)
+    args.b0_threshold = check_b0_threshold(bvals.min(),
+                                           b0_threshold=args.b0_threshold,
+                                           skip_b0_check=args.skip_b0_check)
     gtab = gradient_table(bvals, bvecs, b0_threshold=args.b0_threshold)
 
     mask = None

--- a/scripts/scil_dwi_to_sh.py
+++ b/scripts/scil_dwi_to_sh.py
@@ -15,10 +15,12 @@ from dipy.io.gradients import read_bvals_bvecs
 import nibabel as nib
 import numpy as np
 
+from scilpy.gradients.bvec_bval_tools import check_b0_threshold
 from scilpy.io.image import get_data_as_mask
-from scilpy.io.utils import (add_force_b0_arg, add_overwrite_arg,
-                             add_sh_basis_args, assert_inputs_exist,
-                             add_verbose_arg, assert_outputs_exist)
+from scilpy.io.utils import (add_b0_thresh_arg, add_overwrite_arg,
+                             add_sh_basis_args, add_skip_b0_validation_arg,
+                             add_verbose_arg, assert_inputs_exist,
+                             assert_outputs_exist)
 from scilpy.reconst.sh import compute_sh_coefficients
 
 
@@ -43,11 +45,12 @@ def _build_arg_parser():
     p.add_argument('--use_attenuation', action='store_true',
                    help='If set, will use signal attenuation before fitting '
                         'the SH (i.e. divide by the b0).')
-    add_force_b0_arg(p)
     p.add_argument('--mask',
                    help='Path to a binary mask.\nOnly data inside the mask '
                         'will be used for computations and reconstruction ')
-    
+
+    add_b0_thresh_arg(p)
+    add_skip_b0_validation_arg(p)
     add_verbose_arg(p)
     add_overwrite_arg(p)
 
@@ -66,14 +69,17 @@ def main():
     dwi = vol.get_fdata(dtype=np.float32)
 
     bvals, bvecs = read_bvals_bvecs(args.in_bval, args.in_bvec)
-    gtab = gradient_table(args.in_bval, args.in_bvec, b0_threshold=bvals.min())
+
+    # gtab.b0s_mask in used in compute_sh_coefficients to get the b0s.
+    args.b0_threshold = check_b0_threshold(bvals.min(), args)
+    gtab = gradient_table(bvals, bvecs, b0_threshold=args.b0_threshold)
 
     mask = None
     if args.mask:
         mask = get_data_as_mask(nib.load(args.mask), dtype=bool)
 
-    sh = compute_sh_coefficients(dwi, gtab, args.sh_order, args.sh_basis,
-                                 args.smooth,
+    sh = compute_sh_coefficients(dwi, gtab, args.b0_threshold,
+                                 args.sh_order, args.sh_basis, args.smooth,
                                  use_attenuation=args.use_attenuation,
                                  mask=mask)
 

--- a/scripts/scil_fodf_memsmt.py
+++ b/scripts/scil_fodf_memsmt.py
@@ -52,7 +52,7 @@ from scilpy.io.image import get_data_as_mask
 from scilpy.io.utils import (add_overwrite_arg, add_processes_arg,
                              add_sh_basis_args, add_verbose_arg,
                              assert_inputs_exist, assert_outputs_exist,
-                             add_skip_b0_check_arg)
+                             add_skip_b0_check_arg, add_tolerance_arg)
 from scilpy.reconst.fodf import fit_from_model
 from scilpy.reconst.sh import convert_sh_basis
 
@@ -89,10 +89,7 @@ def _build_arg_parser():
         '--mask',
         help='Path to a binary mask. Only the data inside the '
              'mask will be used for computations and reconstruction.')
-    p.add_argument(
-        '--tolerance', type=int, default=20,
-        help='The tolerated gap between the b-values to '
-             'extract\nand the current b-value. [%(default)s]')
+    add_tolerance_arg(p)
     add_skip_b0_check_arg(p, will_overwrite_with_min=False,
                           b0_tol_name='--tolerance')
 

--- a/scripts/scil_fodf_memsmt.py
+++ b/scripts/scil_fodf_memsmt.py
@@ -49,9 +49,9 @@ from scilpy.image.utils import extract_affine
 from scilpy.io.btensor import (generate_btensor_input,
                                convert_bdelta_to_bshape)
 from scilpy.io.image import get_data_as_mask
-from scilpy.io.utils import (add_overwrite_arg, assert_inputs_exist,
-                             assert_outputs_exist, add_sh_basis_args,
-                             add_processes_arg, add_verbose_arg)
+from scilpy.io.utils import (add_overwrite_arg, add_processes_arg,
+                             add_sh_basis_args, add_verbose_arg,
+                             assert_inputs_exist, assert_outputs_exist)
 from scilpy.reconst.fodf import fit_from_model
 from scilpy.reconst.sh import convert_sh_basis
 
@@ -156,17 +156,19 @@ def main():
 
     affine = extract_affine(args.in_dwis)
 
-    tol = args.tolerance
-
     wm_frf = np.loadtxt(args.in_wm_frf)
     gm_frf = np.loadtxt(args.in_gm_frf)
     csf_frf = np.loadtxt(args.in_csf_frf)
 
+    # Note. This script does not currently allow using a separate b0_threshold
+    # for the b0s. Using the tolerance. To change this, we would have to
+    # change generate_btensor_input. Not doing any verification on the
+    # bvals. Typically, we would use check_b0_threshold(bvals.min(), args)
     gtab, data, ubvals, ubdeltas = generate_btensor_input(args.in_dwis,
                                                           args.in_bvals,
                                                           args.in_bvecs,
                                                           args.in_bdeltas,
-                                                          tol=tol)
+                                                          tol=args.tolerance)
 
     # Checking mask
     if args.mask is None:
@@ -208,7 +210,7 @@ def main():
     memsmt_response = multi_shell_fiber_response(sh_order,
                                                  ubvals,
                                                  wm_frf, gm_frf, csf_frf,
-                                                 tol=tol,
+                                                 tol=args.tolerance,
                                                  btens=ubshapes)
 
     reg_sphere = get_sphere('symmetric362')

--- a/scripts/scil_fodf_memsmt.py
+++ b/scripts/scil_fodf_memsmt.py
@@ -51,7 +51,8 @@ from scilpy.io.btensor import (generate_btensor_input,
 from scilpy.io.image import get_data_as_mask
 from scilpy.io.utils import (add_overwrite_arg, add_processes_arg,
                              add_sh_basis_args, add_verbose_arg,
-                             assert_inputs_exist, assert_outputs_exist)
+                             assert_inputs_exist, assert_outputs_exist,
+                             add_skip_b0_check_arg)
 from scilpy.reconst.fodf import fit_from_model
 from scilpy.reconst.sh import convert_sh_basis
 
@@ -92,6 +93,8 @@ def _build_arg_parser():
         '--tolerance', type=int, default=20,
         help='The tolerated gap between the b-values to '
              'extract\nand the current b-value. [%(default)s]')
+    add_skip_b0_check_arg(p, will_overwrite_with_min=False,
+                          b0_tol_name='--tolerance')
 
     add_sh_basis_args(p)
     add_processes_arg(p)
@@ -164,11 +167,9 @@ def main():
     # for the b0s. Using the tolerance. To change this, we would have to
     # change generate_btensor_input. Not doing any verification on the
     # bvals. Typically, we would use check_b0_threshold(bvals.min(), args)
-    gtab, data, ubvals, ubdeltas = generate_btensor_input(args.in_dwis,
-                                                          args.in_bvals,
-                                                          args.in_bvecs,
-                                                          args.in_bdeltas,
-                                                          tol=args.tolerance)
+    gtab, data, ubvals, ubdeltas = generate_btensor_input(
+        args.in_dwis, args.in_bvals, args.in_bvecs, args.in_bdeltas,
+        tol=args.tolerance, skip_b0_check=args.skip_b0_check)
 
     # Checking mask
     if args.mask is None:

--- a/scripts/scil_fodf_msmt.py
+++ b/scripts/scil_fodf_msmt.py
@@ -37,7 +37,7 @@ from scilpy.io.utils import (add_overwrite_arg, add_processes_arg,
                              add_sh_basis_args, add_skip_b0_check_arg,
                              assert_inputs_exist, assert_outputs_exist,
 
-                             add_verbose_arg)
+                             add_verbose_arg, add_tolerance_arg)
 from scilpy.reconst.fodf import fit_from_model
 from scilpy.reconst.sh import convert_sh_basis
 
@@ -67,14 +67,7 @@ def _build_arg_parser():
         '--mask', metavar='',
         help='Path to a binary mask. Only the data inside the '
              'mask will be used for computations and reconstruction.')
-    p.add_argument(
-        '--tolerance', type=int, default=20,
-        help='The tolerated gap between the b-values to extract and the '
-             'current b-value.\n'
-             'We would expect to find at least one b-value in the range '
-             '[0, tolerance], acting as a b0.\n'
-             'To skip this check, use --skip_b0_check.\n'
-             '[Default: %(default)s]')
+    add_tolerance_arg(p)
     add_skip_b0_check_arg(p, will_overwrite_with_min=False,
                           b0_tol_name='--tolerance')
     add_sh_basis_args(p)

--- a/scripts/scil_fodf_msmt.py
+++ b/scripts/scil_fodf_msmt.py
@@ -34,7 +34,7 @@ from scilpy.gradients.bvec_bval_tools import (check_b0_threshold,
                                               is_normalized_bvecs)
 from scilpy.io.image import get_data_as_mask
 from scilpy.io.utils import (add_overwrite_arg, add_processes_arg,
-                             add_sh_basis_args,  add_skip_b0_validation_arg,
+                             add_sh_basis_args, add_skip_b0_check_arg,
                              assert_inputs_exist, assert_outputs_exist,
 
                              add_verbose_arg)
@@ -73,9 +73,10 @@ def _build_arg_parser():
              'current b-value.\n'
              'We would expect to find at least one b-value in the range '
              '[0, tolerance], acting as a b0.\n'
-             'To skip this check, use --skip_b0_validation.\n'
+             'To skip this check, use --skip_b0_check.\n'
              '[Default: %(default)s]')
-    add_skip_b0_validation_arg(p, b0_tol_name='--tolerance')
+    add_skip_b0_check_arg(p, will_overwrite_with_min=False,
+                          b0_tol_name='--tolerance')
     add_sh_basis_args(p)
     add_processes_arg(p)
 
@@ -167,9 +168,9 @@ def main():
     # ask them to clarify the usage of gtab.b0s_mask. See here:
     #  https://github.com/dipy/dipy/issues/3015
     # b0_threshold option in gradient_table probably unused.
-    args.b0_threshold = args.tolerance
-    args.b0_threshold = check_b0_threshold(bvals.min(), args)
-    gtab = gradient_table(bvals, bvecs, b0_threshold=args.b0_threshold)
+    _ = check_b0_threshold(bvals.min(), b0_threshold=args.tolerance,
+                           skip_b0_check=args.skip_b0_check)
+    gtab = gradient_table(bvals, bvecs, b0_threshold=args.tolerance)
 
     # Checking response functions and computing msmt response function
     if not wm_frf.shape[1] == 4:

--- a/scripts/scil_fodf_msmt.py
+++ b/scripts/scil_fodf_msmt.py
@@ -33,9 +33,10 @@ from scilpy.gradients.bvec_bval_tools import (check_b0_threshold,
                                               normalize_bvecs,
                                               is_normalized_bvecs)
 from scilpy.io.image import get_data_as_mask
-from scilpy.io.utils import (add_overwrite_arg, assert_inputs_exist,
-                             assert_outputs_exist, add_force_b0_arg,
-                             add_sh_basis_args, add_processes_arg,
+from scilpy.io.utils import (add_overwrite_arg, add_processes_arg,
+                             add_sh_basis_args,  add_skip_b0_validation_arg,
+                             assert_inputs_exist, assert_outputs_exist,
+
                              add_verbose_arg)
 from scilpy.reconst.fodf import fit_from_model
 from scilpy.reconst.sh import convert_sh_basis
@@ -69,13 +70,14 @@ def _build_arg_parser():
     p.add_argument(
         '--tolerance', type=int, default=20,
         help='The tolerated gap between the b-values to '
-             'extract and the current b-value. [%(default)s]')
-
-    add_force_b0_arg(p)
+             'extract and the current b-value.\n'
+             'We would expect to find at least one b-value in the range '
+             '[0, tolerance], acting as a b0.\n'
+             'To skip this check, use --skip_b0_validation.\n'
+             'Default: [%(default)s]')
+    add_skip_b0_validation_arg(p, b0_tol_name='--tolerance')
     add_sh_basis_args(p)
     add_processes_arg(p)
-    add_verbose_arg(p)
-    add_overwrite_arg(p)
 
     p.add_argument(
         '--not_all', action='store_true',
@@ -99,6 +101,9 @@ def _build_arg_parser():
     g.add_argument(
         '--vf_rgb', metavar='file', default='',
         help='Output filename for the volume fractions map in rgb.')
+
+    add_verbose_arg(p)
+    add_overwrite_arg(p)
 
     return p
 
@@ -142,13 +147,8 @@ def main():
         if mask.shape != data.shape[:-1]:
             raise ValueError("Mask is not the same shape as data.")
 
-    tol = args.tolerance
-    sh_order = args.sh_order
-
     # Checking data and sh_order
-    b0_thr = check_b0_threshold(
-        args.force_b0_threshold, bvals.min(), bvals.min())
-
+    sh_order = args.sh_order
     if data.shape[-1] < (sh_order + 1) * (sh_order + 2) / 2:
         logging.warning(
             'We recommend having at least {} unique DWIs volumes, but you '
@@ -160,7 +160,15 @@ def main():
     if not is_normalized_bvecs(bvecs):
         logging.warning('Your b-vectors do not seem normalized...')
         bvecs = normalize_bvecs(bvecs)
-    gtab = gradient_table(bvals, bvecs, b0_threshold=b0_thr)
+
+    # Note. This script does not currently allow using a separate b0_threshold
+    # for the b0s. Using the tolerance. To change this, we would have to
+    # change many things in dipy. An issue has been added in dipy to
+    # ask them to clarify the usage of gtab.b0s_mask. See here:
+    #  https://github.com/dipy/dipy/issues/3015
+    # b0_threshold option in gradient_table probably unused.
+    check_b0_threshold(bvals.min(), args, b0_thr=args.tolerance)
+    gtab = gradient_table(bvals, bvecs, b0_threshold=args.tolerance)
 
     # Checking response functions and computing msmt response function
     if not wm_frf.shape[1] == 4:
@@ -172,10 +180,10 @@ def main():
     if not csf_frf.shape[1] == 4:
         raise ValueError('CSF frf file did not contain 4 elements. '
                          'Invalid or deprecated FRF format')
-    ubvals = unique_bvals_tolerance(bvals, tol=tol)
+    ubvals = unique_bvals_tolerance(bvals, tol=args.tolerance)
     msmt_response = multi_shell_fiber_response(sh_order, ubvals,
                                                wm_frf, gm_frf, csf_frf,
-                                               tol=tol)
+                                               tol=args.tolerance)
 
     # Loading spheres
     reg_sphere = get_sphere('symmetric362')

--- a/scripts/scil_fodf_msmt.py
+++ b/scripts/scil_fodf_msmt.py
@@ -69,12 +69,12 @@ def _build_arg_parser():
              'mask will be used for computations and reconstruction.')
     p.add_argument(
         '--tolerance', type=int, default=20,
-        help='The tolerated gap between the b-values to '
-             'extract and the current b-value.\n'
+        help='The tolerated gap between the b-values to extract and the '
+             'current b-value.\n'
              'We would expect to find at least one b-value in the range '
              '[0, tolerance], acting as a b0.\n'
              'To skip this check, use --skip_b0_validation.\n'
-             'Default: [%(default)s]')
+             '[Default: %(default)s]')
     add_skip_b0_validation_arg(p, b0_tol_name='--tolerance')
     add_sh_basis_args(p)
     add_processes_arg(p)
@@ -167,8 +167,9 @@ def main():
     # ask them to clarify the usage of gtab.b0s_mask. See here:
     #  https://github.com/dipy/dipy/issues/3015
     # b0_threshold option in gradient_table probably unused.
-    check_b0_threshold(bvals.min(), args, b0_thr=args.tolerance)
-    gtab = gradient_table(bvals, bvecs, b0_threshold=args.tolerance)
+    args.b0_threshold = args.tolerance
+    args.b0_threshold = check_b0_threshold(bvals.min(), args)
+    gtab = gradient_table(bvals, bvecs, b0_threshold=args.b0_threshold)
 
     # Checking response functions and computing msmt response function
     if not wm_frf.shape[1] == 4:

--- a/scripts/scil_fodf_msmt.py
+++ b/scripts/scil_fodf_msmt.py
@@ -161,7 +161,7 @@ def main():
     # ask them to clarify the usage of gtab.b0s_mask. See here:
     #  https://github.com/dipy/dipy/issues/3015
     # b0_threshold option in gradient_table probably unused.
-    _ = check_b0_threshold(bvals.min(), b0_threshold=args.tolerance,
+    _ = check_b0_threshold(bvals.min(), b0_thr=args.tolerance,
                            skip_b0_check=args.skip_b0_check)
     gtab = gradient_table(bvals, bvecs, b0_threshold=args.tolerance)
 

--- a/scripts/scil_fodf_ssst.py
+++ b/scripts/scil_fodf_ssst.py
@@ -23,10 +23,10 @@ from scilpy.gradients.bvec_bval_tools import (check_b0_threshold,
                                               normalize_bvecs,
                                               is_normalized_bvecs)
 from scilpy.io.image import get_data_as_mask
-from scilpy.io.utils import (add_overwrite_arg,
-                             assert_inputs_exist, add_verbose_arg,
-                             assert_outputs_exist, add_force_b0_arg,
-                             add_sh_basis_args, add_processes_arg)
+from scilpy.io.utils import (add_b0_thresh_arg, add_overwrite_arg,
+                             add_processes_arg, add_sh_basis_args,
+                             add_skip_b0_validation_arg, add_verbose_arg,
+                             assert_inputs_exist, assert_outputs_exist)
 from scilpy.reconst.fodf import fit_from_model
 from scilpy.reconst.sh import convert_sh_basis
 
@@ -54,7 +54,8 @@ def _build_arg_parser():
         help='Path to a binary mask. Only the data inside the mask will be '
              'used for computations and reconstruction.')
 
-    add_force_b0_arg(p)
+    add_b0_thresh_arg(p)
+    add_skip_b0_validation_arg(p)
     add_sh_basis_args(p)
     add_processes_arg(p)
     add_verbose_arg(p)
@@ -89,8 +90,6 @@ def main():
     sh_order = args.sh_order
 
     # Checking data and sh_order
-    b0_thr = check_b0_threshold(
-        args.force_b0_threshold, bvals.min(), bvals.min())
     if data.shape[-1] < (sh_order + 1) * (sh_order + 2) / 2:
         logging.warning(
             'We recommend having at least {} unique DWI volumes, but you '
@@ -102,7 +101,10 @@ def main():
     if not is_normalized_bvecs(bvecs):
         logging.warning('Your b-vectors do not seem normalized...')
         bvecs = normalize_bvecs(bvecs)
-    gtab = gradient_table(bvals, bvecs, b0_threshold=b0_thr)
+
+    # gtab.b0s_mask is used in dipy's csdeconv class.
+    args.b0_threshold = check_b0_threshold(bvals.min(), args)
+    gtab = gradient_table(bvals, bvecs, b0_threshold=args.b0_threshold)
 
     # Checking full_frf and separating it
     if not full_frf.shape[0] == 4:
@@ -115,10 +117,9 @@ def main():
     reg_sphere = get_sphere('symmetric362')
 
     # Computing CSD
-    csd_model = ConstrainedSphericalDeconvModel(
-        gtab, (frf, mean_b0_val),
-        reg_sphere=reg_sphere,
-        sh_order=sh_order)
+    csd_model = ConstrainedSphericalDeconvModel(gtab, (frf, mean_b0_val),
+                                                reg_sphere=reg_sphere,
+                                                sh_order=sh_order)
 
     # Computing CSD fit
     csd_fit = fit_from_model(csd_model, data,

--- a/scripts/scil_fodf_ssst.py
+++ b/scripts/scil_fodf_ssst.py
@@ -52,7 +52,7 @@ def _build_arg_parser():
     p.add_argument(
         '--mask', metavar='',
         help='Path to a binary mask. Only the data inside the mask will be '
-             'used for computations and reconstruction.')
+             'used \nfor computations and reconstruction.')
 
     add_b0_thresh_arg(p)
     add_skip_b0_check_arg(p, will_overwrite_with_min=True)
@@ -104,7 +104,7 @@ def main():
 
     # gtab.b0s_mask is used in dipy's csdeconv class.
     args.b0_threshold = check_b0_threshold(bvals.min(),
-                                           b0_threshold=args.b0_threshold,
+                                           b0_thr=args.b0_threshold,
                                            skip_b0_check=args.skip_b0_check)
     gtab = gradient_table(bvals, bvecs, b0_threshold=args.b0_threshold)
 

--- a/scripts/scil_fodf_ssst.py
+++ b/scripts/scil_fodf_ssst.py
@@ -25,7 +25,7 @@ from scilpy.gradients.bvec_bval_tools import (check_b0_threshold,
 from scilpy.io.image import get_data_as_mask
 from scilpy.io.utils import (add_b0_thresh_arg, add_overwrite_arg,
                              add_processes_arg, add_sh_basis_args,
-                             add_skip_b0_validation_arg, add_verbose_arg,
+                             add_skip_b0_check_arg, add_verbose_arg,
                              assert_inputs_exist, assert_outputs_exist)
 from scilpy.reconst.fodf import fit_from_model
 from scilpy.reconst.sh import convert_sh_basis
@@ -55,7 +55,7 @@ def _build_arg_parser():
              'used for computations and reconstruction.')
 
     add_b0_thresh_arg(p)
-    add_skip_b0_validation_arg(p)
+    add_skip_b0_check_arg(p, will_overwrite_with_min=True)
     add_sh_basis_args(p)
     add_processes_arg(p)
     add_verbose_arg(p)
@@ -103,7 +103,9 @@ def main():
         bvecs = normalize_bvecs(bvecs)
 
     # gtab.b0s_mask is used in dipy's csdeconv class.
-    args.b0_threshold = check_b0_threshold(bvals.min(), args)
+    args.b0_threshold = check_b0_threshold(bvals.min(),
+                                           b0_threshold=args.b0_threshold,
+                                           skip_b0_check=args.skip_b0_check)
     gtab = gradient_table(bvals, bvecs, b0_threshold=args.b0_threshold)
 
     # Checking full_frf and separating it

--- a/scripts/scil_frf_memsmt.py
+++ b/scripts/scil_frf_memsmt.py
@@ -52,7 +52,7 @@ from scilpy.io.btensor import generate_btensor_input
 from scilpy.io.image import get_data_as_mask
 from scilpy.io.utils import (add_overwrite_arg, add_verbose_arg,
                              assert_inputs_exist, assert_outputs_exist,
-                             assert_roi_radii_format)
+                             assert_roi_radii_format, add_skip_b0_check_arg)
 from scilpy.reconst.frf import compute_msmt_frf
 
 
@@ -136,6 +136,8 @@ def _build_arg_parser():
                    type=int, default=20,
                    help='The tolerated gap between the b-values to '
                         'extract and the current b-value. [%(default)s]')
+    add_skip_b0_check_arg(p, will_overwrite_with_min=False,
+                          b0_tol_name='--tolerance')
     p.add_argument('--dti_bval_limit',
                    type=int, default=1200,
                    help='The highest b-value taken for the DTI model. '
@@ -200,11 +202,9 @@ def main():
     # for the b0s. Using the tolerance. To change this, we would have to
     # change generate_btensor_input. Not doing any verification on the
     # bvals. Typically, we would use check_b0_threshold(bvals.min(), args)
-    gtab, data, ubvals, ubdeltas = generate_btensor_input(args.in_dwis,
-                                                          args.in_bvals,
-                                                          args.in_bvecs,
-                                                          args.in_bdeltas,
-                                                          tol=args.tolerance)
+    gtab, data, ubvals, ubdeltas = generate_btensor_input(
+        args.in_dwis, args.in_bvals, args.in_bvecs, args.in_bdeltas,
+        tol=args.tolerance, skip_b0_check=args.skip_b0_check)
 
     if not np.all(ubvals <= args.dti_bval_limit):
         if np.sum(ubdeltas == 1) > 0:

--- a/scripts/scil_frf_memsmt.py
+++ b/scripts/scil_frf_memsmt.py
@@ -52,7 +52,8 @@ from scilpy.io.btensor import generate_btensor_input
 from scilpy.io.image import get_data_as_mask
 from scilpy.io.utils import (add_overwrite_arg, add_verbose_arg,
                              assert_inputs_exist, assert_outputs_exist,
-                             assert_roi_radii_format, add_skip_b0_check_arg)
+                             assert_roi_radii_format, add_skip_b0_check_arg,
+                             add_tolerance_arg)
 from scilpy.reconst.frf import compute_msmt_frf
 
 
@@ -132,10 +133,7 @@ def _build_arg_parser():
                    help='Minimal number of voxels needed for each tissue masks'
                         ' in order to \nproceed to frf estimation. '
                         '[%(default)s]')
-    p.add_argument('--tolerance',
-                   type=int, default=20,
-                   help='The tolerated gap between the b-values to '
-                        'extract and the current b-value. [%(default)s]')
+    add_tolerance_arg(p)
     add_skip_b0_check_arg(p, will_overwrite_with_min=False,
                           b0_tol_name='--tolerance')
     p.add_argument('--dti_bval_limit',

--- a/scripts/scil_frf_msmt.py
+++ b/scripts/scil_frf_msmt.py
@@ -37,11 +37,11 @@ import nibabel as nib
 import numpy as np
 
 from scilpy.dwi.utils import extract_dwi_shell
+from scilpy.gradients.bvec_bval_tools import check_b0_threshold
 from scilpy.io.image import get_data_as_mask
-from scilpy.io.utils import (add_force_b0_arg,
-                             add_overwrite_arg, add_verbose_arg,
-                             assert_inputs_exist, assert_outputs_exist,
-                             assert_roi_radii_format)
+from scilpy.io.utils import (add_overwrite_arg, add_skip_b0_validation_arg,
+                             add_verbose_arg, assert_inputs_exist,
+                             assert_outputs_exist, assert_roi_radii_format)
 from scilpy.reconst.frf import compute_msmt_frf
 
 
@@ -118,6 +118,7 @@ def _build_arg_parser():
                    type=int, default=20,
                    help='The tolerated gap between the b-values to '
                         'extract and the current b-value. [%(default)s]')
+    add_skip_b0_validation_arg(p, b0_tol_name='--tolerance')
     p.add_argument('--dti_bval_limit',
                    type=int, default=1200,
                    help='The highest b-value taken for the DTI model. '
@@ -150,7 +151,6 @@ def _build_arg_parser():
                         'used to compute the CSF frf.')
 
     add_verbose_arg(p)
-    add_force_b0_arg(p)
     add_overwrite_arg(p)
 
     return p
@@ -171,14 +171,19 @@ def main():
     data = vol.get_fdata(dtype=np.float32)
     bvals, bvecs = read_bvals_bvecs(args.in_bval, args.in_bvec)
 
-    tol = args.tolerance
     dti_lim = args.dti_bval_limit
 
-    list_bvals = unique_bvals_tolerance(bvals, tol=tol)
+    # Note. This script does not currently allow using a separate b0_threshold
+    # for the b0s. Using the tolerance. To fix this, we would need to change
+    # the unique_bvals_tolerance and extract_dwi_shell methods.
+    args.b0_threshold = args.tolerance
+    _ = check_b0_threshold(bvals.min(), args)
+
+    list_bvals = unique_bvals_tolerance(bvals, tol=args.tolerance)
     if not np.all(list_bvals <= dti_lim):
         outputs = extract_dwi_shell(vol, bvals, bvecs,
                                     list_bvals[list_bvals <= dti_lim],
-                                    tol=tol)
+                                    tol=args.tolerance)
         _, data_dti, bvals_dti, bvecs_dti = outputs
         bvals_dti = np.squeeze(bvals_dti)
     else:
@@ -201,7 +206,6 @@ def main():
     if args.mask_csf:
         mask_csf = get_data_as_mask(nib.load(args.mask_csf), dtype=bool)
 
-    force_b0_thr = args.force_b0_threshold
     responses, frf_masks = compute_msmt_frf(data, bvals, bvecs,
                                             data_dti=data_dti,
                                             bvals_dti=bvals_dti,
@@ -216,8 +220,7 @@ def main():
                                             min_nvox=args.min_nvox,
                                             roi_radii=roi_radii,
                                             roi_center=args.roi_center,
-                                            tol=tol,
-                                            force_b0_threshold=force_b0_thr)
+                                            tol=args.tolerance)
 
     masks_files = [args.wm_frf_mask, args.gm_frf_mask, args.csf_frf_mask]
     for mask, mask_file in zip(frf_masks, masks_files):

--- a/scripts/scil_frf_msmt.py
+++ b/scripts/scil_frf_msmt.py
@@ -39,7 +39,7 @@ import numpy as np
 from scilpy.dwi.utils import extract_dwi_shell
 from scilpy.gradients.bvec_bval_tools import check_b0_threshold
 from scilpy.io.image import get_data_as_mask
-from scilpy.io.utils import (add_overwrite_arg, add_skip_b0_validation_arg,
+from scilpy.io.utils import (add_overwrite_arg, add_skip_b0_check_arg,
                              add_verbose_arg, assert_inputs_exist,
                              assert_outputs_exist, assert_roi_radii_format)
 from scilpy.reconst.frf import compute_msmt_frf
@@ -118,7 +118,8 @@ def _build_arg_parser():
                    type=int, default=20,
                    help='The tolerated gap between the b-values to '
                         'extract and the current b-value. [%(default)s]')
-    add_skip_b0_validation_arg(p, b0_tol_name='--tolerance')
+    add_skip_b0_check_arg(p, will_overwrite_with_min=False,
+                          b0_tol_name='--tolerance')
     p.add_argument('--dti_bval_limit',
                    type=int, default=1200,
                    help='The highest b-value taken for the DTI model. '
@@ -176,9 +177,8 @@ def main():
     # Note. This script does not currently allow using a separate b0_threshold
     # for the b0s. Using the tolerance. To fix this, we would need to change
     # the unique_bvals_tolerance and extract_dwi_shell methods.
-    args.b0_threshold = args.tolerance
-    _ = check_b0_threshold(bvals.min(), args)
-
+    _ = check_b0_threshold(bvals.min(), b0_threshold=args.tolerance,
+                           skip_b0_check=args.skip_b0_check)
     list_bvals = unique_bvals_tolerance(bvals, tol=args.tolerance)
     if not np.all(list_bvals <= dti_lim):
         outputs = extract_dwi_shell(vol, bvals, bvecs,

--- a/scripts/scil_frf_msmt.py
+++ b/scripts/scil_frf_msmt.py
@@ -177,7 +177,7 @@ def main():
     # Note. This script does not currently allow using a separate b0_threshold
     # for the b0s. Using the tolerance. To fix this, we would need to change
     # the unique_bvals_tolerance and extract_dwi_shell methods.
-    _ = check_b0_threshold(bvals.min(), b0_threshold=args.tolerance,
+    _ = check_b0_threshold(bvals.min(), b0_thr=args.tolerance,
                            skip_b0_check=args.skip_b0_check)
     list_bvals = unique_bvals_tolerance(bvals, tol=args.tolerance)
     if not np.all(list_bvals <= dti_lim):

--- a/scripts/scil_frf_ssst.py
+++ b/scripts/scil_frf_ssst.py
@@ -20,7 +20,7 @@ import numpy as np
 from scilpy.gradients.bvec_bval_tools import check_b0_threshold
 from scilpy.io.image import get_data_as_mask
 from scilpy.io.utils import (add_b0_thresh_arg, add_overwrite_arg,
-                             add_skip_b0_validation_arg, add_verbose_arg,
+                             add_skip_b0_check_arg, add_verbose_arg,
                              assert_inputs_exist, assert_outputs_exist,
                              assert_roi_radii_format)
 from scilpy.reconst.frf import compute_ssst_frf
@@ -82,7 +82,7 @@ def _build_arg_parser():
                         'roi_radius. [center of the 3D volume]')
 
     add_b0_thresh_arg(p)
-    add_skip_b0_validation_arg(p)
+    add_skip_b0_check_arg(p, will_overwrite_with_min=True)
     add_verbose_arg(p)
     add_overwrite_arg(p)
 
@@ -103,8 +103,9 @@ def main():
     data = vol.get_fdata(dtype=np.float32)
 
     bvals, bvecs = read_bvals_bvecs(args.in_bval, args.in_bvec)
-    args.b0_threshold = check_b0_threshold(bvals.min(), args)
-
+    args.b0_threshold = check_b0_threshold(bvals.min(),
+                                           b0_threshold=args.b0_threshold,
+                                           skip_b0_check=args.skip_b0_check)
     mask = None
     if args.mask:
         mask = get_data_as_mask(nib.load(args.mask), dtype=bool)

--- a/scripts/scil_frf_ssst.py
+++ b/scripts/scil_frf_ssst.py
@@ -29,7 +29,7 @@ from scilpy.reconst.frf import compute_ssst_frf
 def _build_arg_parser():
     p = argparse.ArgumentParser(
         description=__doc__,
-        formatter_class=argparse.RawDescriptionHelpFormatter,
+        formatter_class=argparse.RawTextHelpFormatter,
         epilog="References: [1] Tournier et al. NeuroImage 2007")
 
     p.add_argument('in_dwi',
@@ -44,28 +44,28 @@ def _build_arg_parser():
 
     p.add_argument('--mask',
                    help='Path to a binary mask. Only the data inside the '
-                        'mask will be used for computations and '
-                        'reconstruction. Useful if no white matter mask '
+                        'mask will be used \nfor computations and '
+                        'reconstruction. Useful if no white matter mask \n'
                         'is available.')
     p.add_argument('--mask_wm',
                    help='Path to a binary white matter mask. Only the data '
-                        'inside this mask and above the threshold defined '
-                        'by --fa will be used to estimate the fiber response '
-                        'function.')
+                        'inside this mask \nand above the threshold defined '
+                        'by --fa will be used to estimate the \nfiber '
+                        'response function.')
     p.add_argument('--fa', dest='fa_thresh',
                    default=0.7, type=float,
                    help='If supplied, use this threshold as the initial '
-                        'threshold to select single fiber voxels. '
+                        'threshold to select \nsingle fiber voxels. '
                         '[%(default)s]')
     p.add_argument('--min_fa', dest='min_fa_thresh',
                    default=0.5, type=float,
                    help='If supplied, this is the minimal value that will be '
-                        'tried when looking for single fiber '
+                        'tried when looking \nfor single fiber '
                         'voxels. [%(default)s]')
     p.add_argument('--min_nvox',
                    default=300, type=int,
                    help='Minimal number of voxels needing to be identified '
-                        'as single fiber voxels in the automatic '
+                        'as single fiber voxels \nin the automatic '
                         'estimation. [%(default)s]')
 
     p.add_argument('--roi_radii',
@@ -104,7 +104,7 @@ def main():
 
     bvals, bvecs = read_bvals_bvecs(args.in_bval, args.in_bvec)
     args.b0_threshold = check_b0_threshold(bvals.min(),
-                                           b0_threshold=args.b0_threshold,
+                                           b0_thr=args.b0_threshold,
                                            skip_b0_check=args.skip_b0_check)
     mask = None
     if args.mask:

--- a/scripts/scil_qball_metrics.py
+++ b/scripts/scil_qball_metrics.py
@@ -34,7 +34,7 @@ from scilpy.gradients.bvec_bval_tools import (check_b0_threshold,
                                               normalize_bvecs)
 from scilpy.io.utils import (add_b0_thresh_arg, add_overwrite_arg,
                              add_processes_arg, add_sh_basis_args,
-                             add_skip_b0_validation_arg, add_verbose_arg,
+                             add_skip_b0_check_arg, add_verbose_arg,
                              assert_inputs_exist, assert_outputs_exist,
                              validate_nbr_processes)
 from scilpy.io.image import get_data_as_mask
@@ -88,7 +88,7 @@ def _build_arg_parser():
                         '[anisotropic_power.nii.gz].')
 
     add_b0_thresh_arg(p)
-    add_skip_b0_validation_arg(p)
+    add_skip_b0_check_arg(p, will_overwrite_with_min=True)
     add_sh_basis_args(p)
     add_processes_arg(p)
     add_verbose_arg(p)
@@ -134,7 +134,9 @@ def main():
 
     # Usage of gtab.b0s_mask in dipy's models is not very well documented, but
     # we can see that it is indeed used.
-    args.b0_threshold = check_b0_threshold(bvals.min(), args)
+    args.b0_threshold = check_b0_threshold(bvals.min(),
+                                           b0_threshold=args.b0_threshold,
+                                           skip_b0_check=args.skip_b0_check)
     gtab = gradient_table(bvals, bvecs, b0_threshold=args.b0_threshold)
 
     sphere = get_sphere('symmetric724')

--- a/scripts/scil_qball_metrics.py
+++ b/scripts/scil_qball_metrics.py
@@ -135,7 +135,7 @@ def main():
     # Usage of gtab.b0s_mask in dipy's models is not very well documented, but
     # we can see that it is indeed used.
     args.b0_threshold = check_b0_threshold(bvals.min(),
-                                           b0_threshold=args.b0_threshold,
+                                           b0_thr=args.b0_threshold,
                                            skip_b0_check=args.skip_b0_check)
     gtab = gradient_table(bvals, bvecs, b0_threshold=args.b0_threshold)
 

--- a/scripts/scil_sh_to_sf.py
+++ b/scripts/scil_sh_to_sf.py
@@ -79,6 +79,7 @@ def _build_arg_parser():
     # explanation in the text.
     p.add_argument(
         '--b0_threshold', type=float, default=DEFAULT_B0_THRESHOLD,
+        metavar='thr',
         help='Threshold under which b-values are considered to be b0s.\n'
              'Default if not set is {}.\n'
              'This value is used with options --in_bvec or --in_bval only.'
@@ -124,7 +125,7 @@ def main():
     elif args.in_bval:
         bvals, _ = read_bvals_bvecs(args.in_bval, None)
     args.b0_threshold = check_b0_threshold(bvals.min(),
-                                           b0_threshold=args.b0_threshold,
+                                           b0_thr=args.b0_threshold,
                                            skip_b0_check=args.skip_b0_check)
     # Load SH
     vol_sh = nib.load(args.in_sh)

--- a/scripts/scil_sh_to_sf.py
+++ b/scripts/scil_sh_to_sf.py
@@ -26,7 +26,7 @@ from dipy.io import read_bvals_bvecs
 from scilpy.gradients.bvec_bval_tools import (check_b0_threshold,
                                               DEFAULT_B0_THRESHOLD)
 from scilpy.io.utils import (add_overwrite_arg, add_processes_arg,
-                             add_skip_b0_validation_arg, add_sh_basis_args,
+                             add_skip_b0_check_arg, add_sh_basis_args,
                              assert_inputs_exist, add_verbose_arg,
                              assert_outputs_exist, validate_nbr_processes)
 from scilpy.reconst.sh import convert_sh_to_sf
@@ -83,7 +83,7 @@ def _build_arg_parser():
              'Default if not set is {}.\n'
              'This value is used with options --in_bvec or --in_bval only.'
              .format(DEFAULT_B0_THRESHOLD))
-    add_skip_b0_validation_arg(p)
+    add_skip_b0_check_arg(p, will_overwrite_with_min=True)
 
     add_processes_arg(p)
     add_verbose_arg(p)
@@ -123,8 +123,9 @@ def main():
         bvals, bvecs = read_bvals_bvecs(args.in_bval, args.in_bvec)
     elif args.in_bval:
         bvals, _ = read_bvals_bvecs(args.in_bval, None)
-    args.b0_treshold = check_b0_threshold(bvals.min(), args)
-
+    args.b0_threshold = check_b0_threshold(bvals.min(),
+                                           b0_threshold=args.b0_threshold,
+                                           skip_b0_check=args.skip_b0_check)
     # Load SH
     vol_sh = nib.load(args.in_sh)
     data_sh = vol_sh.get_fdata(dtype=np.float32)

--- a/scripts/tests/test_dti_metrics.py
+++ b/scripts/tests/test_dti_metrics.py
@@ -37,3 +37,8 @@ def test_execution_processing(script_runner):
                             '--residual', 'residual.nii.gz',
                             '--mask', mask_uint8)
     assert ret.success
+
+    ret = script_runner.run('scil_dti_metrics.py', in_dwi,
+                            in_bval, in_bvec, '--not_all',
+                            '--fa', 'fa.nii.gz', '--b0_threshold', '1', '-f')
+    assert not ret.success

--- a/scripts/tests/test_dwi_detect_volume_outliers.py
+++ b/scripts/tests/test_dwi_detect_volume_outliers.py
@@ -27,3 +27,8 @@ def test_execution(script_runner):
     ret = script_runner.run('scil_dwi_detect_volume_outliers.py', in_dwi,
                             in_bval, in_bvec, '-v')
     assert ret.success
+
+    # Test wrong b0. Current minimal b-value is 5.
+    ret = script_runner.run('scil_dwi_detect_volume_outliers.py', in_dwi,
+                            in_bval, in_bvec, '--b0_threshold', '1')
+    assert not ret.success

--- a/scripts/tests/test_dwi_extract_b0.py
+++ b/scripts/tests/test_dwi_extract_b0.py
@@ -27,3 +27,8 @@ def test_execution_processing(script_runner):
     ret = script_runner.run('scil_dwi_extract_b0.py', in_dwi, in_bval, in_bvec,
                             'b0_mean.nii.gz', '--mean', '--b0', '20')
     assert ret.success
+
+    # Test wrong b0. Current minimal b-value is 5.
+    ret = script_runner.run('scil_dwi_extract_b0.py', in_dwi, in_bval, in_bvec,
+                            'b0_mean.nii.gz', '--mean', '--b0', '1', '-f')
+    assert not ret.success

--- a/scripts/tests/test_dwi_to_sh.py
+++ b/scripts/tests/test_dwi_to_sh.py
@@ -27,3 +27,9 @@ def test_execution_processing(script_runner):
     ret = script_runner.run('scil_dwi_to_sh.py', in_dwi, in_bval,
                             in_bvec, 'sh_1000.nii.gz')
     assert ret.success
+
+    # Test wrong b0. Current minimal b-value is 5.
+    ret = script_runner.run('scil_dwi_to_sh.py', in_dwi, in_bval,
+                            in_bvec, 'sh_1000.nii.gz', '--b0_threshold', '1',
+                            '-f')
+    assert not ret.success

--- a/scripts/tests/test_fodf_ssst.py
+++ b/scripts/tests/test_fodf_ssst.py
@@ -30,3 +30,10 @@ def test_execution_processing(script_runner):
                             in_bvec, in_frf, 'fodf.nii.gz', '--sh_order', '4',
                             '--sh_basis', 'tournier07', '--processes', '1')
     assert ret.success
+
+    # Test wrong b0. Current minimal b-value is 5.
+    ret = script_runner.run('scil_fodf_ssst.py', in_dwi, in_bval,
+                            in_bvec, in_frf, 'fodf.nii.gz', '--sh_order', '4',
+                            '--sh_basis', 'tournier07', '--processes', '1',
+                            '--b0_threshold', '1', '-f')
+    assert not ret.success

--- a/scripts/tests/test_frf_msmt.py
+++ b/scripts/tests/test_frf_msmt.py
@@ -24,12 +24,19 @@ def test_roi_radii_shape_parameter(script_runner):
     in_bvec = os.path.join(get_home(), 'commit_amico',
                            'dwi.bvec')
     mask = os.path.join(get_home(), 'commit_amico',
-                           'mask.nii.gz')
+                        'mask.nii.gz')
     ret = script_runner.run('scil_frf_msmt.py', in_dwi,
                             in_bval, in_bvec, 'wm_frf.txt', 'gm_frf.txt',
                             'csf_frf.txt', '--mask', mask, '--roi_center',
                             '15', '15', '15', '-f')
     assert ret.success
+
+    # Test wrong tolerance, leading to no b0. Current minimal b-val is 5.
+    ret = script_runner.run('scil_frf_msmt.py', in_dwi,
+                            in_bval, in_bvec, 'wm_frf.txt', 'gm_frf.txt',
+                            'csf_frf.txt', '--mask', mask, '--roi_center',
+                            '15', '15', '15', '-f', '--tol', '1')
+    assert not ret.success
 
     ret = script_runner.run('scil_frf_msmt.py', in_dwi,
                             in_bval, in_bvec, 'wm_frf.txt', 'gm_frf.txt',
@@ -38,7 +45,8 @@ def test_roi_radii_shape_parameter(script_runner):
 
     assert (not ret.success)
 
-def test_roi_radii_shape_parameter(script_runner):
+
+def test_roi_radii_shape_parameter2(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi = os.path.join(get_home(), 'commit_amico',
                           'dwi.nii.gz')
@@ -47,7 +55,7 @@ def test_roi_radii_shape_parameter(script_runner):
     in_bvec = os.path.join(get_home(), 'commit_amico',
                            'dwi.bvec')
     mask = os.path.join(get_home(), 'commit_amico',
-                           'mask.nii.gz')
+                        'mask.nii.gz')
     ret = script_runner.run('scil_frf_msmt.py', in_dwi,
                             in_bval, in_bvec, 'wm_frf.txt', 'gm_frf.txt',
                             'csf_frf.txt', '--mask', mask, '--roi_radii',
@@ -67,6 +75,7 @@ def test_roi_radii_shape_parameter(script_runner):
 
     assert (not ret.success)
 
+
 def test_execution_processing(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi = os.path.join(get_home(), 'commit_amico',
@@ -76,7 +85,7 @@ def test_execution_processing(script_runner):
     in_bvec = os.path.join(get_home(), 'commit_amico',
                            'dwi.bvec')
     mask = os.path.join(get_home(), 'commit_amico',
-                           'mask.nii.gz')
+                        'mask.nii.gz')
     ret = script_runner.run('scil_frf_msmt.py', in_dwi,
                             in_bval, in_bvec, 'wm_frf.txt', 'gm_frf.txt',
                             'csf_frf.txt', '--mask', mask, '--min_nvox', '20',

--- a/scripts/tests/test_frf_ssst.py
+++ b/scripts/tests/test_frf_ssst.py
@@ -35,6 +35,14 @@ def test_roi_center_parameter(script_runner):
 
     assert (not ret.success)
 
+    # Test wrong b0 threshold. Current minimal b-value is 5.
+    ret = script_runner.run('scil_frf_ssst.py', in_dwi,
+                            in_bval, in_bvec, 'frf.txt', '--roi_center',
+                            '15', '15', '15', '-f', '--b0_threshold', '1')
+
+    assert not ret.success
+
+
 def test_roi_radii_shape_parameter(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi = os.path.join(get_home(), 'processing',
@@ -58,6 +66,7 @@ def test_roi_radii_shape_parameter(script_runner):
                             '37', '37', '37', '37', '37', '-f')
 
     assert (not ret.success)
+
 
 def test_execution_processing(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))

--- a/scripts/tests/test_qball_metrics.py
+++ b/scripts/tests/test_qball_metrics.py
@@ -39,3 +39,9 @@ def test_execution_not_all(script_runner):
     ret = script_runner.run('scil_qball_metrics.py', in_dwi,
                             in_bval, in_bvec, "--not_all", "--sh", "2.nii.gz")
     assert ret.success
+
+    # Test wrong b0. Current minimal b-val is 5.
+    ret = script_runner.run('scil_qball_metrics.py', in_dwi,
+                            in_bval, in_bvec, "--not_all", "--sh", "2.nii.gz",
+                            '--b0_threshold', '1', '-f')
+    assert not ret.success

--- a/scripts/tests/test_sh_to_sf.py
+++ b/scripts/tests/test_sh_to_sf.py
@@ -30,15 +30,6 @@ def test_execution_in_sphere(script_runner):
                             '--sphere', 'symmetric724', '--dtype', 'float32')
     assert ret.success
 
-    # Test wrong b0. Current minimal b-val is 5
-    ret = script_runner.run('scil_sh_to_sf.py', in_sh,
-                            'sf_724.nii.gz', '--in_bval',
-                            in_bval, '--in_b0', in_b0, '--out_bval',
-                            'sf_724.bval', '--out_bvec', 'sf_724.bvec',
-                            '--sphere', 'symmetric724', '--dtype', 'float32',
-                            '--b0_threshold', '1', '-f')
-    assert not ret.success
-
 
 def test_execution_in_bvec(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))

--- a/scripts/tests/test_sh_to_sf.py
+++ b/scripts/tests/test_sh_to_sf.py
@@ -16,12 +16,13 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_processing(script_runner):
+def test_execution_in_sphere(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
     in_sh = os.path.join(get_home(), 'processing', 'sh_1000.nii.gz')
     in_b0 = os.path.join(get_home(), 'processing', 'fa.nii.gz')
     in_bval = os.path.join(get_home(), 'processing', '1000.bval')
 
+    # Required: either --sphere or --in_bvec. Here, --sphere
     ret = script_runner.run('scil_sh_to_sf.py', in_sh,
                             'sf_724.nii.gz', '--in_bval',
                             in_bval, '--in_b0', in_b0, '--out_bval',
@@ -37,3 +38,39 @@ def test_execution_processing(script_runner):
                             '--sphere', 'symmetric724', '--dtype', 'float32',
                             '--b0_threshold', '1', '-f')
     assert not ret.success
+
+
+def test_execution_in_bvec(script_runner):
+    os.chdir(os.path.expanduser(tmp_dir.name))
+    in_sh = os.path.join(get_home(), 'processing', 'sh_1000.nii.gz')
+    in_bval = os.path.join(get_home(), 'processing', '1000.bval')
+    in_bvec = os.path.join(get_home(), 'processing', '1000.bvec')
+
+    # --in_bvec: in_bval is required.
+    ret = script_runner.run('scil_sh_to_sf.py', in_sh,
+                            'sf_724.nii.gz', '--in_bval', in_bval,
+                            '--out_bval', 'sf_724.bval',
+                            '--out_bvec', 'sf_724.bvec',
+                            '--in_bvec', in_bvec, '--dtype', 'float32', '-f')
+    assert ret.success
+
+    # Test that fails if no bvals is given.
+    ret = script_runner.run('scil_sh_to_sf.py', in_sh,
+                            'sf_724.nii.gz',
+                            '--out_bvec', 'sf_724.bvec',
+                            '--in_bvec', in_bvec, '--dtype', 'float32', '-f')
+    assert not ret.success
+
+
+def test_execution_no_bval(script_runner):
+    os.chdir(os.path.expanduser(tmp_dir.name))
+    in_sh = os.path.join(get_home(), 'processing', 'sh_1000.nii.gz')
+    in_b0 = os.path.join(get_home(), 'processing', 'fa.nii.gz')
+
+    # --sphere but no --bval
+    ret = script_runner.run('scil_sh_to_sf.py', in_sh,
+                            'sf_724.nii.gz', '--in_b0', in_b0,
+                            '--out_bvec', 'sf_724.bvec',
+                            '--sphere', 'symmetric724', '--dtype', 'float32',
+                            '-f')
+    assert ret.success

--- a/scripts/tests/test_sh_to_sf.py
+++ b/scripts/tests/test_sh_to_sf.py
@@ -28,3 +28,12 @@ def test_execution_processing(script_runner):
                             'sf_724.bval', '--out_bvec', 'sf_724.bvec',
                             '--sphere', 'symmetric724', '--dtype', 'float32')
     assert ret.success
+
+    # Test wrong b0. Current minimal b-val is 5
+    ret = script_runner.run('scil_sh_to_sf.py', in_sh,
+                            'sf_724.nii.gz', '--in_bval',
+                            in_bval, '--in_b0', in_b0, '--out_bval',
+                            'sf_724.bval', '--out_bvec', 'sf_724.bvec',
+                            '--sphere', 'symmetric724', '--dtype', 'float32',
+                            '--b0_threshold', '1', '-f')
+    assert not ret.success


### PR DESCRIPTION
# Quick description

1. [ENH] The argument --force_b0_threshold, used a bit everywhere, was quite unclear. Does it force to use the b0_threshold given, or does it force to work in any case? Answer was: it forced to use the minimal b-value even if it was higher than expected b0_threshold. Renamed --skip_b0_validation.

2.  [FIX] In many cases, the function `check_b0_threshold` was incorrectly used in the scripts (they were using `check_b0_threshold(args)` but the function expected a bool as first argument. It was thus not doing as expected.

3. [FIX] In other cases, it was used with: `b0_thr = check_b0_threshold(force_b0_threshold, bvals.min(), bvals.min())` which was not doing anything!

4. [ENH] It was always used with the default b0_threshold. Added an argument b0_threshold that user may change if there is an error.

5. [FIX] Major fix in scil_sh_to_sf. With option --in_bval, The minimal b-value was always considered as a b0 and rejected from the average, even if the --in_bval contained no b0, which is actually kind of expected in this particular script.

# Complex description :)

**Easy scripts:**
   - scil_dwi_detect_volume_outliers: Ok. Usage was already clean. Just using the new official arg.
   - scil_dwi_extract_b0: Idem.
   - scil_dwi_to_sh: Ok. Idem. However, arg --force_b0 existed but was not used anywhere! Fixed.

**More complicated ones:**
   - scil_fodf_ssst: The usage of a b0_threshold seems straightforward for me but was not implemented in this script! By using `check_b0_threshold(args.force_b0_threshold, bvals.min(), bvals.min())`, it was always setting the b0_thr to the minimal b-value! But dipy's csdeconv does seem to use the gtab.b0s_mask. Added the b0_threshold option.
   - scil_sh_to_sf: There was no option. Used the minimal b-value as threshold. Option added.
   - scil_qball_metrics: Option existed, but then gtab was created with bvals.min(). Fixed, and added option b0_threshold.
   - scil_frf_ssst: The usage of a b0_threshold seems straightforward for me but was not implemented in this script!  Added the b0_threshold option.

**Impossible ones for now:**
   - scil_dti_metrics: I added some text. The gtab.b0_masks does not seem used anywhere in dipy's tensor model I think. To be confirmed by some expert.
   - scil_fodf_msmt: Cannot manage a separate threshold right now. Added link to dipy's issue. Added explanation. Using tolerance as b0_threshold.
   - scil_dki_metrics: Could not modify the identify_shells method right now. Only using tolerance. Link to dipy's issue also added. But if you think usage is clear in dki, please tell me what it does, I will modify the text.
   - scil_frf_msmt: Could not modify the extract_dwi_shell method right now. Only using tolerance. 
   - scil_frf_memsmt: Could not modify the genereate_btensor_input method right now. Only using tolerance. No checks at all here.
   - scil_fodf_memsmt: Idem.
   - scil_btensor_metrics: Idem. Removed unused option force_b0.

## Type of change

Check the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [ x] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ x] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [ x] I have performed a self-review of my code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ x] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes