### PR TITLE
Adding msmt support to set_frf_diffusivities

### DIFF
--- a/scripts/scil_frf_set_diffusivities.py
+++ b/scripts/scil_frf_set_diffusivities.py
@@ -40,10 +40,10 @@ def _build_arg_parser():
                    help='If supplied, the fiber response function is\n'
                         'evaluated without the x 10**-4 factor. [%(default)s].'
                    )
-    
+
     add_verbose_arg(p)
     add_overwrite_arg(p)
-    
+
     return p
 
 

--- a/scripts/scil_frf_set_diffusivities.py
+++ b/scripts/scil_frf_set_diffusivities.py
@@ -6,7 +6,8 @@ Replace the fiber response function in the FRF file.
 Use this script when you want to use a fixed response function
 and keep the mean b0.
 
-The FRF file is obtained from scil_frf_ssst.py
+The FRF file is obtained from scil_frf_ssst.py or scil_frf_msmt.py in the case
+of multi-shell data.
 
 Formerly: scil_set_response_function.py
 """
@@ -30,7 +31,9 @@ def _build_arg_parser():
     p.add_argument('new_frf', metavar='tuple',
                    help='Replace the response function with\n'
                         'this fiber response function x 10**-4 (e.g. '
-                        '15,4,4).')
+                        '15,4,4). \nIf multi-shell, write the first shell'
+                        ', then the second shell, \nand the third, etc '
+                        '(e.g. 15,4,4,13,5,5,12,5,5).')
     p.add_argument('output_frf_file', metavar='output',
                    help='Path of the new FRF file.')
     p.add_argument('--no_factor', action='store_true',
@@ -51,13 +54,24 @@ def main():
     assert_inputs_exist(parser, args.frf_file)
     assert_outputs_exist(parser, args, args.output_frf_file)
 
-    frf_file = np.array(np.loadtxt(args.frf_file))
+    frf_file = np.array(np.loadtxt(args.frf_file)).T
     new_frf = np.array(literal_eval(args.new_frf), dtype=np.float64)
     if not args.no_factor:
         new_frf *= 10 ** -4
     b0_mean = frf_file[3]
 
-    response = np.concatenate([new_frf, [b0_mean]])
+    if new_frf.shape[0] % 3 != 0:
+        raise ValueError('Inputed new frf is not valid. There should be '
+                         'three values per shell, and thus the total number '
+                         'of values should be a multiple of three.')
+
+    nb_shells = int(new_frf.shape[0] / 3)
+    new_frf = new_frf.reshape((nb_shells, 3))
+
+    response = np.empty((nb_shells, 4))
+    response[:, 0:3] = new_frf
+    response[:, 3] = b0_mean
+
     np.savetxt(args.output_frf_file, response)
 
 

--- a/scripts/tests/test_frf_set_diffusivities.py
+++ b/scripts/tests/test_frf_set_diffusivities.py
@@ -7,7 +7,8 @@ import tempfile
 from scilpy.io.fetcher import fetch_data, get_home, get_testing_files_dict
 
 # If they already exist, this only takes 5 seconds (check md5sum)
-fetch_data(get_testing_files_dict(), keys=['processing.zip'])
+fetch_data(get_testing_files_dict(),
+           keys=['processing.zip', 'commit_amico.zip'])
 tmp_dir = tempfile.TemporaryDirectory()
 
 
@@ -16,10 +17,26 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_processing(script_runner):
+def test_execution_processing_ssst(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
     in_frf = os.path.join(get_home(), 'processing',
                           'frf.txt')
     ret = script_runner.run('scil_frf_set_diffusivities.py', in_frf,
-                            '15,4,4', 'nfrf.txt')
+                            '15,4,4', 'new_frf.txt', '-f')
     assert ret.success
+
+def test_execution_processing_msmt(script_runner):
+    os.chdir(os.path.expanduser(tmp_dir.name))
+    in_frf = os.path.join(get_home(), 'commit_amico',
+                          'wm_frf.txt')
+    ret = script_runner.run('scil_frf_set_diffusivities.py', in_frf,
+                            '15,4,4,13,4,4,12,5,5', 'new_frf.txt', '-f')
+    assert ret.success
+
+def test_execution_processing__wrong_input(script_runner):
+    os.chdir(os.path.expanduser(tmp_dir.name))
+    in_frf = os.path.join(get_home(), 'commit_amico',
+                          'wm_frf.txt')
+    ret = script_runner.run('scil_frf_set_diffusivities.py', in_frf,
+                            '15,4,4,13,4,4', 'new_frf.txt', '-f')
+    assert not ret.success

--- a/scripts/tests/test_frf_set_diffusivities.py
+++ b/scripts/tests/test_frf_set_diffusivities.py
@@ -25,6 +25,7 @@ def test_execution_processing_ssst(script_runner):
                             '15,4,4', 'new_frf.txt', '-f')
     assert ret.success
 
+
 def test_execution_processing_msmt(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
     in_frf = os.path.join(get_home(), 'commit_amico',
@@ -32,6 +33,7 @@ def test_execution_processing_msmt(script_runner):
     ret = script_runner.run('scil_frf_set_diffusivities.py', in_frf,
                             '15,4,4,13,4,4,12,5,5', 'new_frf.txt', '-f')
     assert ret.success
+
 
 def test_execution_processing__wrong_input(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))


### PR DESCRIPTION
# Quick description

I added multi-shell support to `scil_frf_set_diffusivities.py`. It only took a few modifcations, and single-shell works as before. This was added with the goal of running it in nf-scil. I added tests also, and a check on the format of the input new_frf.

...

## Type of change

Check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [x] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [x] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
