### PR TITLE
Unit tests: gradients.bvec_bval_tools

### DIFF
--- a/scilpy/gradients/bvec_bval_tools.py
+++ b/scilpy/gradients/bvec_bval_tools.py
@@ -37,7 +37,7 @@ def is_normalized_bvecs(bvecs):
                                 bvecs_norm == 0))
 
 
-def normalize_bvecs(bvecs, filename=None):
+def normalize_bvecs(bvecs):
     """
     Normalize b-vectors
 
@@ -45,8 +45,6 @@ def normalize_bvecs(bvecs, filename=None):
     ----------
     bvecs : (N, 3) array
         input b-vectors (N, 3) array
-    filename : string
-        output filename where to save the normalized bvecs
 
     Returns
     -------
@@ -57,10 +55,6 @@ def normalize_bvecs(bvecs, filename=None):
     bvecs_norm = np.linalg.norm(bvecs, axis=1)
     idx = bvecs_norm != 0
     bvecs[idx] /= bvecs_norm[idx, None]
-
-    if filename is not None:
-        logging.info('Saving new bvecs: {}'.format(filename))
-        np.savetxt(filename, np.transpose(bvecs), "%.8f")
 
     return bvecs
 

--- a/scilpy/gradients/bvec_bval_tools.py
+++ b/scilpy/gradients/bvec_bval_tools.py
@@ -28,7 +28,6 @@ def is_normalized_bvecs(bvecs):
     -------
     True/False
     """
-
     bvecs_norm = np.linalg.norm(bvecs, axis=1)
     return np.all(np.logical_or(np.abs(bvecs_norm - 1) < 1e-3,
                                 bvecs_norm == 0))
@@ -48,7 +47,7 @@ def normalize_bvecs(bvecs):
     bvecs : (N, 3)
        normalized b-vectors
     """
-
+    bvecs = bvecs.copy()  # Avoid in-place modification.
     bvecs_norm = np.linalg.norm(bvecs, axis=1)
     idx = bvecs_norm != 0
     bvecs[idx] /= bvecs_norm[idx, None]
@@ -217,12 +216,13 @@ def flip_gradient_sampling(bvecs, axes, sampling_type):
     Parameters
     ----------
     bvecs: np.ndarray
-        Loaded bvecs. In the case 'mrtrix' the bvecs actually also contain the
-        bvals.
+        bvecs loaded directly, not re-formatted. Careful! Must respect the
+        format (not verified here).
     axes: list of int
-        List of axes to flip (e.g. [0, 1])
+        List of axes to flip (e.g. [0, 1]). See str_to_axis_index.
     sampling_type: str
-        Either 'mrtrix' or 'fsl'.
+        Either 'mrtrix': bvecs are of shape (N, 4) or
+               'fsl': bvecs are of shape (3, N)
 
     Returns
     -------
@@ -230,6 +230,8 @@ def flip_gradient_sampling(bvecs, axes, sampling_type):
         The final bvecs.
     """
     assert sampling_type in ['mrtrix', 'fsl']
+
+    bvecs = bvecs.copy()  # Avoid in-place modification.
     if sampling_type == 'mrtrix':
         for axis in axes:
             bvecs[:, axis] *= -1
@@ -246,12 +248,13 @@ def swap_gradient_axis(bvecs, final_order, sampling_type):
     Parameters
     ----------
     bvecs: np.array
-        Loaded bvecs. In the case 'mrtrix' the bvecs actually also contain the
-        bvals.
+        bvecs loaded directly, not re-formatted. Careful! Must respect the
+        format (not verified here).
     final_order: new order
         Final order (ex, 2 1 0)
     sampling_type: str
-        Either 'mrtrix' or 'fsl'.
+        Either 'mrtrix': bvecs are of shape (N, 4) or
+               'fsl': bvecs are of shape (3, N)
 
     Returns
     -------

--- a/scilpy/gradients/bvec_bval_tools.py
+++ b/scilpy/gradients/bvec_bval_tools.py
@@ -6,9 +6,6 @@ from enum import Enum
 from dipy.core.gradients import get_bval_indices
 import numpy as np
 
-from scilpy.io.gradients import (save_gradient_sampling_fsl,
-                                 save_gradient_sampling_mrtrix)
-
 DEFAULT_B0_THRESHOLD = 20
 
 
@@ -112,75 +109,6 @@ def check_b0_threshold(
                              .format(bvals_min, b0_thr))
 
     return b0_thr
-
-
-def fsl2mrtrix(fsl_bval_filename, fsl_bvec_filename, mrtrix_filename):
-    """
-    Convert a fsl dir_grad.bvec/.bval files to mrtrix encoding.b file.
-
-    Parameters
-    ----------
-    fsl_bval_filename: str
-        path to input fsl bval file.
-    fsl_bvec_filename: str
-        path to input fsl bvec file.
-    mrtrix_filename : str
-        path to output mrtrix encoding.b file.
-
-    Returns
-    -------
-    """
-
-    shells = np.loadtxt(fsl_bval_filename)
-    points = np.loadtxt(fsl_bvec_filename)
-    bvals = np.unique(shells).tolist()
-
-    # Remove .bval and .bvec if present
-    mrtrix_filename = mrtrix_filename.replace('.b', '')
-
-    if not points.shape[0] == 3:
-        points = points.transpose()
-        logging.warning('WARNING: Your bvecs seem transposed. ' +
-                        'Transposing them.')
-
-    shell_idx = [int(np.where(bval == bvals)[0]) for bval in shells]
-    save_gradient_sampling_mrtrix(points,
-                                  shell_idx,
-                                  bvals,
-                                  mrtrix_filename + '.b')
-
-
-def mrtrix2fsl(mrtrix_filename, fsl_filename):
-    """
-    Convert a mrtrix encoding.b file to fsl dir_grad.bvec/.bval files.
-
-    Parameters
-    ----------
-    mrtrix_filename : str
-        path to mrtrix encoding.b file.
-    fsl_bval_filename: str
-        path to the output fsl files. Files will be named
-        fsl_bval_filename.bval and fsl_bval_filename.bvec.
-    """
-    # Remove .bval and .bvec if present
-    fsl_filename = fsl_filename.replace('.bval', '')
-    fsl_filename = fsl_filename.replace('.bvec', '')
-
-    mrtrix_b = np.loadtxt(mrtrix_filename)
-    if not len(mrtrix_b.shape) == 2 or not mrtrix_b.shape[1] == 4:
-        raise ValueError('mrtrix file must have 4 columns')
-
-    points = np.array([mrtrix_b[:, 0], mrtrix_b[:, 1], mrtrix_b[:, 2]])
-    shells = np.array(mrtrix_b[:, 3])
-
-    bvals = np.unique(shells).tolist()
-    shell_idx = [int(np.where(bval == bvals)[0]) for bval in shells]
-
-    save_gradient_sampling_fsl(points,
-                               shell_idx,
-                               bvals,
-                               filename_bval=fsl_filename + '.bval',
-                               filename_bvec=fsl_filename + '.bvec')
 
 
 def identify_shells(bvals, threshold=40.0, roundCentroids=False, sort=False):

--- a/scilpy/gradients/tests/test_bvec_bval_tools.py
+++ b/scilpy/gradients/tests/test_bvec_bval_tools.py
@@ -1,17 +1,22 @@
 # -*- coding: utf-8 -*-
 import numpy as np
 
-from scilpy.gradients.bvec_bval_tools import round_bvals_to_shell
+from scilpy.gradients.bvec_bval_tools import (is_normalized_bvecs,
+                                              round_bvals_to_shell, normalize_bvecs)
+
+bvecs = np.asarray([[1.0, 1.0, 1.0],
+                    [1.0, 0.0, 1.0],
+                    [0.0, 1.0, 0.0]])
 
 
 def test_is_normalized_bvecs():
-    # toDO
-    pass
+    assert not is_normalized_bvecs(bvecs)
+    assert is_normalized_bvecs(
+        bvecs / np.linalg.norm(bvecs, axis=1, keepdims=True))
 
 
 def test_normalize_bvecs():
-    # toDo
-    pass
+    assert is_normalized_bvecs(normalize_bvecs(bvecs))
 
 
 def test_check_b0_threshold():

--- a/scilpy/gradients/tests/test_bvec_bval_tools.py
+++ b/scilpy/gradients/tests/test_bvec_bval_tools.py
@@ -3,11 +3,13 @@ import numpy as np
 
 from scilpy.gradients.bvec_bval_tools import (
     check_b0_threshold, is_normalized_bvecs, normalize_bvecs,
-    round_bvals_to_shell, identify_shells)
+    round_bvals_to_shell, identify_shells, str_to_axis_index, flip_gradient_sampling,
+    swap_gradient_axis)
 
 bvecs = np.asarray([[1.0, 1.0, 1.0],
                     [1.0, 0.0, 1.0],
-                    [0.0, 1.0, 0.0]])
+                    [0.0, 1.0, 0.0],
+                    [8.0, 1.0, 1.0]])
 
 
 def test_is_normalized_bvecs():
@@ -63,17 +65,26 @@ def test_identify_shells():
 
 def test_str_to_axis_index():
     # Very simple, nothing to do
-    pass
+    assert str_to_axis_index('x') == 0
 
 
 def test_flip_gradient_sampling():
-    # toDo
-    pass
+    fsl_bvecs = bvecs.T
+    b = flip_gradient_sampling(fsl_bvecs, axes=[0], sampling_type='fsl')
+    assert np.array_equal(b, np.asarray([[-1.0, 1.0, 1.0],
+                                         [-1.0, 0.0, 1.0],
+                                         [-0.0, 1.0, 0.0],
+                                         [-8.0, 1.0, 1.0]]).T)
 
 
 def test_swap_gradient_axis():
-    # toDo
-    pass
+    fsl_bvecs = bvecs.T
+    final_order = [1, 0, 2]
+    b = swap_gradient_axis(fsl_bvecs, final_order, sampling_type='fsl')
+    assert np.array_equal(b, np.asarray([[1.0, 1.0, 1.0],
+                                         [0.0, 1.0, 1.0],
+                                         [1.0, 0.0, 0.0],
+                                         [1.0, 8.0, 1.0]]).T)
 
 
 def test_round_bvals_to_shell():

--- a/scilpy/gradients/tests/test_bvec_bval_tools.py
+++ b/scilpy/gradients/tests/test_bvec_bval_tools.py
@@ -2,8 +2,8 @@
 import numpy as np
 
 from scilpy.gradients.bvec_bval_tools import (
-    check_b0_threshold, is_normalized_bvecs, normalize_bvecs,
-    round_bvals_to_shell, identify_shells, str_to_axis_index, flip_gradient_sampling,
+    identify_shells, is_normalized_bvecs, flip_gradient_sampling,
+    normalize_bvecs, round_bvals_to_shell, str_to_axis_index,
     swap_gradient_axis)
 
 bvecs = np.asarray([[1.0, 1.0, 1.0],
@@ -68,7 +68,7 @@ def test_str_to_axis_index():
     assert str_to_axis_index('x') == 0
     assert str_to_axis_index('y') == 1
     assert str_to_axis_index('z') == 2
-
+    assert str_to_axis_index('v') is None
 
 
 def test_flip_gradient_sampling():

--- a/scilpy/gradients/tests/test_bvec_bval_tools.py
+++ b/scilpy/gradients/tests/test_bvec_bval_tools.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 import numpy as np
 
-from scilpy.gradients.bvec_bval_tools import (is_normalized_bvecs,
-                                              round_bvals_to_shell, normalize_bvecs)
+from scilpy.gradients.bvec_bval_tools import (
+    check_b0_threshold, is_normalized_bvecs, normalize_bvecs,
+    round_bvals_to_shell)
 
 bvecs = np.asarray([[1.0, 1.0, 1.0],
                     [1.0, 0.0, 1.0],
@@ -20,17 +21,7 @@ def test_normalize_bvecs():
 
 
 def test_check_b0_threshold():
-    # toDo
-    pass
-
-
-def test_fsl2mrtrix():
-    # toDo
-    pass
-
-
-def test_mrtrix2fsl():
-    # toDo
+    # toDo To be modified (see PR#867).
     pass
 
 

--- a/scilpy/gradients/tests/test_bvec_bval_tools.py
+++ b/scilpy/gradients/tests/test_bvec_bval_tools.py
@@ -66,6 +66,9 @@ def test_identify_shells():
 def test_str_to_axis_index():
     # Very simple, nothing to do
     assert str_to_axis_index('x') == 0
+    assert str_to_axis_index('y') == 1
+    assert str_to_axis_index('z') == 2
+
 
 
 def test_flip_gradient_sampling():

--- a/scilpy/image/volume_operations.py
+++ b/scilpy/image/volume_operations.py
@@ -279,8 +279,8 @@ def compute_snr(dwi, bval, bvec, b0_thr, mask,
     mask = get_data_as_mask(mask, dtype=bool)
 
     if split_shells:
-        centroids, shell_indices = identify_shells(bval, threshold=40.0,
-                                                   roundCentroids=False,
+        centroids, shell_indices = identify_shells(bval, tol=40.0,
+                                                   round_centroids=False,
                                                    sort=False)
         bval = centroids[shell_indices]
 

--- a/scilpy/io/gradients.py
+++ b/scilpy/io/gradients.py
@@ -6,6 +6,69 @@ import os
 import numpy as np
 
 
+def fsl2mrtrix(fsl_bval_filename, fsl_bvec_filename, mrtrix_filename):
+    """
+    Convert a fsl dir_grad.bvec/.bval files to mrtrix encoding.b file.
+    Saves the result.
+
+    Parameters
+    ----------
+    fsl_bval_filename: str
+        path to input fsl bval file.
+    fsl_bvec_filename: str
+        path to input fsl bvec file.
+    mrtrix_filename : str
+        path to output mrtrix encoding.b file.
+    """
+    shells = np.loadtxt(fsl_bval_filename)
+    points = np.loadtxt(fsl_bvec_filename)
+    bvals = np.unique(shells).tolist()
+
+    # Remove .bval and .bvec if present
+    mrtrix_filename = mrtrix_filename.replace('.b', '')
+
+    if not points.shape[0] == 3:
+        points = points.transpose()
+        logging.warning('WARNING: Your bvecs seem transposed. ' +
+                        'Transposing them.')
+
+    shell_idx = [int(np.where(bval == bvals)[0]) for bval in shells]
+    save_gradient_sampling_mrtrix(points, shell_idx, bvals,
+                                  mrtrix_filename + '.b')
+
+
+def mrtrix2fsl(mrtrix_filename, fsl_filename):
+    """
+    Convert a mrtrix encoding.b file to fsl dir_grad.bvec/.bval files.
+    Saves the result.
+
+    Parameters
+    ----------
+    mrtrix_filename : str
+        path to mrtrix encoding.b file.
+    fsl_filename: str
+        path to the output fsl files. Files will be named
+        fsl_bval_filename.bval and fsl_bval_filename.bvec.
+    """
+    # Remove .bval and .bvec if present
+    fsl_filename = fsl_filename.replace('.bval', '')
+    fsl_filename = fsl_filename.replace('.bvec', '')
+
+    mrtrix_b = np.loadtxt(mrtrix_filename)
+    if not len(mrtrix_b.shape) == 2 or not mrtrix_b.shape[1] == 4:
+        raise ValueError('mrtrix file must have 4 columns')
+
+    points = np.array([mrtrix_b[:, 0], mrtrix_b[:, 1], mrtrix_b[:, 2]])
+    shells = np.array(mrtrix_b[:, 3])
+
+    bvals = np.unique(shells).tolist()
+    shell_idx = [int(np.where(bval == bvals)[0]) for bval in shells]
+
+    save_gradient_sampling_fsl(points, shell_idx, bvals,
+                               filename_bval=fsl_filename + '.bval',
+                               filename_bvec=fsl_filename + '.bvec')
+
+
 def save_gradient_sampling_mrtrix(bvecs, shell_idx, bvals, filename):
     """
     Save table gradient (MRtrix format)

--- a/scripts/scil_NODDI_maps.py
+++ b/scripts/scil_NODDI_maps.py
@@ -119,7 +119,7 @@ def main():
     bvals, _ = read_bvals_bvecs(args.in_bval, args.in_bvec)
     shells_centroids, indices_shells = identify_shells(bvals,
                                                        args.b_thr,
-                                                       roundCentroids=True)
+                                                       round_centroids=True)
     np.savetxt(tmp_bval_filename, shells_centroids[indices_shells],
                newline=' ', fmt='%i')
     fsl2mrtrix(tmp_bval_filename, args.in_bvec, tmp_scheme_filename)

--- a/scripts/scil_NODDI_maps.py
+++ b/scripts/scil_NODDI_maps.py
@@ -20,13 +20,14 @@ import amico
 from dipy.io.gradients import read_bvals_bvecs
 import numpy as np
 
+from scilpy.io.gradients import fsl2mrtrix
 from scilpy.io.utils import (add_overwrite_arg,
                              add_processes_arg,
                              add_verbose_arg,
                              assert_inputs_exist,
                              assert_output_dirs_exist_and_empty,
                              redirect_stdout_c)
-from scilpy.gradients.bvec_bval_tools import fsl2mrtrix, identify_shells
+from scilpy.gradients.bvec_bval_tools import identify_shells
 
 EPILOG = """
 Reference:

--- a/scripts/scil_freewater_maps.py
+++ b/scripts/scil_freewater_maps.py
@@ -126,7 +126,7 @@ def main():
     bvals, _ = read_bvals_bvecs(args.in_bval, args.in_bvec)
     shells_centroids, indices_shells = identify_shells(bvals,
                                                        args.b_thr,
-                                                       roundCentroids=True)
+                                                       round_centroids=True)
     np.savetxt(tmp_bval_filename, shells_centroids[indices_shells],
                newline=' ', fmt='%i')
     fsl2mrtrix(tmp_bval_filename, args.in_bvec, tmp_scheme_filename)

--- a/scripts/scil_freewater_maps.py
+++ b/scripts/scil_freewater_maps.py
@@ -20,13 +20,14 @@ import amico
 from dipy.io.gradients import read_bvals_bvecs
 import numpy as np
 
+from scilpy.io.gradients import fsl2mrtrix
 from scilpy.io.utils import (add_overwrite_arg,
                              add_processes_arg,
                              add_verbose_arg,
                              assert_inputs_exist,
                              assert_output_dirs_exist_and_empty,
                              redirect_stdout_c)
-from scilpy.gradients.bvec_bval_tools import fsl2mrtrix, identify_shells
+from scilpy.gradients.bvec_bval_tools import identify_shells
 
 
 EPILOG = """

--- a/scripts/scil_gradients_convert.py
+++ b/scripts/scil_gradients_convert.py
@@ -14,7 +14,7 @@ import logging
 from scilpy.io.utils import (assert_gradients_filenames_valid,
                              assert_inputs_exist, assert_outputs_exist,
                              add_overwrite_arg, add_verbose_arg)
-from scilpy.gradients.bvec_bval_tools import fsl2mrtrix, mrtrix2fsl
+from scilpy.io.gradients import fsl2mrtrix, mrtrix2fsl
 
 
 def _build_arg_parser():

--- a/scripts/scil_gradients_modify_axes.py
+++ b/scripts/scil_gradients_modify_axes.py
@@ -83,14 +83,24 @@ def main():
     if len(np.unique(swapped_order)) != 3:
         parser.error("final_order should contain the three axis.")
 
+    # Could use io.gradients method, but we don't have a bvals file here, only
+    # treating with the bvecs. Loading directly.
     bvecs = np.loadtxt(args.in_gradient_sampling_file)
     if ext_in == '.bvec':
-        # Supposing FSL format
+        # Supposing FSL format: Per columns
+        if bvecs.shape[0] != 3:
+            parser.error("b-vectors format for a .b file should be FSL, "
+                         "and contain 3 lines (x, y, z), but got {}"
+                         .format(bvecs.shape[0]))
         bvecs = flip_gradient_sampling(bvecs, axes_to_flip, 'fsl')
         bvecs = swap_gradient_axis(bvecs, swapped_order, 'fsl')
         np.savetxt(args.out_gradient_sampling_file, bvecs, "%.8f")
     else:  # ext == '.b':
         # Supposing mrtrix format
+        if bvecs.shape[1] != 4:
+            parser.error("b-vectors format for a .b file should be mrtrix, "
+                         "and contain 4 columns (x, y, z, bval), but got {}"
+                         .format(bvecs.shape[1]))
         bvecs = flip_gradient_sampling(bvecs, axes_to_flip, 'mrtrix')
         bvecs = swap_gradient_axis(bvecs, swapped_order, 'mrtrix')
         np.savetxt(args.out_gradient_sampling_file, bvecs,

--- a/scripts/scil_tractogram_commit.py
+++ b/scripts/scil_tractogram_commit.py
@@ -385,7 +385,7 @@ def main():
     tmp_bval_filename = os.path.join(tmp_dir.name, 'bval')
     bvals, _ = read_bvals_bvecs(args.in_bval, args.in_bvec)
     shells_centroids, indices_shells = identify_shells(bvals, args.b_thr,
-                                                       roundCentroids=True)
+                                                       round_centroids=True)
     np.savetxt(tmp_bval_filename, shells_centroids[indices_shells],
                newline=' ', fmt='%i')
     fsl2mrtrix(tmp_bval_filename, args.in_bvec, tmp_scheme_filename)

--- a/scripts/scil_tractogram_commit.py
+++ b/scripts/scil_tractogram_commit.py
@@ -84,6 +84,7 @@ import h5py
 import numpy as np
 import nibabel as nib
 
+from scilpy.io.gradients import fsl2mrtrix
 from scilpy.io.streamlines import (reconstruct_streamlines,
                                    reconstruct_streamlines_from_hdf5)
 from scilpy.io.utils import (add_overwrite_arg,
@@ -92,7 +93,7 @@ from scilpy.io.utils import (add_overwrite_arg,
                              assert_inputs_exist,
                              assert_output_dirs_exist_and_empty,
                              redirect_stdout_c)
-from scilpy.gradients.bvec_bval_tools import fsl2mrtrix, identify_shells
+from scilpy.gradients.bvec_bval_tools import identify_shells
 
 
 EPILOG = """


### PR DESCRIPTION
# Quick description

Unit tests for methods in bvec_val_tools.

(Moved `fsl2mrtrix` and `mrtrix2fsl` out of there, to `io.gradients`, because they load and save data. To avoid having to load data in unit tests).

...

## Type of change

Check the relevant options.

- [x] Unit tests :)

## Provide data, screenshots, command line to test (if relevant)

`pytest scilpy/gradients/tests/test_bvec_bval_tools.py`

# Checklist

- [x] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [x] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
