### PR TITLE
disable test run on forks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,9 +19,10 @@ env:
 jobs:
   test:
     runs-on: scilus-runners
+    if: github.repository == 'scilus/scilpy'
     steps:
       - name: Checkout repository for merge
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
 
       - name: Fetch python version from repository
         id: python-selector


### PR DESCRIPTION
# Quick description

Disable workflow run on forks. The workflow will still trigger, but all jobs will be skipped

## Type of change

Check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [x] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [x] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
