### PR TITLE
Fix bad commit in codecov

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,7 +60,9 @@ pipeline {
                     shasum -a 256 -c codecov.SHA256SUM
 
                     chmod +x codecov
-                    ./codecov -t ${CODECOV_TOKEN} -f .test_reports/coverage.xml
+                    ./codecov -t ${CODECOV_TOKEN} \
+                        -f .test_reports/coverage.xml \
+                        -C ${GIT_PREVIOUS_COMMIT}
                 '''
             }
         }


### PR DESCRIPTION
# Quick description

When Jenkins checkouts a PR, it merges its head with the origin/master branch locally and produces a new commit. This has a bad side-effect that Jenkins knows about the revision, but no one else. Codecov reports the bad commit, but since it does not exist on Github, it can break the links between coverage reports.

...

## Type of change

Check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Provide data, screenshots, command line to test (if relevant)

We'll see on codecov if the right commit is used and if bindings with Jenkins does work with the forced commit SHA

# Checklist

- [x] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [x] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
