### PR TITLE
Ability to resume workflow when codecov push fails

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,7 +2,7 @@
 branch = True
 concurrency = multiprocessing
 data_file = .coverage
-source_pkgs = 
+source_pkgs =
     scilpy
     scripts
 relative_files = True
@@ -17,6 +17,9 @@ omit =
 [report]
 skip_empty = True
 skip_covered = True
+exclude_also =
+    if __name__ == "__main__":
+    main()
 
 [html]
 title = Scilpy Coverage Report

--- a/.coveragerc
+++ b/.coveragerc
@@ -19,7 +19,7 @@ skip_empty = True
 skip_covered = True
 exclude_also =
     if __name__ == "__main__":
-    main()
+    (?<!def )main()
 
 [html]
 title = Scilpy Coverage Report

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
           name: test-coverage-${{ github.run_id }}
           failOnError: false
 
-      - name: Checkout repository for merge
+      - name: Checkout repository at merge
         uses: actions/checkout@v4
 
       - name: Fetch python version from repository
@@ -64,7 +64,7 @@ jobs:
       - name: Run tests
         run: |
           export C_INCLUDE_PATH=$pythonLocation/include/python${{ steps.python-selector.outputs.python-version }}:$C_INCLUDE_PATH
-          pytest --cov-report term-missing:skip-covered
+          pytest --cov-report term-missing:skip-covered scripts/tests/test_bids_validate.py
 
       - name: Save test results and coverage
         uses: actions/upload-artifact@v4
@@ -81,10 +81,10 @@ jobs:
     needs: test
 
     steps:
-      - name: Checkout repository for merge
+      - name: Checkout repository at merge
         uses: actions/checkout@v4
 
-      - name: Set up Python for Scilpy
+      - name: Set up Python for codecov upload
         uses: actions/setup-python@v5.0.0
         with:
           python-version: '3.10'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,11 +84,19 @@ jobs:
       - name: Checkout repository for merge
         uses: actions/checkout@v4
 
+      - name: Set up Python for Scilpy
+        uses: actions/setup-python@v5.0.0
+        with:
+          python-version: 3.10
+          cache: 'pip'
+
+      - name: Install pycoverage
+        run: pip install coverage
+
       - name: Download test results and coverage
         uses: actions/download-artifact@v4
         with:
           name: test-coverage-${{ github.run_id }}
-          path: ${{ github.workspace }}/scilpy
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Run tests
         run: |
           export C_INCLUDE_PATH=$pythonLocation/include/python${{ steps.python-selector.outputs.python-version }}:$C_INCLUDE_PATH
-          pytest --cov-report term-missing:skip-covered scripts/tests/test_bids_validate.py
+          pytest --cov-report term-missing:skip-covered
 
       - name: Save test results and coverage
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,9 +23,9 @@ jobs:
 
     steps:
       # If this runs and does not fails, its because the workflow was relaunched
-      # with no resuming and we need to delete the artifact since we 
-      # re-executed the tests. Else, it'll fail the job (silently) and the 
-      # remaining workflow will continue
+      # with no resuming and we need to delete the artifact since we
+      # re-executed the tests. Else, if nothing to do, it'll fail the job
+      # (silently) and the remaining workflow will continue
       - name: Delete tests and coverage artifact
         uses: geekyeggo/delete-artifact@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,9 @@ env:
   MPLBACKEND: agg
   OPENBLAS_NUM_THREADS: 1
 
+permissions:
+  actions: write
+
 jobs:
   test:
     runs-on: scilus-runners

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,7 @@ jobs:
           name: test-coverage-${{ github.run_id }}
           path: |
             .coverage
-            .test_data/
+            .test_reports/
 
   coverage:
     runs-on: scilus-runners
@@ -88,6 +88,16 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: test-coverage-${{ github.run_id }}
+
+      - name: Show the content of the workspace where we upload
+        run: |
+          echo "what is here : $(pwd)"
+          ls .
+          echo "what is in GITHUB_WORKSPACE : $GITHUB_WORKSPACE"
+          ls $GITHUB_WORKSPACE
+          echo "what is in github.workspace : ${{ github.workspace }}"
+          ls ${{ github.workspace }}
+          exit 1
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,25 +16,12 @@ env:
   MPLBACKEND: agg
   OPENBLAS_NUM_THREADS: 1
 
-permissions:
-  actions: write
-
 jobs:
   test:
     runs-on: scilus-runners
     if: github.repository == 'scilus/scilpy'
 
     steps:
-      # If this runs and does not fails, its because the workflow was relaunched
-      # with no resuming and we need to delete the artifact since we
-      # re-executed the tests. Else, if nothing to do, it'll fail the job
-      # (silently) and the remaining workflow will continue
-      - name: Delete tests and coverage artifact
-        uses: geekyeggo/delete-artifact@v4
-        with:
-          name: test-coverage-${{ github.run_id }}
-          failOnError: false
-
       - name: Checkout repository at merge
         uses: actions/checkout@v4
 
@@ -74,6 +61,7 @@ jobs:
         id: test-coverage-results
         with:
           name: test-coverage-${{ github.run_id }}
+          retention-days: 1
           path: |
             .coverage
             .test_reports/
@@ -106,14 +94,8 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unittests
-          name: scilpy-unittests-${{ github.run_id }}
+          name: scilpy-unittests-${{ github.run_id }}-${{ github.run_attempt }}
           verbose: true
           fail_ci_if_error: true
           plugin: pycoverage
 
-      - name: Delete tests and coverage artifact
-        uses: geekyeggo/delete-artifact@v4
-        if: success()
-        with:
-          name: test-coverage-${{ github.run_id }}
-          failOnError: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,18 @@ jobs:
   test:
     runs-on: scilus-runners
     if: github.repository == 'scilus/scilpy'
+
     steps:
+      # If this runs and does not fails, its because the workflow was relaunched
+      # with no resuming and we need to delete the artifact since we 
+      # re-executed the tests. Else, it'll fail the job (silently) and the 
+      # remaining workflow will continue
+      - name: Delete tests and coverage artifact
+        uses: geekyeggo/delete-artifact@v4
+        with:
+          name: test-coverage-${{ github.run_id }}
+          failOnError: false
+
       - name: Checkout repository for merge
         uses: actions/checkout@v4
 
@@ -55,6 +66,29 @@ jobs:
           export C_INCLUDE_PATH=$pythonLocation/include/python${{ steps.python-selector.outputs.python-version }}:$C_INCLUDE_PATH
           pytest --cov-report term-missing:skip-covered
 
+      - name: Save test results and coverage
+        uses: actions/upload-artifact@v4
+        id: test-coverage-results
+        with:
+          name: test-coverage-${{ github.run_id }}
+          path: |
+            .coverage
+            .test_data/
+
+  coverage:
+    runs-on: scilus-runners
+    if: github.repository == 'scilus/scilpy'
+    needs: test
+
+    steps:
+      - name: Checkout repository for merge
+        uses: actions/checkout@v4
+
+      - name: Download test results and coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: test-coverage-${{ github.run_id }}
+
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4
         with:
@@ -65,9 +99,9 @@ jobs:
           fail_ci_if_error: true
           plugin: pycoverage
 
-      - name: Upload test reports and coverage to artifacts
-        uses: actions/upload-artifact@v4.3.1
+      - name: Delete tests and coverage artifact
+        uses: geekyeggo/delete-artifact@v4
+        if: success()
         with:
-          name: test-reports
-          path: |
-            .test_reports/*
+          name: test-coverage-${{ github.run_id }}
+          failOnError: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Set up Python for Scilpy
         uses: actions/setup-python@v5.0.0
         with:
-          python-version: 3.10
+          python-version: '3.10'
           cache: 'pip'
 
       - name: Install pycoverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,11 +92,11 @@ jobs:
       - name: Show the content of the workspace where we upload
         run: |
           echo "what is here : $(pwd)"
-          ls .
+          ls -lha .
           echo "what is in GITHUB_WORKSPACE : $GITHUB_WORKSPACE"
-          ls $GITHUB_WORKSPACE
+          ls -lha $GITHUB_WORKSPACE
           echo "what is in github.workspace : ${{ github.workspace }}"
-          ls ${{ github.workspace }}
+          ls -lha ${{ github.workspace }}
           exit 1
 
       - name: Upload coverage reports to Codecov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,16 +88,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: test-coverage-${{ github.run_id }}
-
-      - name: Show the content of the workspace where we upload
-        run: |
-          echo "what is here : $(pwd)"
-          ls -lha .
-          echo "what is in GITHUB_WORKSPACE : $GITHUB_WORKSPACE"
-          ls -lha $GITHUB_WORKSPACE
-          echo "what is in github.workspace : ${{ github.workspace }}"
-          ls -lha ${{ github.workspace }}
-          exit 1
+          path: ${{ github.workspace }}/scilpy
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4


### PR DESCRIPTION
# Quick description

Codecov is not super stable right now. When the coverage upload fails, we need to re-run the whole test suite (long). This PR splits the workflow in twain, so only the second job fails when codecov push fails. Then, to retry the upload, re-run the workflow, specifying to run ONLY the failed jobs. Voilà ?

## Type of change

Check the relevant options.

- [x] New feature (non-breaking change which adds functionality)

# Checklist

- [x] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [x] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
