### PR TITLE
Fix weighted mean std when infinite values

### DIFF
--- a/scilpy/utils/metrics_tools.py
+++ b/scilpy/utils/metrics_tools.py
@@ -157,9 +157,9 @@ def weighted_mean_std(weights, data):
         a tuple containing the mean and standard deviation of the data
     """
 
-    masked_data = np.ma.masked_array(data, np.isnan(data))
-    mean = np.average(masked_data, weights=weights)
-    variance = np.average((masked_data-mean)**2, weights=weights)
+    masked_data = np.ma.masked_array(data, np.logical_or(np.isnan(a), np.isinf(a)))
+    mean = np.ma.average(masked_data, weights=weights)
+    variance = np.ma.average((masked_data-mean)**2, weights=weights)
 
     return mean, np.sqrt(variance)
 

--- a/scilpy/utils/metrics_tools.py
+++ b/scilpy/utils/metrics_tools.py
@@ -157,7 +157,8 @@ def weighted_mean_std(weights, data):
         a tuple containing the mean and standard deviation of the data
     """
 
-    masked_data = np.ma.masked_array(data, np.logical_or(np.isnan(a), np.isinf(a)))
+    masked_data = np.ma.masked_array(data, np.logical_or(np.isnan(data),
+                                                         np.isinf(data)))
     mean = np.ma.average(masked_data, weights=weights)
     variance = np.ma.average((masked_data-mean)**2, weights=weights)
 


### PR DESCRIPTION
# Quick description

Email from Po-Jui:

**_Mario and I found an unexpected behavior with the function weighted_mean_std in scilpy. np.average is used inside that function to compute the weighted mean with the image saved in a numpy masked array. In this case, the voxels of invalid nan values would be considered in the denominator of the weighted mean computation. To compute the weighted average on a masked numpy array without the invalid voxels, np.ma.average should be used.
Another thing we would like to propose is to check infinity values in the image, in addition to checking nan values. The proposed modification is in blue_**


...

## Type of change

Check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [ ] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
