### PR TITLE
Robustify the coloring

### DIFF
--- a/scripts/scil_tractogram_assign_custom_color.py
+++ b/scripts/scil_tractogram_assign_custom_color.py
@@ -200,7 +200,9 @@ def main():
                 data = np.clip(data, np.quantile(data, 0.05),
                                np.quantile(data, 0.95))
         elif args.use_dpp:
-            data = np.squeeze(sft.data_per_point[args.use_dpp]._data)
+            tmp = [np.squeeze(sft.data_per_point[args.use_dpp][s]) for s in
+                   range(len(sft))]
+            data = np.hstack(tmp)
         elif args.load_dps:
             data = np.squeeze(load_matrix_in_any_format(args.load_dps))
             if len(data) != len(sft):

--- a/scripts/tests/test_tractogram_assign_custom_color.py
+++ b/scripts/tests/test_tractogram_assign_custom_color.py
@@ -13,7 +13,7 @@ tmp_dir = tempfile.TemporaryDirectory()
 
 
 def test_help_option(script_runner):
-    ret = script_runner.run('scil_assign_uniform_color_to_tractograms.py',
+    ret = script_runner.run('scil_tractogram_assign_custom_color.py',
                             '--help')
     assert ret.success
 
@@ -22,7 +22,9 @@ def test_execution_tractometry(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
     in_bundle = os.path.join(get_home(), 'tractometry',
                              'IFGWM.trk')
-    ret = script_runner.run('scil_assign_uniform_color_to_tractograms.py',
-                            in_bundle, '--fill_color', '0x000000',
-                            '--out_tractogram', 'colored.trk')
+    in_anat = os.path.join(get_home(), 'tractometry',
+                           'IFGWM_labels_map.nii.gz')
+    ret = script_runner.run('scil_tractogram_assign_custom_color.py',
+                            in_bundle, 'colored.trk', '--from_anatomy',
+                            in_anat)
     assert ret.success

--- a/scripts/tests/test_tractogram_assign_uniform_color.py
+++ b/scripts/tests/test_tractogram_assign_uniform_color.py
@@ -13,7 +13,7 @@ tmp_dir = tempfile.TemporaryDirectory()
 
 
 def test_help_option(script_runner):
-    ret = script_runner.run('scil_assign_custom_color_to_tractogram.py',
+    ret = script_runner.run('scil_tractogram_assign_uniform_color.py',
                             '--help')
     assert ret.success
 
@@ -22,9 +22,7 @@ def test_execution_tractometry(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
     in_bundle = os.path.join(get_home(), 'tractometry',
                              'IFGWM.trk')
-    in_anat = os.path.join(get_home(), 'tractometry',
-                           'IFGWM_labels_map.nii.gz')
-    ret = script_runner.run('scil_assign_custom_color_to_tractogram.py',
-                            in_bundle, 'colored.trk', '--from_anatomy',
-                            in_anat)
+    ret = script_runner.run('scil_tractogram_assign_uniform_color.py',
+                            in_bundle, '--fill_color', '0x000000',
+                            '--out_tractogram', 'colored.trk')
     assert ret.success


### PR DESCRIPTION
# Quick description

In some cases, the hidden _data is not ordered correctly. Ex:

```
new_order = np.flip(np.arange(len(sft)))
sft = sft[new_order]
```

The sft.data_per_point[key]._data is not always updated!

Accessing the data directly instead.

! **Note: There are many other _data usage in that file. I didn't test them all.**

It also made me notice that the test name was not correct.
...

## Type of change

Check the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [x] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [x] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
