### PR TITLE
fix gdrive endpoint for tests

### DIFF
--- a/scilpy/io/fetcher.py
+++ b/scilpy/io/fetcher.py
@@ -151,6 +151,11 @@ def fetch_data(files_dict, keys=None):
                     data = file_to_check.read()
                     md5_returned = hashlib.md5(data).hexdigest()
                 if md5_returned != md5:
+                    try:
+                        zipfile.ZipFile(full_path)
+                    except zipfile.BadZipFile:
+                        raise RuntimeError("Could not fetch valid archive for "
+                                           "file {}".format(f))
                     raise ValueError('MD5 mismatch for file {}.'.format(f))
 
                 try:

--- a/scilpy/io/fetcher.py
+++ b/scilpy/io/fetcher.py
@@ -6,7 +6,7 @@ import pathlib
 import requests
 import zipfile
 
-GOOGLE_URL = "https://drive.google.com/uc?"
+GOOGLE_URL = "https://drive.usercontent.google.com/download?"
 
 
 def download_file_from_google_drive(id, destination):


### PR DESCRIPTION
# Quick description

Tests are not passing because of a confirmation on large file download from gdrive. This fies the endpoint used so the confimation works.
...

## Type of change

Check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

Run the tests or wait for Jenkins

# Checklist

- [x] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [x] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
