### PR TITLE
FIX: screenshot functions no longer working

### DIFF
--- a/scilpy/viz/scene_utils.py
+++ b/scilpy/viz/scene_utils.py
@@ -793,7 +793,7 @@ def create_image_from_scene(scene, size, mode=None, cmap_name=None):
     # solved in newer versions of the package.
     image = Image.fromarray(_arr, mode=mode).transpose(Image.FLIP_TOP_BOTTOM)
 
-    return image.resize(size, Image.ANTIALIAS)
+    return image.resize(size, Image.LANCZOS)
 
 
 def create_mask_from_scene(scene, size):

--- a/scilpy/viz/scene_utils.py
+++ b/scilpy/viz/scene_utils.py
@@ -1144,6 +1144,8 @@ def compose_mosaic(
             labelmap_cmap_name=labelmap_cmap_name,
         )
 
-        annotate_scene(mosaic, slice_number, display_slice_number, display_lr)
+        if display_slice_number or display_lr:
+            annotate_scene(
+                mosaic, slice_number, display_slice_number, display_lr)
 
     return mosaic

--- a/scripts/tests/test_screenshot_volume.py
+++ b/scripts/tests/test_screenshot_volume.py
@@ -1,6 +1,26 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+import os
+import tempfile
+
+from scilpy.io.fetcher import get_testing_files_dict, fetch_data, get_home
+
+
+# If they already exist, this only takes 5 seconds (check md5sum)
+fetch_data(get_testing_files_dict(), keys=['bst.zip'])
+tmp_dir = tempfile.TemporaryDirectory()
+
+
+def test_screenshot(script_runner):
+    in_fa = os.path.join(get_home(), 'bst',
+                         'fa.nii.gz')
+
+    ret = script_runner.run(
+        "scil_screenshot_volume.py", in_fa, 'fa.png'
+    )
+    assert ret.success
+
 
 def test_help_option(script_runner):
 


### PR DESCRIPTION
# Quick description

`scil_screenshot_*` scripts were broken because of a fix in Pillow. See:
https://stackoverflow.com/questions/76616042/attributeerror-module-pil-image-has-no-attribute-antialias

Replaced `ANTIALIAS` with `LANCZOS`, now they work.

## Type of change

Check the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

![test_slice_40](https://github.com/scilus/scilpy/assets/10272382/959f32c5-51ef-43f7-8c39-6e31a74ddf9b)

...

# Checklist

- [X] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [X] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~My changes generate no new warnings~
- [ ] ~I moved all functions from the script file (except the argparser and main) to scilpy modules~
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
