### PR TITLE
Finish cleaning the main of dwi_ scripts, to allow eventual unit tests

### DIFF
--- a/scilpy/dwi/tests/test_operations.py
+++ b/scilpy/dwi/tests/test_operations.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+
+
+def test_apply_bias_field():
+    pass
+
+
+def test_compute_dwi_attenuation():
+    pass

--- a/scilpy/dwi/tests/test_operations.py
+++ b/scilpy/dwi/tests/test_operations.py
@@ -7,3 +7,7 @@ def test_apply_bias_field():
 
 def test_compute_dwi_attenuation():
     pass
+
+
+def test_detect_volume_outliers():
+    pass

--- a/scilpy/dwi/tests/test_utils.py
+++ b/scilpy/dwi/tests/test_utils.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+
+
+def test_extract_dwi_shell():
+    pass
+
+
+def test_extract_b0():
+    pass

--- a/scilpy/io/varian_fdf.py
+++ b/scilpy/io/varian_fdf.py
@@ -424,7 +424,9 @@ def correct_procpar_intensity(dwi_data, dwi_path, b0_path):
 
             P1 = 10**(Ldb/20)
     """
-
+    # Not really an io function: does not load and save! But it is the only
+    # method we have concerning varian_fdf. Kept here, as decided by guru
+    # Arnaud.
     dwi_gain = get_gain(dwi_path)
     b0_gain = get_gain(b0_path)
 

--- a/scripts/scil_dwi_detect_volume_outliers.py
+++ b/scripts/scil_dwi_detect_volume_outliers.py
@@ -15,20 +15,16 @@ before launching pre-processing.
 """
 
 import argparse
-import pprint
 
 from dipy.io.gradients import read_bvals_bvecs
 import nibabel as nib
-import numpy as np
 
+from scilpy.dwi.operations import detect_volume_outliers
 from scilpy.io.utils import (assert_inputs_exist,
                              add_force_b0_arg,
                              add_verbose_arg)
 from scilpy.gradients.bvec_bval_tools import (check_b0_threshold,
-                                              identify_shells,
-                                              normalize_bvecs,
-                                              round_bvals_to_shell)
-import math
+                                              normalize_bvecs)
 
 
 def _build_arg_parser():
@@ -49,7 +45,7 @@ def _build_arg_parser():
                         'diffusion weighting. [%(default)s]')
     p.add_argument('--std_scale', type=float, default=2.0,
                    help='How many deviation from the mean are required to be '
-                        'considered an outliers. [%(default)s]')
+                        'considered an outlier. [%(default)s]')
 
     add_force_b0_arg(p)
     add_verbose_arg(p)
@@ -64,73 +60,14 @@ def main():
     assert_inputs_exist(parser, [args.in_dwi, args.in_bval, args.in_bvec])
 
     bvals, bvecs = read_bvals_bvecs(args.in_bval, args.in_bvec)
-    dwi = nib.load(args.in_dwi)
-    data = dwi.get_fdata()
+    data = nib.load(args.in_dwi).get_fdata()
 
     b0_thr = check_b0_threshold(args.force_b0_threshold,
                                 bvals.min(), args.b0_thr)
     bvecs = normalize_bvecs(bvecs)
 
-    results_dict = {}
-    shells_to_extract = identify_shells(bvals, b0_thr, sort=True)[0]
-    bvals = round_bvals_to_shell(bvals, shells_to_extract)
-    for bval in shells_to_extract[shells_to_extract > args.b0_thr]:
-        shell_idx = np.where(bvals == bval)[0]
-        shell = bvecs[shell_idx]
-        results_dict[bval] = np.ones((len(shell), 3)) * -1
-        for i, vec in enumerate(shell):
-            if np.linalg.norm(vec) < 0.001:
-                continue
-
-            dot_product = np.clip(np.tensordot(shell, vec, axes=1), -1, 1)
-            angle = np.arccos(dot_product) * 180 / math.pi
-            angle[np.isnan(angle)] = 0
-            idx = np.argpartition(angle, 4).tolist()
-            idx.remove(i)
-
-            avg_angle = np.average(angle[idx[:3]])
-            corr = np.corrcoef([data[..., shell_idx[i]].ravel(),
-                                data[..., shell_idx[idx[0]]].ravel(),
-                                data[..., shell_idx[idx[1]]].ravel(),
-                                data[..., shell_idx[idx[2]]].ravel()])
-            results_dict[bval][i] = [shell_idx[i], avg_angle,
-                                     np.average(corr[0, 1:])]
-
-    for key in results_dict.keys():
-        avg_angle = np.round(np.average(results_dict[key][:, 1]), 4)
-        std_angle = np.round(np.std(results_dict[key][:, 1]), 4)
-
-        avg_corr = np.round(np.average(results_dict[key][:, 2]), 4)
-        std_corr = np.round(np.std(results_dict[key][:, 2]), 4)
-
-        outliers_angle = np.argwhere(
-            results_dict[key][:, 1] < avg_angle-(args.std_scale*std_angle))
-        outliers_corr = np.argwhere(
-            results_dict[key][:, 2] < avg_corr-(args.std_scale*std_corr))
-
-        print('Results for shell {} with {} directions:'.format(
-            key, len(results_dict[key])))
-        print('AVG and STD of angles: {} +/- {}'.format(
-            avg_angle, std_angle))
-        print('AVG and STD of correlations: {} +/- {}'.format(
-            avg_corr, std_corr))
-
-        if len(outliers_angle) or len(outliers_corr):
-            print('Possible outliers ({} STD below or above average):'.format(
-                args.std_scale))
-            print('Outliers based on angle [position (4D), value]')
-            for i in outliers_angle:
-                print(results_dict[key][i, :][0][0:2])
-            print('Outliers based on correlation [position (4D), value]')
-            for i in outliers_corr:
-                print(results_dict[key][i, :][0][0::2])
-        else:
-            print('No outliers detected.')
-
-        if args.verbose:
-            print('Shell with b-value {}'.format(key))
-            pprint.pprint(results_dict[key])
-        print()
+    detect_volume_outliers(data, bvecs, bvals, args.std_scale,
+                           args.verbose, b0_thr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Quick description

In preparation for next unit tests (in module dwi), finish cleaning the main of all scripts in the column DWI of our super excel file. Remaining files were:

- scil_dwi_detect_volume_outliers: Most of the main copy-pasted into a method. Absolutely no change made.
- scil_prepare_topup and scil_prepare_eddy: I give up for these two. No unit test for now.
- scil_dwi_convert_FDF: Was aldready clean, but in module io instead of module dwi. Arnaud choose to keep as is.

So in summary: Absolutely no line of code changed here.

...

## Type of change

Check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [ ] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
