### PR TITLE
Fix coverage report paths

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,11 +1,11 @@
 [run]
 branch = True
 concurrency = multiprocessing
-data_file = .test_reports/.coverage
-relative_files = True
-source_pkgs =
+data_file = .coverage
+source_pkgs = 
     scilpy
     scripts
+relative_files = True
 omit =
     scripts/tests/*.py
     scilpy/tests/**/*.py
@@ -16,6 +16,11 @@ omit =
 
 [report]
 skip_empty = True
+skip_covered = True
 
 [html]
 title = Scilpy Coverage Report
+directory = .test_reports/coverage.html
+
+[xml]
+output = .test_reports/coverage.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,6 @@ jobs:
           flags: unittests
           name: scilpy-unittests-${{ github.run_id }}
           verbose: true
-          directory: .test_reports/
           fail_ci_if_error: true
           plugin: pycoverage
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -33,8 +33,7 @@ junit_logging = out-err
 
 addopts =
     --html=.test_reports/pytest.html
-    --cov-report=html:.test_reports/coverage.html
     --junit-xml=.test_reports/junit.xml
-    --cov-report=xml:.test_reports/coverage.xml
-    --cov=scilpy/
-    --cov=scripts/    
+    --cov
+    --cov-report html
+    --cov-report xml


### PR DESCRIPTION
# Quick description

Paths between the source, the coverage report and codecov were muddled. I moved .coverage at the root, and now codecov can execute there and everything is golden.

## Type of change

Check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [ ] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
