### PR TITLE
Cleaning reconst scripts, part 3.

### DIFF
--- a/scilpy/io/mti.py
+++ b/scilpy/io/mti.py
@@ -14,6 +14,11 @@ from scilpy.reconst.mti import adjust_B1_map_intensities, smooth_B1_map, \
 
 
 def add_common_args_mti(p):
+    """
+    Defines arguments used in common for these scripts:
+    - scil_mti_maps_MT.py
+    - scil_mti_maps_ihMT.py
+    """
     p.add_argument('--extended', action='store_true',
                    help='If set, outputs the folder Complementary_maps.')
     p.add_argument('--filtering', action='store_true',
@@ -69,7 +74,34 @@ def add_common_args_mti(p):
 def verifications_and_loading_mti(args, parser, input_maps_lists,
                                   extended_dir, affine, contrast_names):
     """
-    Common verifications for both MT and ihMT scripts.
+    Common verifications and loading for both MT and ihMT scripts.
+
+    Parameters
+    ----------
+    args: Namespace
+    parser: Argparser
+    input_maps_lists: list[list]
+        A list of lists of inputs.
+    extended_dir: str
+        The folder for extended savings (with option args.extended).
+    affine: np.ndarray
+        A reference affine to save files.
+    contrast_names: list
+        A list of prefixes for each sub-list in input_maps_lists.
+
+    Returns
+    -------
+    single_echo: bool
+        True if the first list in input_maps_lists (i.e. the main echoes)
+        contains only one file.
+    flip_angles: list[float]
+        The flip angles, in radian
+    rep_times: list[float]
+        The rep times, in ms.
+    B1_map: np.ndarray
+        The loaded map, with adjusted intensities, smoothed, corrected.
+    contrast_maps: list[np.ndarray]
+        One contrast map per string in contrast_names.
     """
     # Verify that there is the same number of --positive, --negative,
     # --in_mtoff_pd and --in_mtoff_t1
@@ -111,10 +143,10 @@ def verifications_and_loading_mti(args, parser, input_maps_lists,
                 logging.warning('Repetition time found in {} does not seem to '
                                 'be given in seconds. MTsat and ihMTsat '
                                 'results might be affected.'.format(curr_json))
-            rep_times.append(acq_parameter[0] * 1000)  # convert ms.
-            flip_angles.append(acq_parameter[1] * np.pi / 180.)  # convert rad.
+            rep_times.append(acq_parameter[0] * 1000)  # convert to ms.
+            flip_angles.append(np.deg2rad(acq_parameter[1]))
 
-    # Fix issue from the presence of invalide value and division by zero
+    # Fix issue from the presence of invalid value and division by zero
     np.seterr(divide='ignore', invalid='ignore')
 
     # Load B1 image

--- a/scilpy/io/mti.py
+++ b/scilpy/io/mti.py
@@ -1,0 +1,163 @@
+# -*- coding: utf-8 -*-
+import logging
+import os
+import sys
+
+import nibabel as nib
+import numpy as np
+
+from scilpy.image.volume_math import concatenate
+from scilpy.io.image import load_img
+from scilpy.io.utils import get_acq_parameters
+from scilpy.reconst.mti import adjust_B1_map_intensities, smooth_B1_map, \
+    process_contrast_map
+
+
+def add_common_args_mti(p):
+    p.add_argument('--extended', action='store_true',
+                   help='If set, outputs the folder Complementary_maps.')
+    p.add_argument('--filtering', action='store_true',
+                   help='Gaussian filtering to remove Gibbs ringing. '
+                        'Not recommended.')
+
+    a = p.add_argument_group(
+        title='Acquisition parameters',
+        description='Acquisition parameters required for MTsat and ihMTsat '
+                    'calculation. \nThese are the excitation flip angles '
+                    '(a_PD, a_T1), in DEGREES, and \nrepetition times (TR_PD, '
+                    'TR_T1) of the PD and T1 images, in SECONDS. \nCan be '
+                    'given through json files (--in_jsons) or directly '
+                    '(--in_acq_parameters).')
+    a1 = a.add_mutually_exclusive_group(required='--in_mtoff_t1' in sys.argv)
+    a1.add_argument('--in_jsons', nargs=2,
+                    metavar=('PD_json', 'T1_json'),
+                    help='Path to MToff PD json file and MToff T1 json file, '
+                         'in that order. \nThe acquisition parameters will be '
+                         'extracted from these files. \nMust come from a '
+                         'Philips acquisition, otherwise, use '
+                         'in_acq_parameters.')
+    a1.add_argument('--in_acq_parameters', nargs=4, type=float,
+                    metavar=('PD flip angle', 'T1 flip angle',
+                             'PD repetition time', 'T1 repetition time'),
+                    help='Acquisition parameters in that order: flip angle of '
+                         'mtoff_PD, \nflip angle of mtoff_T1, repetition time '
+                         'of mtoff_PD, \nrepetition time of mtoff_T1')
+
+    b = p.add_argument_group(title='B1 correction')
+    b.add_argument('--in_B1_map',
+                   help='Path to B1 coregister map to MT contrasts.')
+    b.add_argument('--B1_correction_method',
+                   choices=['empiric', 'model_based'], default='empiric',
+                   help='Choice of B1 correction method. Choose between '
+                        'empiric and model-based. \nNote that the model-based '
+                        'method requires a B1 fitvalues file. \nBoth method '
+                        'will only correct the saturation measures. '
+                        '[%(default)s]')
+    b.add_argument('--B1_fitvalues', nargs='+',
+                   help='Path to B1 fitvalues files obtained externally. '
+                        'Should be one .mat \nfile per input MT-on image, '
+                        'given in this specific order: \npositive frequency '
+                        'saturation, negative frequency saturation.')
+    b.add_argument('--B1_nominal', default=100, type=float,
+                   help='Nominal value for the B1 map. For Philips, should be '
+                        '100. [%(default)s]')
+    b.add_argument('--B1_smooth_dims', default=5, type=int,
+                   help='Dimension of the squared window used for B1 '
+                        'smoothing, in number of voxels. [%(default)s]')
+
+
+def verifications_and_loading_mti(args, parser, input_maps_lists,
+                                  extended_dir, affine, contrast_names):
+    """
+    Common verifications for both MT and ihMT scripts.
+    """
+    # Verify that there is the same number of --positive, --negative,
+    # --in_mtoff_pd and --in_mtoff_t1
+    for curr_map_list in input_maps_lists[1:]:
+        if len(curr_map_list) != len(input_maps_lists[0]):
+            parser.error('Not the same number of echoes per contrast')
+
+    if len(input_maps_lists[0]) == 1:
+        single_echo = True
+    else:
+        single_echo = False
+
+    if args.in_B1_map and not args.in_mtoff_t1:
+        logging.warning('No B1 correction was applied because no MTsat or '
+                        'ihMTsat can be computed without the in_mtoff_t1.')
+
+    if args.B1_correction_method == 'model_based' and not args.B1_fitvalues:
+        parser.error('Fitvalues files must be given when choosing the '
+                     'model-based B1 correction method. Please use '
+                     '--B1_fitvalues.')
+
+    # Set TR and FlipAngle parameters. Required with --in_mtoff_t1, in which
+    # case one of --in_aqc_parameters or --in_jsons is set.
+    rep_times = None
+    flip_angles = None
+    if args.in_acq_parameters:
+        flip_angles = np.asarray(args.in_acq_parameters[:2]) * np.pi / 180.
+        rep_times = np.asarray(args.in_acq_parameters[2:]) * 1000
+        if rep_times[0] > 10000 or rep_times[1] > 10000:
+            logging.warning('Given repetition times do not seem to be given '
+                            'in seconds. MTsat results might be affected.')
+    elif args.in_jsons:
+        rep_times = []
+        flip_angles = []
+        for curr_json in args.in_jsons:
+            acq_parameter = get_acq_parameters(curr_json,
+                                               ['RepetitionTime', 'FlipAngle'])
+            if acq_parameter[0] > 10:
+                logging.warning('Repetition time found in {} does not seem to '
+                                'be given in seconds. MTsat and ihMTsat '
+                                'results might be affected.'.format(curr_json))
+            rep_times.append(acq_parameter[0] * 1000)  # convert ms.
+            flip_angles.append(acq_parameter[1] * np.pi / 180.)  # convert rad.
+
+    # Fix issue from the presence of invalide value and division by zero
+    np.seterr(divide='ignore', invalid='ignore')
+
+    # Load B1 image
+    B1_map = None
+    if args.in_B1_map and args.in_mtoff_t1:
+        B1_img = nib.load(args.in_B1_map)
+        B1_map = B1_img.get_fdata(dtype=np.float32)
+        B1_map = adjust_B1_map_intensities(B1_map, nominal=args.B1_nominal)
+        B1_map = smooth_B1_map(B1_map, wdims=args.B1_smooth_dims)
+        if args.B1_correction_method == 'model_based':
+            # Apply the B1 map to the flip angles for model-based correction
+            flip_angles[0] *= B1_map
+            flip_angles[1] *= B1_map
+        if args.extended:
+            nib.save(nib.Nifti1Image(B1_map, affine),
+                     os.path.join(extended_dir, "B1_map.nii.gz"))
+
+    # Define contrasts maps names
+    if args.filtering:
+        contrast_names = [curr_name + '_filter'
+                          for curr_name in contrast_names]
+    if single_echo:
+        contrast_names = [curr_name + '_single_echo'
+                          for curr_name in contrast_names]
+    if args.out_prefix:
+        contrast_names = [args.out_prefix + '_' + curr_name
+                          for curr_name in contrast_names]
+
+    # Compute contrasts maps
+    contrast_maps = []
+    for idx, curr_map in enumerate(input_maps_lists):
+        input_images = []
+        for image in curr_map:
+            img, _ = load_img(image)
+            input_images.append(img)
+        merged_curr_map = concatenate(input_images, input_images[0])
+        contrast_maps.append(process_contrast_map(merged_curr_map,
+                                                  filtering=args.filtering,
+                                                  single_echo=single_echo))
+        if args.extended:
+            nib.save(nib.Nifti1Image(contrast_maps[idx].astype(np.float32),
+                                     affine),
+                     os.path.join(extended_dir,
+                                  contrast_names[idx] + '.nii.gz'))
+
+    return single_echo, flip_angles, rep_times, B1_map, contrast_maps

--- a/scripts/scil_mti_maps_MT.py
+++ b/scripts/scil_mti_maps_MT.py
@@ -84,19 +84,15 @@ import sys
 import nibabel as nib
 import numpy as np
 
-from scilpy.io.utils import (get_acq_parameters, add_overwrite_arg,
+from scilpy.io.mti import add_common_args_mti, verifications_and_loading_mti
+from scilpy.io.utils import (add_overwrite_arg,
                              assert_inputs_exist, add_verbose_arg,
                              assert_output_dirs_exist_and_empty)
-from scilpy.io.image import load_img
-from scilpy.image.volume_math import concatenate
-from scilpy.reconst.mti import (adjust_B1_map_intensities,
-                                apply_B1_corr_empiric,
+from scilpy.reconst.mti import (apply_B1_corr_empiric,
                                 apply_B1_corr_model_based,
                                 compute_ratio_map,
                                 compute_saturation_map,
-                                process_contrast_map,
-                                threshold_map,
-                                smooth_B1_map)
+                                threshold_map)
 
 EPILOG = """
 Helms G, Dathe H, Kallenberg K, Dechent P. High-resolution maps of
@@ -115,11 +111,6 @@ def _build_arg_parser():
                    help='Prefix to be used for each output image.')
     p.add_argument('--mask',
                    help='Path to the binary brain mask.')
-    p.add_argument('--extended', action='store_true',
-                   help='If set, outputs the folder Complementary_maps.')
-    p.add_argument('--filtering', action='store_true',
-                   help='Gaussian filtering to remove Gibbs ringing. '
-                        'Not recommended.')
 
     g = p.add_argument_group(title='Contrast maps', description='Path to '
                              'echoes corresponding to contrast images. All '
@@ -147,54 +138,7 @@ def _build_arg_parser():
                         'calculation of MTsat. \nAcquisition '
                         'parameters should also be set with this image.')
 
-    a = p.add_argument_group(title='Acquisition parameters',
-                             description='Acquisition parameters required '
-                                         'for MTsat and ihMTsat '
-                                         'calculation. \nThese are the '
-                                         'excitation flip angles '
-                                         '(a_PD, a_T1), in DEGREES, and \n'
-                                         'repetition times (TR_PD, TR_T1) of '
-                                         'the PD and T1 images, in SECONDS. '
-                                         '\nCan be given through json files '
-                                         '(--in_jsons) or directly '
-                                         '(--in_acq_parameters).')
-    a1 = a.add_mutually_exclusive_group(required='--in_mtoff_t1' in sys.argv)
-    a1.add_argument('--in_jsons', nargs=2,
-                    metavar=('PD_json', 'T1_json'),
-                    help='Path to MToff PD json file and MToff T1 json file, '
-                         'in that order. \nThe acquisition parameters will be '
-                         'extracted from these files. \nMust come from a '
-                         'Philips acquisition, otherwise, use '
-                         'in_acq_parameters.')
-    a1.add_argument('--in_acq_parameters', nargs=4, type=float,
-                    metavar=('PD flip angle', 'T1 flip angle',
-                             'PD repetition time', 'T1 repetition time'),
-                    help='Acquisition parameters in that order: flip angle of '
-                         'mtoff_PD, \nflip angle of mtoff_T1, repetition time '
-                         'of mtoff_PD, \nrepetition time of mtoff_T1')
-
-    b = p.add_argument_group(title='B1 correction')
-    b.add_argument('--in_B1_map',
-                   help='Path to B1 coregister map to MT contrasts.')
-    b.add_argument('--B1_correction_method',
-                   choices=['empiric', 'model_based'], default='empiric',
-                   help='Choice of B1 correction method. Choose between '
-                        'empiric and model-based. \nNote that the model-based '
-                        'method requires a B1 fitvalues file. \nBoth method '
-                        'will only correct the saturation measures. '
-                        '[%(default)s]')
-    b.add_argument('--B1_fitvalues', nargs='+',
-                   help='Path to B1 fitvalues files obtained externally. '
-                        'Should be one .mat \nfile per input MT-on image, '
-                        'given in this specific order: \npositive frequency '
-                        'saturation, negative frequency saturation.')
-    b.add_argument('--B1_nominal', default=100, type=float,
-                   help='Nominal value for the B1 map. For Philips, should be '
-                        '100. [%(default)s]')
-    b.add_argument('--B1_smooth_dims', default=5, type=int,
-                   help='Dimension of the squared window used for B1 '
-                        'smoothing, in number of voxels. [%(default)s]')
-
+    add_common_args_mti(p)
     add_verbose_arg(p)
     add_overwrite_arg(p)
 
@@ -207,6 +151,7 @@ def main():
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
     output_dir = os.path.join(args.out_dir, 'MT_native_maps')
+    extended_dir = None
     if args.extended:
         extended_dir = os.path.join(args.out_dir, 'Complementary_maps')
         assert_output_dirs_exist_and_empty(parser, args, extended_dir,
@@ -215,110 +160,34 @@ def main():
         assert_output_dirs_exist_and_empty(parser, args, output_dir,
                                            create_dir=True)
 
-    # Merge all echos path into a list
-    input_maps = []
+    # Combine all echos path into a list of lists
+    input_maps_lists = []
     contrast_names = []
     if args.in_positive:
-        input_maps.append(args.in_positive)
+        input_maps_lists.append(args.in_positive)
         contrast_names.append('positive')
     if args.in_negative:
-        input_maps.append(args.in_negative)
+        input_maps_lists.append(args.in_negative)
         contrast_names.append('negative')
-    input_maps.append(args.in_mtoff_pd)
+    input_maps_lists.append(args.in_mtoff_pd)
     contrast_names.append('mtoff_PD')
     if args.in_mtoff_t1:
-        input_maps.append(args.in_mtoff_t1)
+        input_maps_lists.append(args.in_mtoff_t1)
         contrast_names.append('mtoff_T1')
+    contrast_names_og = contrast_names
 
     # check data
-    assert_inputs_exist(parser, args.in_mtoff_pd)  # Problem with maps_flat...
-    # cannot verify the not required input. Somehow it breaks the input_maps...
-    # even if it is not linked at all. WTF.
-    for curr_map in input_maps[1:]:
-        if len(curr_map) != len(input_maps[0]):
-            parser.error('Not the same number of echoes per contrast')
-    if len(input_maps[0]) == 1:
-        single_echo = True
-    else:
-        single_echo = False
-
-    if args.in_B1_map and not args.in_mtoff_t1:
-        logging.warning('No B1 correction was applied because no MTsat or '
-                        'ihMTsat can be computed without the in_mtoff_t1.')
-
-    if args.B1_correction_method == 'model_based' and not args.B1_fitvalues:
-        parser.error('Fitvalues files must be given when choosing the '
-                     'model-based B1 correction method. Please use '
-                     '--B1_fitvalues.')
-
-    # Set TR and FlipAngle parameters
-    if args.in_acq_parameters:
-        flip_angles = np.asarray(args.in_acq_parameters[:2]) * np.pi / 180.
-        rep_times = np.asarray(args.in_acq_parameters[2:]) * 1000
-        if rep_times[0] > 10000 or rep_times[1] > 10000:
-            logging.warning('Given repetition times do not seem to be given '
-                            'in seconds. MTsat results might be affected.')
-    elif args.in_jsons:
-        rep_times = []
-        flip_angles = []
-        for curr_json in args.in_jsons:
-            acq_parameter = get_acq_parameters(curr_json,
-                                               ['RepetitionTime', 'FlipAngle'])
-            if acq_parameter[0] > 10:
-                logging.warning('Repetition time found in {} does not seem to '
-                                'be given in seconds. MTsat results might be '
-                                'affected.'.format(curr_json))
-            rep_times.append(acq_parameter[0] * 1000)  # convert ms.
-            flip_angles.append(acq_parameter[1] * np.pi / 180.)  # convert rad.
-
-    # Fix issue from the presence of invalide value and division by zero
-    np.seterr(divide='ignore', invalid='ignore')
+    input_maps_flat_list = [m for _list in input_maps_lists for m in _list]
+    assert_inputs_exist(parser, args.in_mtoff_pd + input_maps_flat_list,
+                        optional=args.in_mtoff_t1 or [] + [args.mask])
 
     # Define reference image for saving maps
-    affine = nib.load(input_maps[0][0]).affine
+    affine = nib.load(input_maps_lists[0][0]).affine
 
-    # Load B1 image
-    if args.in_B1_map and args.in_mtoff_t1:
-        B1_img = nib.load(args.in_B1_map)
-        B1_map = B1_img.get_fdata(dtype=np.float32)
-        B1_map = adjust_B1_map_intensities(B1_map, nominal=args.B1_nominal)
-        B1_map = smooth_B1_map(B1_map, wdims=args.B1_smooth_dims)
-        if args.B1_correction_method == 'model_based':
-            # Apply the B1 map to the flip angles for model-based correction
-            flip_angles[0] *= B1_map
-            flip_angles[1] *= B1_map
-        if args.extended:
-            nib.save(nib.Nifti1Image(B1_map, affine),
-                     os.path.join(extended_dir, "B1_map.nii.gz"))
-
-    # Define contrasts maps names
-    contrast_names_og = contrast_names
-    if args.filtering:
-        contrast_names = [curr_name + '_filter'
-                          for curr_name in contrast_names]
-    if single_echo:
-        contrast_names = [curr_name + '_single_echo'
-                          for curr_name in contrast_names]
-    if args.out_prefix:
-        contrast_names = [args.out_prefix + '_' + curr_name
-                          for curr_name in contrast_names]
-
-    # Compute contrasts maps
-    contrast_maps = []
-    for idx, curr_map in enumerate(input_maps):
-        input_images = []
-        for image in curr_map:
-            img, _ = load_img(image)
-            input_images.append(img)
-        merged_curr_map = concatenate(input_images, input_images[0])
-        contrast_maps.append(process_contrast_map(merged_curr_map,
-                                                  filtering=args.filtering,
-                                                  single_echo=single_echo))
-        if args.extended:
-            nib.save(nib.Nifti1Image(contrast_maps[idx].astype(np.float32),
-                                     affine),
-                     os.path.join(extended_dir,
-                                  contrast_names[idx] + '.nii.gz'))
+    # Other checks, loading, saving contrast_maps.
+    single_echo, flip_angles, rep_times, B1_map, contrast_maps = \
+        verifications_and_loading_mti(args, parser, input_maps_lists,
+                                      extended_dir, affine, contrast_names)
 
     # Compute MTR
     if 'positive' in contrast_names_og and 'negative' in contrast_names_og:
@@ -327,8 +196,8 @@ def main():
     else:
         MTR = compute_ratio_map(contrast_maps[0], contrast_maps[1])
 
-    img_name = ['MTR']
-    img_data = [MTR]
+    img_names = ['MTR']
+    img_data_list = [MTR]
 
     # Compute MTsat
     if args.in_mtoff_t1:
@@ -374,30 +243,29 @@ def main():
             # MTR = apply_B1_correction_empiric(MTR, B1_map)
             MTsat = apply_B1_corr_empiric(MTsat, B1_map)
 
-        img_name.append('MTsat')
-        img_data.append(MTsat)
+        img_names.append('MTsat')
+        img_data_list.append(MTsat)
 
     # Apply thresholds on maps
-    for i, map in enumerate(img_data):
-        img_data[i] = threshold_map(map, args.mask, 0, 100)
+    for i, map in enumerate(img_data_list):
+        img_data_list[i] = threshold_map(map, args.mask, 0, 100)
 
     # Save ihMT and MT images
     if args.filtering:
-        img_name = [curr_name + '_filter'
-                    for curr_name in img_name]
+        img_names = [curr_name + '_filter'
+                     for curr_name in img_names]
     if single_echo:
-        img_name = [curr_name + '_single_echo'
-                    for curr_name in img_name]
+        img_names = [curr_name + '_single_echo'
+                     for curr_name in img_names]
     if args.in_B1_map:
-        img_name = [curr_name + '_B1_corrected'
-                    for curr_name in img_name]
+        img_names = [curr_name + '_B1_corrected'
+                     for curr_name in img_names]
     if args.out_prefix:
-        img_name = [args.out_prefix + '_' + curr_name
-                    for curr_name in img_name]
+        img_names = [args.out_prefix + '_' + curr_name
+                     for curr_name in img_names]
 
-    for img_to_save, name in zip(img_data, img_name):
-        nib.save(nib.Nifti1Image(img_to_save.astype(np.float32),
-                                 affine),
+    for img_to_save, name in zip(img_data_list, img_names):
+        nib.save(nib.Nifti1Image(img_to_save.astype(np.float32), affine),
                  os.path.join(output_dir, name + '.nii.gz'))
 
 

--- a/scripts/scil_mti_maps_ihMT.py
+++ b/scripts/scil_mti_maps_ihMT.py
@@ -86,24 +86,19 @@ the echo.
 import argparse
 import logging
 import os
-import sys
 
 import nibabel as nib
 import numpy as np
 
-from scilpy.io.utils import (get_acq_parameters, add_overwrite_arg,
+from scilpy.io.mti import add_common_args_mti, verifications_and_loading_mti
+from scilpy.io.utils import (add_overwrite_arg,
                              assert_inputs_exist, add_verbose_arg,
                              assert_output_dirs_exist_and_empty)
-from scilpy.io.image import load_img
-from scilpy.image.volume_math import concatenate
-from scilpy.reconst.mti import (adjust_B1_map_intensities,
-                                apply_B1_corr_empiric,
+from scilpy.reconst.mti import (apply_B1_corr_empiric,
                                 apply_B1_corr_model_based,
                                 compute_ratio_map,
                                 compute_saturation_map,
-                                process_contrast_map,
-                                threshold_map,
-                                smooth_B1_map)
+                                threshold_map)
 
 EPILOG = """
 Varma G, Girard OM, Prevost VH, Grant AK, Duhamel G, Alsop DC.
@@ -127,16 +122,10 @@ def _build_arg_parser():
                                 formatter_class=argparse.RawTextHelpFormatter)
     p.add_argument('out_dir',
                    help='Path to output folder.')
-
     p.add_argument('--out_prefix',
                    help='Prefix to be used for each output image.')
     p.add_argument('--mask',
                    help='Path to the binary brain mask.')
-    p.add_argument('--extended', action='store_true',
-                   help='If set, outputs the folder Complementary_maps.')
-    p.add_argument('--filtering', action='store_true',
-                   help='Gaussian filtering to remove Gibbs ringing. '
-                        'Not recommended.')
 
     g = p.add_argument_group(title='Contrast maps', description='Path to '
                              'echoes corresponding to contrast images. All '
@@ -168,54 +157,7 @@ def _build_arg_parser():
                         'calculation of MTsat and ihMTsat. \nAcquisition '
                         'parameters should also be set with this image.')
 
-    a = p.add_argument_group(title='Acquisition parameters',
-                             description='Acquisition parameters required '
-                                         'for MTsat and ihMTsat '
-                                         'calculation. \nThese are the '
-                                         'excitation flip angles '
-                                         '(a_PD, a_T1), in DEGREES, and \n'
-                                         'repetition times (TR_PD, TR_T1) of '
-                                         'the PD and T1 images, in SECONDS. '
-                                         '\nCan be given through json files '
-                                         '(--in_jsons) or directly '
-                                         '(--in_acq_parameters).')
-    a1 = a.add_mutually_exclusive_group(required='--in_mtoff_t1' in sys.argv)
-    a1.add_argument('--in_jsons', nargs=2,
-                    metavar=('PD_json', 'T1_json'),
-                    help='Path to MToff PD json file and MToff T1 json file, '
-                         'in that order. \nThe acquisition parameters will be '
-                         'extracted from these files. \nMust come from a '
-                         'Philips acquisition, otherwise, use '
-                         'in_acq_parameters.')
-    a1.add_argument('--in_acq_parameters', nargs=4, type=float,
-                    metavar=('PD flip angle', 'T1 flip angle',
-                             'PD repetition time', 'T1 repetition time'),
-                    help='Acquisition parameters in that order: flip angle of '
-                         'mtoff_PD, \nflip angle of mtoff_T1, repetition time '
-                         'of mtoff_PD, \nrepetition time of mtoff_T1')
-
-    b = p.add_argument_group(title='B1 correction')
-    b.add_argument('--in_B1_map',
-                   help='Path to B1 coregister map to MT contrasts.')
-    b.add_argument('--B1_correction_method',
-                   choices=['empiric', 'model_based'], default='empiric',
-                   help='Choice of B1 correction method. Choose between '
-                        'empiric and model-based. \nNote that the model-based '
-                        'method requires a B1 fitvalues file. \nBoth method '
-                        'will only correct the saturation measures. '
-                        '[%(default)s]')
-    b.add_argument('--B1_fitvalues', nargs=3,
-                   help='Path to B1 fitvalues files obtained externally. '
-                        'Should be three .mat \nfiles given in this specific '
-                        'order: positive frequency saturation, \nnegative '
-                        'frequency saturation, dual frequency saturation.')
-    b.add_argument('--B1_nominal', default=100, type=float,
-                   help='Nominal value for the B1 map. For Philips, should be '
-                        '100. [%(default)s]')
-    b.add_argument('--B1_smooth_dims', default=5, type=int,
-                   help='Dimension of the squared window used for B1 '
-                        'smoothing, in number of voxels. [%(default)s]')
-
+    add_common_args_mti(p)
     add_verbose_arg(p)
     add_overwrite_arg(p)
 
@@ -228,6 +170,7 @@ def main():
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
     output_dir = os.path.join(args.out_dir, 'ihMT_native_maps')
+    extended_dir = None
     if args.extended:
         extended_dir = os.path.join(args.out_dir, 'Complementary_maps')
         assert_output_dirs_exist_and_empty(parser, args, extended_dir,
@@ -241,106 +184,27 @@ def main():
     else:
         out_prefix = ""
 
-    # Merge all echos path into a list
-    input_maps = [args.in_altnp, args.in_altpn, args.in_negative,
-                  args.in_positive, args.in_mtoff_pd]
-    maps_flat = (args.in_altnp + args.in_altpn + args.in_negative +
-                 args.in_positive + args.in_mtoff_pd)
+    # Combine all echos path into a list of lists
+    input_maps_lists = [args.in_altnp, args.in_altpn, args.in_negative,
+                        args.in_positive, args.in_mtoff_pd]
     if args.in_mtoff_t1:
-        input_maps.append(args.in_mtoff_t1)
+        input_maps_lists.append(args.in_mtoff_t1)
 
-    # check echoes number and jsons
-    assert_inputs_exist(parser, maps_flat, optional=args.in_mtoff_t1)
-    for curr_map in input_maps[1:]:
-        if len(curr_map) != len(input_maps[0]):
-            parser.error('Not the same number of echoes per contrast')
-    if len(input_maps[0]) == 1:
-        single_echo = True
-    else:
-        single_echo = False
+    input_maps_flat_list = [m for _list in input_maps_lists for m in _list]
+    assert_inputs_exist(parser, input_maps_flat_list,
+                        optional=args.in_mtoff_t1 or [] + [args.mask])
 
-    if args.in_B1_map and not args.in_mtoff_t1:
-        logging.warning('No B1 correction was applied because no MTsat or '
-                        'ihMTsat can be computed without the in_mtoff_t1.')
-
-    if args.B1_correction_method == 'model_based' and not args.B1_fitvalues:
-        parser.error('Fitvalues files must be given when choosing the '
-                     'model-based B1 correction method. Please use '
-                     '--B1_fitvalues.')
-
-    # Set TR and FlipAngle parameters
-    if args.in_acq_parameters:
-        flip_angles = np.asarray(args.in_acq_parameters[:2]) * np.pi / 180.
-        rep_times = np.asarray(args.in_acq_parameters[2:]) * 1000
-        if rep_times[0] > 10000 or rep_times[1] > 10000:
-            logging.warning('Given repetition times do not seem to be given '
-                            'in seconds. MTsat results might be affected.')
-    elif args.in_jsons:
-        rep_times = []
-        flip_angles = []
-        for curr_json in args.in_jsons:
-            acq_parameter = get_acq_parameters(curr_json,
-                                               ['RepetitionTime', 'FlipAngle'])
-            if acq_parameter[0] > 10:
-                logging.warning('Repetition time found in {} does not seem to '
-                                'be given in seconds. MTsat and ihMTsat '
-                                'results might be affected.'.format(curr_json))
-            rep_times.append(acq_parameter[0] * 1000)  # convert ms.
-            flip_angles.append(acq_parameter[1] * np.pi / 180.)  # convert rad.
-
-    # Fix issue from the presence of invalide value and division by zero
-    np.seterr(divide='ignore', invalid='ignore')
-
-    # Define affine
-    affine = nib.load(input_maps[4][0]).affine
-
-    # Load B1 image
-    if args.in_B1_map and args.in_mtoff_t1:
-        B1_img = nib.load(args.in_B1_map)
-        B1_map = B1_img.get_fdata(dtype=np.float32)
-        B1_map = adjust_B1_map_intensities(B1_map, nominal=args.B1_nominal)
-        B1_map = smooth_B1_map(B1_map, wdims=args.B1_smooth_dims)
-        if args.B1_correction_method == 'model_based':
-            # Apply shift to the B1 map for better correction
-            # shift = 0.05
-            # expt = 1.3
-            # B1_map = (B1_map + shift) ** expt
-            # Apply the B1 map to the flip angles for model-based correction
-            flip_angles[0] *= B1_map
-            flip_angles[1] *= B1_map
-        if args.extended:
-            nib.save(nib.Nifti1Image(B1_map, affine),
-                     os.path.join(extended_dir, out_prefix + "B1_map.nii.gz"))
+    # Define affine. Uses the first in_mtoff_pd (required).
+    affine = nib.load(input_maps_lists[4][0]).affine
 
     # Define contrasts maps names
     contrast_names = ['altnp', 'altpn', 'negative', 'positive', 'mtoff_PD',
                       'mtoff_T1']
-    if args.filtering:
-        contrast_names = [curr_name + '_filter'
-                          for curr_name in contrast_names]
-    if single_echo:
-        contrast_names = [curr_name + '_single_echo'
-                          for curr_name in contrast_names]
-    if args.out_prefix:
-        contrast_names = [out_prefix + curr_name
-                          for curr_name in contrast_names]
 
-# Compute contrasts maps
-    contrast_maps = []
-    for idx, curr_map in enumerate(input_maps):
-        input_images = []
-        for image in curr_map:
-            img, _ = load_img(image)
-            input_images.append(img)
-        merged_curr_map = concatenate(input_images, input_images[0])
-        contrast_maps.append(process_contrast_map(merged_curr_map,
-                                                  filtering=args.filtering,
-                                                  single_echo=single_echo))
-        if args.extended:
-            nib.save(nib.Nifti1Image(contrast_maps[idx].astype(np.float32),
-                                     affine),
-                     os.path.join(extended_dir,
-                                  contrast_names[idx] + '.nii.gz'))
+    # Other checks, loading, saving contrast_maps.
+    single_echo, flip_angles, rep_times, B1_map, contrast_maps = \
+        verifications_and_loading_mti(args, parser, input_maps_lists,
+                                      extended_dir, affine, contrast_names)
 
     # Compute ratio maps
     MTR, ihMTR = compute_ratio_map((contrast_maps[2] + contrast_maps[3]) / 2,
@@ -394,8 +258,6 @@ def main():
 
         # Apply empiric B1 correction
         if args.in_B1_map and args.B1_correction_method == 'empiric':
-            # MTR = apply_B1_correction_empiric(MTR, B1_map)
-            # ihMTR = apply_B1_correction_empiric(ihMTR, B1_map)
             MTsat = apply_B1_corr_empiric(MTsat, B1_map)
             ihMTsat = apply_B1_corr_empiric(ihMTsat, B1_map)
 
@@ -425,8 +287,7 @@ def main():
                     for curr_name in img_name]
 
     for img_to_save, name in zip(img_data, img_name):
-        nib.save(nib.Nifti1Image(img_to_save.astype(np.float32),
-                                 affine),
+        nib.save(nib.Nifti1Image(img_to_save.astype(np.float32), affine),
                  os.path.join(output_dir, name + '.nii.gz'))
 
 

--- a/scripts/tests/test_mti_maps_MT.py
+++ b/scripts/tests/test_mti_maps_MT.py
@@ -11,6 +11,51 @@ fetch_data(get_testing_files_dict(), keys=['MT.zip'])
 tmp_dir = tempfile.TemporaryDirectory()
 
 
+# Preparing once the filenames.
+in_mask = os.path.join(get_home(), 'MT', 'mask.nii.gz')
+
+in_mtoff_json = os.path.join(get_home(),
+                             'MT', 'sub-001_echo-1_acq-mtoff_mtsat.json')
+in_t1w_json = os.path.join(get_home(),
+                           'MT', 'sub-001_echo-1_acq-t1w_mtsat.json')
+
+in_e1_mtoff = os.path.join(get_home(),
+                           'MT', 'sub-001_echo-1_acq-mtoff_mtsat.nii.gz')
+in_e2_mtoff = os.path.join(get_home(),
+                           'MT', 'sub-001_echo-2_acq-mtoff_mtsat.nii.gz')
+in_e3_mtoff = os.path.join(get_home(),
+                           'MT', 'sub-001_echo-3_acq-mtoff_mtsat.nii.gz')
+in_e4_mtoff = os.path.join(get_home(),
+                           'MT', 'sub-001_echo-4_acq-mtoff_mtsat.nii.gz')
+in_e5_mtoff = os.path.join(get_home(),
+                           'MT', 'sub-001_echo-5_acq-mtoff_mtsat.nii.gz')
+
+in_e1_mton = os.path.join(get_home(),
+                          'MT', 'sub-001_echo-1_acq-mton_mtsat.nii.gz')
+in_e2_mton = os.path.join(get_home(),
+                          'MT', 'sub-001_echo-2_acq-mton_mtsat.nii.gz')
+in_e3_mton = os.path.join(get_home(),
+                          'MT', 'sub-001_echo-3_acq-mton_mtsat.nii.gz')
+in_e4_mton = os.path.join(get_home(),
+                          'MT', 'sub-001_echo-4_acq-mton_mtsat.nii.gz')
+in_e5_mton = os.path.join(get_home(),
+                          'MT', 'sub-001_echo-5_acq-mton_mtsat.nii.gz')
+
+in_e1_t1w = os.path.join(get_home(),
+                         'MT', 'sub-001_echo-1_acq-t1w_mtsat.nii.gz')
+in_e2_t1w = os.path.join(get_home(),
+                         'MT', 'sub-001_echo-2_acq-t1w_mtsat.nii.gz')
+in_e3_t1w = os.path.join(get_home(),
+                         'MT', 'sub-001_echo-3_acq-t1w_mtsat.nii.gz')
+in_e4_t1w = os.path.join(get_home(),
+                         'MT', 'sub-001_echo-4_acq-t1w_mtsat.nii.gz')
+in_e5_t1w = os.path.join(get_home(),
+                         'MT', 'sub-001_echo-5_acq-t1w_mtsat.nii.gz')
+
+in_b1_map = os.path.join(get_home(), 'MT', 'sub-001_run-01_B1map.nii.gz')
+in_b1_json = os.path.join(get_home(), 'MT', 'sub-001_run-01_B1map.json')
+
+
 def test_help_option(script_runner):
     ret = script_runner.run('scil_mti_maps_MT.py', '--help')
     assert ret.success
@@ -18,46 +63,6 @@ def test_help_option(script_runner):
 
 def test_execution_MT_no_option(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
-
-    in_mask = os.path.join(get_home(), 'MT', 'mask.nii.gz')
-
-    in_mtoff_json = os.path.join(get_home(),
-                                 'MT', 'sub-001_echo-1_acq-mtoff_mtsat.json')
-    in_t1w_json = os.path.join(get_home(),
-                               'MT', 'sub-001_echo-1_acq-t1w_mtsat.json')
-
-    in_e1_mtoff = os.path.join(get_home(),
-                               'MT', 'sub-001_echo-1_acq-mtoff_mtsat.nii.gz')
-    in_e2_mtoff = os.path.join(get_home(),
-                               'MT', 'sub-001_echo-2_acq-mtoff_mtsat.nii.gz')
-    in_e3_mtoff = os.path.join(get_home(),
-                               'MT', 'sub-001_echo-3_acq-mtoff_mtsat.nii.gz')
-    in_e4_mtoff = os.path.join(get_home(),
-                               'MT', 'sub-001_echo-4_acq-mtoff_mtsat.nii.gz')
-    in_e5_mtoff = os.path.join(get_home(),
-                               'MT', 'sub-001_echo-5_acq-mtoff_mtsat.nii.gz')
-
-    in_e1_mton = os.path.join(get_home(),
-                              'MT', 'sub-001_echo-1_acq-mton_mtsat.nii.gz')
-    in_e2_mton = os.path.join(get_home(),
-                              'MT', 'sub-001_echo-2_acq-mton_mtsat.nii.gz')
-    in_e3_mton = os.path.join(get_home(),
-                              'MT', 'sub-001_echo-3_acq-mton_mtsat.nii.gz')
-    in_e4_mton = os.path.join(get_home(),
-                              'MT', 'sub-001_echo-4_acq-mton_mtsat.nii.gz')
-    in_e5_mton = os.path.join(get_home(),
-                              'MT', 'sub-001_echo-5_acq-mton_mtsat.nii.gz')
-
-    in_e1_t1w = os.path.join(get_home(),
-                             'MT', 'sub-001_echo-1_acq-t1w_mtsat.nii.gz')
-    in_e2_t1w = os.path.join(get_home(),
-                             'MT', 'sub-001_echo-2_acq-t1w_mtsat.nii.gz')
-    in_e3_t1w = os.path.join(get_home(),
-                             'MT', 'sub-001_echo-3_acq-t1w_mtsat.nii.gz')
-    in_e4_t1w = os.path.join(get_home(),
-                             'MT', 'sub-001_echo-4_acq-t1w_mtsat.nii.gz')
-    in_e5_t1w = os.path.join(get_home(),
-                             'MT', 'sub-001_echo-5_acq-t1w_mtsat.nii.gz')
 
     # no option
     ret = script_runner.run('scil_mti_maps_MT.py', tmp_dir.name,
@@ -75,46 +80,6 @@ def test_execution_MT_no_option(script_runner):
 
 def test_execution_MT_prefix(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
-
-    in_mask = os.path.join(get_home(), 'MT', 'mask.nii.gz')
-
-    in_mtoff_json = os.path.join(get_home(),
-                                 'MT', 'sub-001_echo-1_acq-mtoff_mtsat.json')
-    in_t1w_json = os.path.join(get_home(),
-                               'MT', 'sub-001_echo-1_acq-t1w_mtsat.json')
-
-    in_e1_mtoff = os.path.join(get_home(),
-                               'MT', 'sub-001_echo-1_acq-mtoff_mtsat.nii.gz')
-    in_e2_mtoff = os.path.join(get_home(),
-                               'MT', 'sub-001_echo-2_acq-mtoff_mtsat.nii.gz')
-    in_e3_mtoff = os.path.join(get_home(),
-                               'MT', 'sub-001_echo-3_acq-mtoff_mtsat.nii.gz')
-    in_e4_mtoff = os.path.join(get_home(),
-                               'MT', 'sub-001_echo-4_acq-mtoff_mtsat.nii.gz')
-    in_e5_mtoff = os.path.join(get_home(),
-                               'MT', 'sub-001_echo-5_acq-mtoff_mtsat.nii.gz')
-
-    in_e1_mton = os.path.join(get_home(),
-                              'MT', 'sub-001_echo-1_acq-mton_mtsat.nii.gz')
-    in_e2_mton = os.path.join(get_home(),
-                              'MT', 'sub-001_echo-2_acq-mton_mtsat.nii.gz')
-    in_e3_mton = os.path.join(get_home(),
-                              'MT', 'sub-001_echo-3_acq-mton_mtsat.nii.gz')
-    in_e4_mton = os.path.join(get_home(),
-                              'MT', 'sub-001_echo-4_acq-mton_mtsat.nii.gz')
-    in_e5_mton = os.path.join(get_home(),
-                              'MT', 'sub-001_echo-5_acq-mton_mtsat.nii.gz')
-
-    in_e1_t1w = os.path.join(get_home(),
-                             'MT', 'sub-001_echo-1_acq-t1w_mtsat.nii.gz')
-    in_e2_t1w = os.path.join(get_home(),
-                             'MT', 'sub-001_echo-2_acq-t1w_mtsat.nii.gz')
-    in_e3_t1w = os.path.join(get_home(),
-                             'MT', 'sub-001_echo-3_acq-t1w_mtsat.nii.gz')
-    in_e4_t1w = os.path.join(get_home(),
-                             'MT', 'sub-001_echo-4_acq-t1w_mtsat.nii.gz')
-    in_e5_t1w = os.path.join(get_home(),
-                             'MT', 'sub-001_echo-5_acq-t1w_mtsat.nii.gz')
 
     # --out_prefix
     ret = script_runner.run('scil_mti_maps_MT.py', tmp_dir.name,
@@ -134,46 +99,6 @@ def test_execution_MT_prefix(script_runner):
 def test_execution_MT_extended(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
 
-    in_mask = os.path.join(get_home(), 'MT', 'mask.nii.gz')
-
-    in_mtoff_json = os.path.join(get_home(),
-                                 'MT', 'sub-001_echo-1_acq-mtoff_mtsat.json')
-    in_t1w_json = os.path.join(get_home(),
-                               'MT', 'sub-001_echo-1_acq-t1w_mtsat.json')
-
-    in_e1_mtoff = os.path.join(get_home(),
-                               'MT', 'sub-001_echo-1_acq-mtoff_mtsat.nii.gz')
-    in_e2_mtoff = os.path.join(get_home(),
-                               'MT', 'sub-001_echo-2_acq-mtoff_mtsat.nii.gz')
-    in_e3_mtoff = os.path.join(get_home(),
-                               'MT', 'sub-001_echo-3_acq-mtoff_mtsat.nii.gz')
-    in_e4_mtoff = os.path.join(get_home(),
-                               'MT', 'sub-001_echo-4_acq-mtoff_mtsat.nii.gz')
-    in_e5_mtoff = os.path.join(get_home(),
-                               'MT', 'sub-001_echo-5_acq-mtoff_mtsat.nii.gz')
-
-    in_e1_mton = os.path.join(get_home(),
-                              'MT', 'sub-001_echo-1_acq-mton_mtsat.nii.gz')
-    in_e2_mton = os.path.join(get_home(),
-                              'MT', 'sub-001_echo-2_acq-mton_mtsat.nii.gz')
-    in_e3_mton = os.path.join(get_home(),
-                              'MT', 'sub-001_echo-3_acq-mton_mtsat.nii.gz')
-    in_e4_mton = os.path.join(get_home(),
-                              'MT', 'sub-001_echo-4_acq-mton_mtsat.nii.gz')
-    in_e5_mton = os.path.join(get_home(),
-                              'MT', 'sub-001_echo-5_acq-mton_mtsat.nii.gz')
-
-    in_e1_t1w = os.path.join(get_home(),
-                             'MT', 'sub-001_echo-1_acq-t1w_mtsat.nii.gz')
-    in_e2_t1w = os.path.join(get_home(),
-                             'MT', 'sub-001_echo-2_acq-t1w_mtsat.nii.gz')
-    in_e3_t1w = os.path.join(get_home(),
-                             'MT', 'sub-001_echo-3_acq-t1w_mtsat.nii.gz')
-    in_e4_t1w = os.path.join(get_home(),
-                             'MT', 'sub-001_echo-4_acq-t1w_mtsat.nii.gz')
-    in_e5_t1w = os.path.join(get_home(),
-                             'MT', 'sub-001_echo-5_acq-t1w_mtsat.nii.gz')
-
     # --extended
     ret = script_runner.run('scil_mti_maps_MT.py', tmp_dir.name,
                             '--mask', in_mask,
@@ -191,46 +116,6 @@ def test_execution_MT_extended(script_runner):
 
 def test_execution_MT_filtering(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
-
-    in_mask = os.path.join(get_home(), 'MT', 'mask.nii.gz')
-
-    in_mtoff_json = os.path.join(get_home(),
-                                 'MT', 'sub-001_echo-1_acq-mtoff_mtsat.json')
-    in_t1w_json = os.path.join(get_home(),
-                               'MT', 'sub-001_echo-1_acq-t1w_mtsat.json')
-
-    in_e1_mtoff = os.path.join(get_home(),
-                               'MT', 'sub-001_echo-1_acq-mtoff_mtsat.nii.gz')
-    in_e2_mtoff = os.path.join(get_home(),
-                               'MT', 'sub-001_echo-2_acq-mtoff_mtsat.nii.gz')
-    in_e3_mtoff = os.path.join(get_home(),
-                               'MT', 'sub-001_echo-3_acq-mtoff_mtsat.nii.gz')
-    in_e4_mtoff = os.path.join(get_home(),
-                               'MT', 'sub-001_echo-4_acq-mtoff_mtsat.nii.gz')
-    in_e5_mtoff = os.path.join(get_home(),
-                               'MT', 'sub-001_echo-5_acq-mtoff_mtsat.nii.gz')
-
-    in_e1_mton = os.path.join(get_home(),
-                              'MT', 'sub-001_echo-1_acq-mton_mtsat.nii.gz')
-    in_e2_mton = os.path.join(get_home(),
-                              'MT', 'sub-001_echo-2_acq-mton_mtsat.nii.gz')
-    in_e3_mton = os.path.join(get_home(),
-                              'MT', 'sub-001_echo-3_acq-mton_mtsat.nii.gz')
-    in_e4_mton = os.path.join(get_home(),
-                              'MT', 'sub-001_echo-4_acq-mton_mtsat.nii.gz')
-    in_e5_mton = os.path.join(get_home(),
-                              'MT', 'sub-001_echo-5_acq-mton_mtsat.nii.gz')
-
-    in_e1_t1w = os.path.join(get_home(),
-                             'MT', 'sub-001_echo-1_acq-t1w_mtsat.nii.gz')
-    in_e2_t1w = os.path.join(get_home(),
-                             'MT', 'sub-001_echo-2_acq-t1w_mtsat.nii.gz')
-    in_e3_t1w = os.path.join(get_home(),
-                             'MT', 'sub-001_echo-3_acq-t1w_mtsat.nii.gz')
-    in_e4_t1w = os.path.join(get_home(),
-                             'MT', 'sub-001_echo-4_acq-t1w_mtsat.nii.gz')
-    in_e5_t1w = os.path.join(get_home(),
-                             'MT', 'sub-001_echo-5_acq-t1w_mtsat.nii.gz')
 
     # --filtering
     ret = script_runner.run('scil_mti_maps_MT.py', tmp_dir.name,
@@ -250,50 +135,6 @@ def test_execution_MT_filtering(script_runner):
 def test_execution_MT_B1_map(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
 
-    in_mask = os.path.join(get_home(), 'MT', 'mask.nii.gz')
-
-    in_mtoff_json = os.path.join(get_home(),
-                                 'MT', 'sub-001_echo-1_acq-mtoff_mtsat.json')
-    in_t1w_json = os.path.join(get_home(),
-                               'MT', 'sub-001_echo-1_acq-t1w_mtsat.json')
-
-    in_e1_mtoff = os.path.join(get_home(),
-                               'MT', 'sub-001_echo-1_acq-mtoff_mtsat.nii.gz')
-    in_e2_mtoff = os.path.join(get_home(),
-                               'MT', 'sub-001_echo-2_acq-mtoff_mtsat.nii.gz')
-    in_e3_mtoff = os.path.join(get_home(),
-                               'MT', 'sub-001_echo-3_acq-mtoff_mtsat.nii.gz')
-    in_e4_mtoff = os.path.join(get_home(),
-                               'MT', 'sub-001_echo-4_acq-mtoff_mtsat.nii.gz')
-    in_e5_mtoff = os.path.join(get_home(),
-                               'MT', 'sub-001_echo-5_acq-mtoff_mtsat.nii.gz')
-
-    in_e1_mton = os.path.join(get_home(),
-                              'MT', 'sub-001_echo-1_acq-mton_mtsat.nii.gz')
-    in_e2_mton = os.path.join(get_home(),
-                              'MT', 'sub-001_echo-2_acq-mton_mtsat.nii.gz')
-    in_e3_mton = os.path.join(get_home(),
-                              'MT', 'sub-001_echo-3_acq-mton_mtsat.nii.gz')
-    in_e4_mton = os.path.join(get_home(),
-                              'MT', 'sub-001_echo-4_acq-mton_mtsat.nii.gz')
-    in_e5_mton = os.path.join(get_home(),
-                              'MT', 'sub-001_echo-5_acq-mton_mtsat.nii.gz')
-
-    in_e1_t1w = os.path.join(get_home(),
-                             'MT', 'sub-001_echo-1_acq-t1w_mtsat.nii.gz')
-    in_e2_t1w = os.path.join(get_home(),
-                             'MT', 'sub-001_echo-2_acq-t1w_mtsat.nii.gz')
-    in_e3_t1w = os.path.join(get_home(),
-                             'MT', 'sub-001_echo-3_acq-t1w_mtsat.nii.gz')
-    in_e4_t1w = os.path.join(get_home(),
-                             'MT', 'sub-001_echo-4_acq-t1w_mtsat.nii.gz')
-    in_e5_t1w = os.path.join(get_home(),
-                             'MT', 'sub-001_echo-5_acq-t1w_mtsat.nii.gz')
-
-    in_b1_map = os.path.join(get_home(),
-                             'MT', 'sub-001_run-01_B1map.nii.gz')
-    in_b1_json = os.path.join(get_home(),
-                              'MT', 'sub-001_run-01_B1map.json')
     out_b1_map = tmp_dir.name + '/B1map.nii.gz'
 
     # Temporary trick to have the B1 map with proper header.
@@ -322,46 +163,6 @@ def test_execution_MT_B1_map(script_runner):
 def test_execution_MT_wrong_echoes(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
 
-    in_mask = os.path.join(get_home(), 'MT', 'mask.nii.gz')
-
-    in_mtoff_json = os.path.join(get_home(),
-                                 'MT', 'sub-001_echo-1_acq-mtoff_mtsat.json')
-    in_t1w_json = os.path.join(get_home(),
-                               'MT', 'sub-001_echo-1_acq-t1w_mtsat.json')
-
-    in_e1_mtoff = os.path.join(get_home(),
-                               'MT', 'sub-001_echo-1_acq-mtoff_mtsat.nii.gz')
-    in_e2_mtoff = os.path.join(get_home(),
-                               'MT', 'sub-001_echo-2_acq-mtoff_mtsat.nii.gz')
-    in_e3_mtoff = os.path.join(get_home(),
-                               'MT', 'sub-001_echo-3_acq-mtoff_mtsat.nii.gz')
-    in_e4_mtoff = os.path.join(get_home(),
-                               'MT', 'sub-001_echo-4_acq-mtoff_mtsat.nii.gz')
-    in_e5_mtoff = os.path.join(get_home(),
-                               'MT', 'sub-001_echo-5_acq-mtoff_mtsat.nii.gz')
-
-    in_e1_mton = os.path.join(get_home(),
-                              'MT', 'sub-001_echo-1_acq-mton_mtsat.nii.gz')
-    in_e2_mton = os.path.join(get_home(),
-                              'MT', 'sub-001_echo-2_acq-mton_mtsat.nii.gz')
-    in_e3_mton = os.path.join(get_home(),
-                              'MT', 'sub-001_echo-3_acq-mton_mtsat.nii.gz')
-    in_e4_mton = os.path.join(get_home(),
-                              'MT', 'sub-001_echo-4_acq-mton_mtsat.nii.gz')
-    in_e5_mton = os.path.join(get_home(),
-                              'MT', 'sub-001_echo-5_acq-mton_mtsat.nii.gz')
-
-    in_e1_t1w = os.path.join(get_home(),
-                             'MT', 'sub-001_echo-1_acq-t1w_mtsat.nii.gz')
-    in_e2_t1w = os.path.join(get_home(),
-                             'MT', 'sub-001_echo-2_acq-t1w_mtsat.nii.gz')
-    in_e3_t1w = os.path.join(get_home(),
-                             'MT', 'sub-001_echo-3_acq-t1w_mtsat.nii.gz')
-    in_e4_t1w = os.path.join(get_home(),
-                             'MT', 'sub-001_echo-4_acq-t1w_mtsat.nii.gz')
-    in_e5_t1w = os.path.join(get_home(),
-                             'MT', 'sub-001_echo-5_acq-t1w_mtsat.nii.gz')
-
     # Wrong number of echoes for negative
     ret = script_runner.run('scil_mti_maps_MT.py', tmp_dir.name,
                             '--mask', in_mask,
@@ -381,22 +182,6 @@ def test_execution_MT_wrong_echoes(script_runner):
 def test_execution_MT_single_echoe(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
 
-    in_mask = os.path.join(get_home(), 'MT', 'mask.nii.gz')
-
-    in_mtoff_json = os.path.join(get_home(),
-                                 'MT', 'sub-001_echo-1_acq-mtoff_mtsat.json')
-    in_t1w_json = os.path.join(get_home(),
-                               'MT', 'sub-001_echo-1_acq-t1w_mtsat.json')
-
-    in_e1_mtoff = os.path.join(get_home(),
-                               'MT', 'sub-001_echo-1_acq-mtoff_mtsat.nii.gz')
-
-    in_e1_mton = os.path.join(get_home(),
-                              'MT', 'sub-001_echo-1_acq-mton_mtsat.nii.gz')
-
-    in_e1_t1w = os.path.join(get_home(),
-                             'MT', 'sub-001_echo-1_acq-t1w_mtsat.nii.gz')
-
     # Single echoe
     ret = script_runner.run('scil_mti_maps_MT.py', tmp_dir.name,
                             '--mask', in_mask,
@@ -412,23 +197,6 @@ def test_execution_MT_single_echoe(script_runner):
 def test_execution_MT_B1_not_T1(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
 
-    in_mask = os.path.join(get_home(), 'MT', 'mask.nii.gz')
-
-    in_mtoff_json = os.path.join(get_home(),
-                                 'MT', 'sub-001_echo-1_acq-mtoff_mtsat.json')
-    in_t1w_json = os.path.join(get_home(),
-                               'MT', 'sub-001_echo-1_acq-t1w_mtsat.json')
-
-    in_e1_mtoff = os.path.join(get_home(),
-                               'MT', 'sub-001_echo-1_acq-mtoff_mtsat.nii.gz')
-
-    in_e1_mton = os.path.join(get_home(),
-                              'MT', 'sub-001_echo-1_acq-mton_mtsat.nii.gz')
-
-    in_b1_map = os.path.join(get_home(),
-                             'MT', 'sub-001_run-01_B1map.nii.gz')
-    in_b1_json = os.path.join(get_home(),
-                              'MT', 'sub-001_run-01_B1map.json')
     out_b1_map = tmp_dir.name + '/B1map.nii.gz'
 
     # Temporary trick to have the B1 map with proper header.
@@ -451,26 +219,6 @@ def test_execution_MT_B1_not_T1(script_runner):
 def test_execution_MT_B1_no_fit(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
 
-    in_mask = os.path.join(get_home(), 'MT', 'mask.nii.gz')
-
-    in_mtoff_json = os.path.join(get_home(),
-                                 'MT', 'sub-001_echo-1_acq-mtoff_mtsat.json')
-    in_t1w_json = os.path.join(get_home(),
-                               'MT', 'sub-001_echo-1_acq-t1w_mtsat.json')
-
-    in_e1_mtoff = os.path.join(get_home(),
-                               'MT', 'sub-001_echo-1_acq-mtoff_mtsat.nii.gz')
-
-    in_e1_mton = os.path.join(get_home(),
-                              'MT', 'sub-001_echo-1_acq-mton_mtsat.nii.gz')
-
-    in_e1_t1w = os.path.join(get_home(),
-                             'MT', 'sub-001_echo-1_acq-t1w_mtsat.nii.gz')
-
-    in_b1_map = os.path.join(get_home(),
-                             'MT', 'sub-001_run-01_B1map.nii.gz')
-    in_b1_json = os.path.join(get_home(),
-                              'MT', 'sub-001_run-01_B1map.json')
     out_b1_map = tmp_dir.name + '/B1map.nii.gz'
 
     # Temporary trick to have the B1 map with proper header.
@@ -493,22 +241,6 @@ def test_execution_MT_B1_no_fit(script_runner):
 
 def test_execution_MT_acq_params(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
-
-    in_mask = os.path.join(get_home(), 'MT', 'mask.nii.gz')
-
-    in_mtoff_json = os.path.join(get_home(),
-                                 'MT', 'sub-001_echo-1_acq-mtoff_mtsat.json')
-    in_t1w_json = os.path.join(get_home(),
-                               'MT', 'sub-001_echo-1_acq-t1w_mtsat.json')
-
-    in_e1_mtoff = os.path.join(get_home(),
-                               'MT', 'sub-001_echo-1_acq-mtoff_mtsat.nii.gz')
-
-    in_e1_mton = os.path.join(get_home(),
-                              'MT', 'sub-001_echo-1_acq-mton_mtsat.nii.gz')
-
-    in_e1_t1w = os.path.join(get_home(),
-                             'MT', 'sub-001_echo-1_acq-t1w_mtsat.nii.gz')
 
     # Acquisition parameters
     ret = script_runner.run('scil_mti_maps_MT.py', tmp_dir.name,

--- a/scripts/tests/test_mti_maps_ihMT.py
+++ b/scripts/tests/test_mti_maps_ihMT.py
@@ -10,6 +10,60 @@ from scilpy.io.fetcher import fetch_data, get_home, get_testing_files_dict
 fetch_data(get_testing_files_dict(), keys=['ihMT.zip'])
 tmp_dir = tempfile.TemporaryDirectory()
 
+# Preparing once the filenames.
+
+in_mask = os.path.join(get_home(), 'ihMT', 'mask_resample.nii.gz')
+
+in_mtoff_pd_json = os.path.join(get_home(),
+                                'ihMT', 'echo-1_acq-mtoff_ihmt.json')
+in_mtoff_t1_json = os.path.join(get_home(),
+                                'ihMT', 'echo-1_acq-T1w_ihmt.json')
+
+in_e1_altnp = os.path.join(get_home(),
+                           'ihMT', 'echo-1_acq-altnp_ihmt.nii.gz')
+in_e2_altnp = os.path.join(get_home(),
+                           'ihMT', 'echo-2_acq-altnp_ihmt.nii.gz')
+in_e3_altnp = os.path.join(get_home(),
+                           'ihMT', 'echo-3_acq-altnp_ihmt.nii.gz')
+
+in_e1_altpn = os.path.join(get_home(),
+                           'ihMT', 'echo-1_acq-altpn_ihmt.nii.gz')
+in_e2_altpn = os.path.join(get_home(),
+                           'ihMT', 'echo-2_acq-altpn_ihmt.nii.gz')
+in_e3_altpn = os.path.join(get_home(),
+                           'ihMT', 'echo-3_acq-altpn_ihmt.nii.gz')
+
+in_e1_mtoff_pd = os.path.join(get_home(),
+                              'ihMT', 'echo-1_acq-mtoff_ihmt.nii.gz')
+in_e2_mtoff_pd = os.path.join(get_home(),
+                              'ihMT', 'echo-2_acq-mtoff_ihmt.nii.gz')
+in_e3_mtoff_pd = os.path.join(get_home(),
+                              'ihMT', 'echo-3_acq-mtoff_ihmt.nii.gz')
+
+in_e1_neg = os.path.join(get_home(),
+                         'ihMT', 'echo-1_acq-neg_ihmt.nii.gz')
+in_e2_neg = os.path.join(get_home(),
+                         'ihMT', 'echo-2_acq-neg_ihmt.nii.gz')
+in_e3_neg = os.path.join(get_home(),
+                         'ihMT', 'echo-3_acq-neg_ihmt.nii.gz')
+
+in_e1_pos = os.path.join(get_home(),
+                         'ihMT', 'echo-1_acq-pos_ihmt.nii.gz')
+in_e2_pos = os.path.join(get_home(),
+                         'ihMT', 'echo-2_acq-pos_ihmt.nii.gz')
+in_e3_pos = os.path.join(get_home(),
+                         'ihMT', 'echo-3_acq-pos_ihmt.nii.gz')
+
+in_e1_mtoff_t1 = os.path.join(get_home(),
+                              'ihMT', 'echo-1_acq-T1w_ihmt.nii.gz')
+in_e2_mtoff_t1 = os.path.join(get_home(),
+                              'ihMT', 'echo-2_acq-T1w_ihmt.nii.gz')
+in_e3_mtoff_t1 = os.path.join(get_home(),
+                              'ihMT', 'echo-3_acq-T1w_ihmt.nii.gz')
+
+in_b1_map = os.path.join(get_home(), 'ihMT', 'B1map.nii.gz')
+in_b1_json = os.path.join(get_home(), 'MT', 'sub-001_run-01_B1map.json')
+
 
 def test_help_option(script_runner):
     ret = script_runner.run('scil_mti_maps_ihMT.py', '--help')
@@ -18,55 +72,6 @@ def test_help_option(script_runner):
 
 def test_execution_ihMT_no_option(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
-
-    in_mask = os.path.join(get_home(), 'ihMT', 'mask_resample.nii.gz')
-
-    in_mtoff_pd_json = os.path.join(get_home(),
-                                    'ihMT', 'echo-1_acq-mtoff_ihmt.json')
-    in_mtoff_t1_json = os.path.join(get_home(),
-                                    'ihMT', 'echo-1_acq-T1w_ihmt.json')
-
-    in_e1_altnp = os.path.join(get_home(),
-                               'ihMT', 'echo-1_acq-altnp_ihmt.nii.gz')
-    in_e2_altnp = os.path.join(get_home(),
-                               'ihMT', 'echo-2_acq-altnp_ihmt.nii.gz')
-    in_e3_altnp = os.path.join(get_home(),
-                               'ihMT', 'echo-3_acq-altnp_ihmt.nii.gz')
-
-    in_e1_altpn = os.path.join(get_home(),
-                               'ihMT', 'echo-1_acq-altpn_ihmt.nii.gz')
-    in_e2_altpn = os.path.join(get_home(),
-                               'ihMT', 'echo-2_acq-altpn_ihmt.nii.gz')
-    in_e3_altpn = os.path.join(get_home(),
-                               'ihMT', 'echo-3_acq-altpn_ihmt.nii.gz')
-
-    in_e1_mtoff_pd = os.path.join(get_home(),
-                                  'ihMT', 'echo-1_acq-mtoff_ihmt.nii.gz')
-    in_e2_mtoff_pd = os.path.join(get_home(),
-                                  'ihMT', 'echo-2_acq-mtoff_ihmt.nii.gz')
-    in_e3_mtoff_pd = os.path.join(get_home(),
-                                  'ihMT', 'echo-3_acq-mtoff_ihmt.nii.gz')
-
-    in_e1_neg = os.path.join(get_home(),
-                             'ihMT', 'echo-1_acq-neg_ihmt.nii.gz')
-    in_e2_neg = os.path.join(get_home(),
-                             'ihMT', 'echo-2_acq-neg_ihmt.nii.gz')
-    in_e3_neg = os.path.join(get_home(),
-                             'ihMT', 'echo-3_acq-neg_ihmt.nii.gz')
-
-    in_e1_pos = os.path.join(get_home(),
-                             'ihMT', 'echo-1_acq-pos_ihmt.nii.gz')
-    in_e2_pos = os.path.join(get_home(),
-                             'ihMT', 'echo-2_acq-pos_ihmt.nii.gz')
-    in_e3_pos = os.path.join(get_home(),
-                             'ihMT', 'echo-3_acq-pos_ihmt.nii.gz')
-
-    in_e1_mtoff_t1 = os.path.join(get_home(),
-                                  'ihMT', 'echo-1_acq-T1w_ihmt.nii.gz')
-    in_e2_mtoff_t1 = os.path.join(get_home(),
-                                  'ihMT', 'echo-2_acq-T1w_ihmt.nii.gz')
-    in_e3_mtoff_t1 = os.path.join(get_home(),
-                                  'ihMT', 'echo-3_acq-T1w_ihmt.nii.gz')
 
     # no option
     ret = script_runner.run('scil_mti_maps_ihMT.py', tmp_dir.name,
@@ -89,55 +94,6 @@ def test_execution_ihMT_no_option(script_runner):
 
 def test_execution_ihMT_prefix(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
-
-    in_mask = os.path.join(get_home(), 'ihMT', 'mask_resample.nii.gz')
-
-    in_mtoff_pd_json = os.path.join(get_home(),
-                                    'ihMT', 'echo-1_acq-mtoff_ihmt.json')
-    in_mtoff_t1_json = os.path.join(get_home(),
-                                    'ihMT', 'echo-1_acq-T1w_ihmt.json')
-
-    in_e1_altnp = os.path.join(get_home(),
-                               'ihMT', 'echo-1_acq-altnp_ihmt.nii.gz')
-    in_e2_altnp = os.path.join(get_home(),
-                               'ihMT', 'echo-2_acq-altnp_ihmt.nii.gz')
-    in_e3_altnp = os.path.join(get_home(),
-                               'ihMT', 'echo-3_acq-altnp_ihmt.nii.gz')
-
-    in_e1_altpn = os.path.join(get_home(),
-                               'ihMT', 'echo-1_acq-altpn_ihmt.nii.gz')
-    in_e2_altpn = os.path.join(get_home(),
-                               'ihMT', 'echo-2_acq-altpn_ihmt.nii.gz')
-    in_e3_altpn = os.path.join(get_home(),
-                               'ihMT', 'echo-3_acq-altpn_ihmt.nii.gz')
-
-    in_e1_mtoff_pd = os.path.join(get_home(),
-                                  'ihMT', 'echo-1_acq-mtoff_ihmt.nii.gz')
-    in_e2_mtoff_pd = os.path.join(get_home(),
-                                  'ihMT', 'echo-2_acq-mtoff_ihmt.nii.gz')
-    in_e3_mtoff_pd = os.path.join(get_home(),
-                                  'ihMT', 'echo-3_acq-mtoff_ihmt.nii.gz')
-
-    in_e1_neg = os.path.join(get_home(),
-                             'ihMT', 'echo-1_acq-neg_ihmt.nii.gz')
-    in_e2_neg = os.path.join(get_home(),
-                             'ihMT', 'echo-2_acq-neg_ihmt.nii.gz')
-    in_e3_neg = os.path.join(get_home(),
-                             'ihMT', 'echo-3_acq-neg_ihmt.nii.gz')
-
-    in_e1_pos = os.path.join(get_home(),
-                             'ihMT', 'echo-1_acq-pos_ihmt.nii.gz')
-    in_e2_pos = os.path.join(get_home(),
-                             'ihMT', 'echo-2_acq-pos_ihmt.nii.gz')
-    in_e3_pos = os.path.join(get_home(),
-                             'ihMT', 'echo-3_acq-pos_ihmt.nii.gz')
-
-    in_e1_mtoff_t1 = os.path.join(get_home(),
-                                  'ihMT', 'echo-1_acq-T1w_ihmt.nii.gz')
-    in_e2_mtoff_t1 = os.path.join(get_home(),
-                                  'ihMT', 'echo-2_acq-T1w_ihmt.nii.gz')
-    in_e3_mtoff_t1 = os.path.join(get_home(),
-                                  'ihMT', 'echo-3_acq-T1w_ihmt.nii.gz')
 
     # --out_prefix
     ret = script_runner.run('scil_mti_maps_ihMT.py', tmp_dir.name,
@@ -164,55 +120,6 @@ def test_execution_ihMT_prefix(script_runner):
 def test_execution_ihMT_extended(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
 
-    in_mask = os.path.join(get_home(), 'ihMT', 'mask_resample.nii.gz')
-
-    in_mtoff_pd_json = os.path.join(get_home(),
-                                    'ihMT', 'echo-1_acq-mtoff_ihmt.json')
-    in_mtoff_t1_json = os.path.join(get_home(),
-                                    'ihMT', 'echo-1_acq-T1w_ihmt.json')
-
-    in_e1_altnp = os.path.join(get_home(),
-                               'ihMT', 'echo-1_acq-altnp_ihmt.nii.gz')
-    in_e2_altnp = os.path.join(get_home(),
-                               'ihMT', 'echo-2_acq-altnp_ihmt.nii.gz')
-    in_e3_altnp = os.path.join(get_home(),
-                               'ihMT', 'echo-3_acq-altnp_ihmt.nii.gz')
-
-    in_e1_altpn = os.path.join(get_home(),
-                               'ihMT', 'echo-1_acq-altpn_ihmt.nii.gz')
-    in_e2_altpn = os.path.join(get_home(),
-                               'ihMT', 'echo-2_acq-altpn_ihmt.nii.gz')
-    in_e3_altpn = os.path.join(get_home(),
-                               'ihMT', 'echo-3_acq-altpn_ihmt.nii.gz')
-
-    in_e1_mtoff_pd = os.path.join(get_home(),
-                                  'ihMT', 'echo-1_acq-mtoff_ihmt.nii.gz')
-    in_e2_mtoff_pd = os.path.join(get_home(),
-                                  'ihMT', 'echo-2_acq-mtoff_ihmt.nii.gz')
-    in_e3_mtoff_pd = os.path.join(get_home(),
-                                  'ihMT', 'echo-3_acq-mtoff_ihmt.nii.gz')
-
-    in_e1_neg = os.path.join(get_home(),
-                             'ihMT', 'echo-1_acq-neg_ihmt.nii.gz')
-    in_e2_neg = os.path.join(get_home(),
-                             'ihMT', 'echo-2_acq-neg_ihmt.nii.gz')
-    in_e3_neg = os.path.join(get_home(),
-                             'ihMT', 'echo-3_acq-neg_ihmt.nii.gz')
-
-    in_e1_pos = os.path.join(get_home(),
-                             'ihMT', 'echo-1_acq-pos_ihmt.nii.gz')
-    in_e2_pos = os.path.join(get_home(),
-                             'ihMT', 'echo-2_acq-pos_ihmt.nii.gz')
-    in_e3_pos = os.path.join(get_home(),
-                             'ihMT', 'echo-3_acq-pos_ihmt.nii.gz')
-
-    in_e1_mtoff_t1 = os.path.join(get_home(),
-                                  'ihMT', 'echo-1_acq-T1w_ihmt.nii.gz')
-    in_e2_mtoff_t1 = os.path.join(get_home(),
-                                  'ihMT', 'echo-2_acq-T1w_ihmt.nii.gz')
-    in_e3_mtoff_t1 = os.path.join(get_home(),
-                                  'ihMT', 'echo-3_acq-T1w_ihmt.nii.gz')
-
     # --extended
     ret = script_runner.run('scil_mti_maps_ihMT.py', tmp_dir.name,
                             '--mask', in_mask,
@@ -238,55 +145,6 @@ def test_execution_ihMT_extended(script_runner):
 def test_execution_ihMT_filtering(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
 
-    in_mask = os.path.join(get_home(), 'ihMT', 'mask_resample.nii.gz')
-
-    in_mtoff_pd_json = os.path.join(get_home(),
-                                    'ihMT', 'echo-1_acq-mtoff_ihmt.json')
-    in_mtoff_t1_json = os.path.join(get_home(),
-                                    'ihMT', 'echo-1_acq-T1w_ihmt.json')
-
-    in_e1_altnp = os.path.join(get_home(),
-                               'ihMT', 'echo-1_acq-altnp_ihmt.nii.gz')
-    in_e2_altnp = os.path.join(get_home(),
-                               'ihMT', 'echo-2_acq-altnp_ihmt.nii.gz')
-    in_e3_altnp = os.path.join(get_home(),
-                               'ihMT', 'echo-3_acq-altnp_ihmt.nii.gz')
-
-    in_e1_altpn = os.path.join(get_home(),
-                               'ihMT', 'echo-1_acq-altpn_ihmt.nii.gz')
-    in_e2_altpn = os.path.join(get_home(),
-                               'ihMT', 'echo-2_acq-altpn_ihmt.nii.gz')
-    in_e3_altpn = os.path.join(get_home(),
-                               'ihMT', 'echo-3_acq-altpn_ihmt.nii.gz')
-
-    in_e1_mtoff_pd = os.path.join(get_home(),
-                                  'ihMT', 'echo-1_acq-mtoff_ihmt.nii.gz')
-    in_e2_mtoff_pd = os.path.join(get_home(),
-                                  'ihMT', 'echo-2_acq-mtoff_ihmt.nii.gz')
-    in_e3_mtoff_pd = os.path.join(get_home(),
-                                  'ihMT', 'echo-3_acq-mtoff_ihmt.nii.gz')
-
-    in_e1_neg = os.path.join(get_home(),
-                             'ihMT', 'echo-1_acq-neg_ihmt.nii.gz')
-    in_e2_neg = os.path.join(get_home(),
-                             'ihMT', 'echo-2_acq-neg_ihmt.nii.gz')
-    in_e3_neg = os.path.join(get_home(),
-                             'ihMT', 'echo-3_acq-neg_ihmt.nii.gz')
-
-    in_e1_pos = os.path.join(get_home(),
-                             'ihMT', 'echo-1_acq-pos_ihmt.nii.gz')
-    in_e2_pos = os.path.join(get_home(),
-                             'ihMT', 'echo-2_acq-pos_ihmt.nii.gz')
-    in_e3_pos = os.path.join(get_home(),
-                             'ihMT', 'echo-3_acq-pos_ihmt.nii.gz')
-
-    in_e1_mtoff_t1 = os.path.join(get_home(),
-                                  'ihMT', 'echo-1_acq-T1w_ihmt.nii.gz')
-    in_e2_mtoff_t1 = os.path.join(get_home(),
-                                  'ihMT', 'echo-2_acq-T1w_ihmt.nii.gz')
-    in_e3_mtoff_t1 = os.path.join(get_home(),
-                                  'ihMT', 'echo-3_acq-T1w_ihmt.nii.gz')
-
     # --filtering
     ret = script_runner.run('scil_mti_maps_ihMT.py', tmp_dir.name,
                             '--mask', in_mask,
@@ -311,59 +169,6 @@ def test_execution_ihMT_filtering(script_runner):
 def test_execution_ihMT_B1_map(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
 
-    in_mask = os.path.join(get_home(), 'ihMT', 'mask_resample.nii.gz')
-
-    in_mtoff_pd_json = os.path.join(get_home(),
-                                    'ihMT', 'echo-1_acq-mtoff_ihmt.json')
-    in_mtoff_t1_json = os.path.join(get_home(),
-                                    'ihMT', 'echo-1_acq-T1w_ihmt.json')
-
-    in_e1_altnp = os.path.join(get_home(),
-                               'ihMT', 'echo-1_acq-altnp_ihmt.nii.gz')
-    in_e2_altnp = os.path.join(get_home(),
-                               'ihMT', 'echo-2_acq-altnp_ihmt.nii.gz')
-    in_e3_altnp = os.path.join(get_home(),
-                               'ihMT', 'echo-3_acq-altnp_ihmt.nii.gz')
-
-    in_e1_altpn = os.path.join(get_home(),
-                               'ihMT', 'echo-1_acq-altpn_ihmt.nii.gz')
-    in_e2_altpn = os.path.join(get_home(),
-                               'ihMT', 'echo-2_acq-altpn_ihmt.nii.gz')
-    in_e3_altpn = os.path.join(get_home(),
-                               'ihMT', 'echo-3_acq-altpn_ihmt.nii.gz')
-
-    in_e1_mtoff_pd = os.path.join(get_home(),
-                                  'ihMT', 'echo-1_acq-mtoff_ihmt.nii.gz')
-    in_e2_mtoff_pd = os.path.join(get_home(),
-                                  'ihMT', 'echo-2_acq-mtoff_ihmt.nii.gz')
-    in_e3_mtoff_pd = os.path.join(get_home(),
-                                  'ihMT', 'echo-3_acq-mtoff_ihmt.nii.gz')
-
-    in_e1_neg = os.path.join(get_home(),
-                             'ihMT', 'echo-1_acq-neg_ihmt.nii.gz')
-    in_e2_neg = os.path.join(get_home(),
-                             'ihMT', 'echo-2_acq-neg_ihmt.nii.gz')
-    in_e3_neg = os.path.join(get_home(),
-                             'ihMT', 'echo-3_acq-neg_ihmt.nii.gz')
-
-    in_e1_pos = os.path.join(get_home(),
-                             'ihMT', 'echo-1_acq-pos_ihmt.nii.gz')
-    in_e2_pos = os.path.join(get_home(),
-                             'ihMT', 'echo-2_acq-pos_ihmt.nii.gz')
-    in_e3_pos = os.path.join(get_home(),
-                             'ihMT', 'echo-3_acq-pos_ihmt.nii.gz')
-
-    in_e1_mtoff_t1 = os.path.join(get_home(),
-                                  'ihMT', 'echo-1_acq-T1w_ihmt.nii.gz')
-    in_e2_mtoff_t1 = os.path.join(get_home(),
-                                  'ihMT', 'echo-2_acq-T1w_ihmt.nii.gz')
-    in_e3_mtoff_t1 = os.path.join(get_home(),
-                                  'ihMT', 'echo-3_acq-T1w_ihmt.nii.gz')
-
-    in_b1_map = os.path.join(get_home(),
-                             'ihMT', 'B1map.nii.gz')
-    in_b1_json = os.path.join(get_home(),
-                              'MT', 'sub-001_run-01_B1map.json')
     out_b1_map = tmp_dir.name + '/B1map.nii.gz'
 
     # Temporary trick to have the B1 map with proper header.
@@ -394,52 +199,6 @@ def test_execution_ihMT_B1_map(script_runner):
 def test_execution_ihMT_B1_no_T1(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
 
-    in_mask = os.path.join(get_home(), 'ihMT', 'mask_resample.nii.gz')
-
-    in_mtoff_pd_json = os.path.join(get_home(),
-                                    'ihMT', 'echo-1_acq-mtoff_ihmt.json')
-    in_mtoff_t1_json = os.path.join(get_home(),
-                                    'ihMT', 'echo-1_acq-T1w_ihmt.json')
-
-    in_e1_altnp = os.path.join(get_home(),
-                               'ihMT', 'echo-1_acq-altnp_ihmt.nii.gz')
-    in_e2_altnp = os.path.join(get_home(),
-                               'ihMT', 'echo-2_acq-altnp_ihmt.nii.gz')
-    in_e3_altnp = os.path.join(get_home(),
-                               'ihMT', 'echo-3_acq-altnp_ihmt.nii.gz')
-
-    in_e1_altpn = os.path.join(get_home(),
-                               'ihMT', 'echo-1_acq-altpn_ihmt.nii.gz')
-    in_e2_altpn = os.path.join(get_home(),
-                               'ihMT', 'echo-2_acq-altpn_ihmt.nii.gz')
-    in_e3_altpn = os.path.join(get_home(),
-                               'ihMT', 'echo-3_acq-altpn_ihmt.nii.gz')
-
-    in_e1_mtoff_pd = os.path.join(get_home(),
-                                  'ihMT', 'echo-1_acq-mtoff_ihmt.nii.gz')
-    in_e2_mtoff_pd = os.path.join(get_home(),
-                                  'ihMT', 'echo-2_acq-mtoff_ihmt.nii.gz')
-    in_e3_mtoff_pd = os.path.join(get_home(),
-                                  'ihMT', 'echo-3_acq-mtoff_ihmt.nii.gz')
-
-    in_e1_neg = os.path.join(get_home(),
-                             'ihMT', 'echo-1_acq-neg_ihmt.nii.gz')
-    in_e2_neg = os.path.join(get_home(),
-                             'ihMT', 'echo-2_acq-neg_ihmt.nii.gz')
-    in_e3_neg = os.path.join(get_home(),
-                             'ihMT', 'echo-3_acq-neg_ihmt.nii.gz')
-
-    in_e1_pos = os.path.join(get_home(),
-                             'ihMT', 'echo-1_acq-pos_ihmt.nii.gz')
-    in_e2_pos = os.path.join(get_home(),
-                             'ihMT', 'echo-2_acq-pos_ihmt.nii.gz')
-    in_e3_pos = os.path.join(get_home(),
-                             'ihMT', 'echo-3_acq-pos_ihmt.nii.gz')
-
-    in_b1_map = os.path.join(get_home(),
-                             'ihMT', 'B1map.nii.gz')
-    in_b1_json = os.path.join(get_home(),
-                              'MT', 'sub-001_run-01_B1map.json')
     out_b1_map = tmp_dir.name + '/B1map.nii.gz'
 
     # Temporary trick to have the B1 map with proper header.
@@ -467,53 +226,6 @@ def test_execution_ihMT_B1_no_T1(script_runner):
 def test_execution_ihMT_wrong_echoes(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
 
-    in_mask = os.path.join(get_home(), 'ihMT', 'mask_resample.nii.gz')
-
-    in_mtoff_pd_json = os.path.join(get_home(),
-                                    'ihMT', 'echo-1_acq-mtoff_ihmt.json')
-    in_mtoff_t1_json = os.path.join(get_home(),
-                                    'ihMT', 'echo-1_acq-T1w_ihmt.json')
-
-    in_e1_altnp = os.path.join(get_home(),
-                               'ihMT', 'echo-1_acq-altnp_ihmt.nii.gz')
-    in_e2_altnp = os.path.join(get_home(),
-                               'ihMT', 'echo-2_acq-altnp_ihmt.nii.gz')
-    in_e3_altnp = os.path.join(get_home(),
-                               'ihMT', 'echo-3_acq-altnp_ihmt.nii.gz')
-
-    in_e1_altpn = os.path.join(get_home(),
-                               'ihMT', 'echo-1_acq-altpn_ihmt.nii.gz')
-    in_e2_altpn = os.path.join(get_home(),
-                               'ihMT', 'echo-2_acq-altpn_ihmt.nii.gz')
-    in_e3_altpn = os.path.join(get_home(),
-                               'ihMT', 'echo-3_acq-altpn_ihmt.nii.gz')
-
-    in_e1_mtoff_pd = os.path.join(get_home(),
-                                  'ihMT', 'echo-1_acq-mtoff_ihmt.nii.gz')
-    in_e2_mtoff_pd = os.path.join(get_home(),
-                                  'ihMT', 'echo-2_acq-mtoff_ihmt.nii.gz')
-    in_e3_mtoff_pd = os.path.join(get_home(),
-                                  'ihMT', 'echo-3_acq-mtoff_ihmt.nii.gz')
-
-    in_e1_neg = os.path.join(get_home(),
-                             'ihMT', 'echo-1_acq-neg_ihmt.nii.gz')
-    in_e2_neg = os.path.join(get_home(),
-                             'ihMT', 'echo-2_acq-neg_ihmt.nii.gz')
-    in_e3_neg = os.path.join(get_home(),
-                             'ihMT', 'echo-3_acq-neg_ihmt.nii.gz')
-
-    in_e1_pos = os.path.join(get_home(),
-                             'ihMT', 'echo-1_acq-pos_ihmt.nii.gz')
-    in_e2_pos = os.path.join(get_home(),
-                             'ihMT', 'echo-2_acq-pos_ihmt.nii.gz')
-    in_e3_pos = os.path.join(get_home(),
-                             'ihMT', 'echo-3_acq-pos_ihmt.nii.gz')
-
-    in_e1_mtoff_t1 = os.path.join(get_home(),
-                                  'ihMT', 'echo-1_acq-T1w_ihmt.nii.gz')
-    in_e2_mtoff_t1 = os.path.join(get_home(),
-                                  'ihMT', 'echo-2_acq-T1w_ihmt.nii.gz')
-
     ret = script_runner.run('scil_mti_maps_ihMT.py', tmp_dir.name,
                             '--mask', in_mask,
                             '--in_altnp', in_e1_altnp, in_e2_altnp,
@@ -534,59 +246,6 @@ def test_execution_ihMT_wrong_echoes(script_runner):
 def test_execution_ihMT_B1_no_fit(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
 
-    in_mask = os.path.join(get_home(), 'ihMT', 'mask_resample.nii.gz')
-
-    in_mtoff_pd_json = os.path.join(get_home(),
-                                    'ihMT', 'echo-1_acq-mtoff_ihmt.json')
-    in_mtoff_t1_json = os.path.join(get_home(),
-                                    'ihMT', 'echo-1_acq-T1w_ihmt.json')
-
-    in_e1_altnp = os.path.join(get_home(),
-                               'ihMT', 'echo-1_acq-altnp_ihmt.nii.gz')
-    in_e2_altnp = os.path.join(get_home(),
-                               'ihMT', 'echo-2_acq-altnp_ihmt.nii.gz')
-    in_e3_altnp = os.path.join(get_home(),
-                               'ihMT', 'echo-3_acq-altnp_ihmt.nii.gz')
-
-    in_e1_altpn = os.path.join(get_home(),
-                               'ihMT', 'echo-1_acq-altpn_ihmt.nii.gz')
-    in_e2_altpn = os.path.join(get_home(),
-                               'ihMT', 'echo-2_acq-altpn_ihmt.nii.gz')
-    in_e3_altpn = os.path.join(get_home(),
-                               'ihMT', 'echo-3_acq-altpn_ihmt.nii.gz')
-
-    in_e1_mtoff_pd = os.path.join(get_home(),
-                                  'ihMT', 'echo-1_acq-mtoff_ihmt.nii.gz')
-    in_e2_mtoff_pd = os.path.join(get_home(),
-                                  'ihMT', 'echo-2_acq-mtoff_ihmt.nii.gz')
-    in_e3_mtoff_pd = os.path.join(get_home(),
-                                  'ihMT', 'echo-3_acq-mtoff_ihmt.nii.gz')
-
-    in_e1_neg = os.path.join(get_home(),
-                             'ihMT', 'echo-1_acq-neg_ihmt.nii.gz')
-    in_e2_neg = os.path.join(get_home(),
-                             'ihMT', 'echo-2_acq-neg_ihmt.nii.gz')
-    in_e3_neg = os.path.join(get_home(),
-                             'ihMT', 'echo-3_acq-neg_ihmt.nii.gz')
-
-    in_e1_pos = os.path.join(get_home(),
-                             'ihMT', 'echo-1_acq-pos_ihmt.nii.gz')
-    in_e2_pos = os.path.join(get_home(),
-                             'ihMT', 'echo-2_acq-pos_ihmt.nii.gz')
-    in_e3_pos = os.path.join(get_home(),
-                             'ihMT', 'echo-3_acq-pos_ihmt.nii.gz')
-
-    in_e1_mtoff_t1 = os.path.join(get_home(),
-                                  'ihMT', 'echo-1_acq-T1w_ihmt.nii.gz')
-    in_e2_mtoff_t1 = os.path.join(get_home(),
-                                  'ihMT', 'echo-2_acq-T1w_ihmt.nii.gz')
-    in_e3_mtoff_t1 = os.path.join(get_home(),
-                                  'ihMT', 'echo-3_acq-T1w_ihmt.nii.gz')
-
-    in_b1_map = os.path.join(get_home(),
-                             'ihMT', 'B1map.nii.gz')
-    in_b1_json = os.path.join(get_home(),
-                              'MT', 'sub-001_run-01_B1map.json')
     out_b1_map = tmp_dir.name + '/B1map.nii.gz'
 
     # Temporary trick to have the B1 map with proper header.
@@ -617,31 +276,6 @@ def test_execution_ihMT_B1_no_fit(script_runner):
 def test_execution_ihMT_single_echo(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
 
-    in_mask = os.path.join(get_home(), 'ihMT', 'mask_resample.nii.gz')
-
-    in_mtoff_pd_json = os.path.join(get_home(),
-                                    'ihMT', 'echo-1_acq-mtoff_ihmt.json')
-    in_mtoff_t1_json = os.path.join(get_home(),
-                                    'ihMT', 'echo-1_acq-T1w_ihmt.json')
-
-    in_e1_altnp = os.path.join(get_home(),
-                               'ihMT', 'echo-1_acq-altnp_ihmt.nii.gz')
-
-    in_e1_altpn = os.path.join(get_home(),
-                               'ihMT', 'echo-1_acq-altpn_ihmt.nii.gz')
-
-    in_e1_mtoff_pd = os.path.join(get_home(),
-                                  'ihMT', 'echo-1_acq-mtoff_ihmt.nii.gz')
-
-    in_e1_neg = os.path.join(get_home(),
-                             'ihMT', 'echo-1_acq-neg_ihmt.nii.gz')
-
-    in_e1_pos = os.path.join(get_home(),
-                             'ihMT', 'echo-1_acq-pos_ihmt.nii.gz')
-
-    in_e1_mtoff_t1 = os.path.join(get_home(),
-                                  'ihMT', 'echo-1_acq-T1w_ihmt.nii.gz')
-
     ret = script_runner.run('scil_mti_maps_ihMT.py', tmp_dir.name,
                             '--mask', in_mask,
                             '--in_altnp', in_e1_altnp,
@@ -658,26 +292,6 @@ def test_execution_ihMT_single_echo(script_runner):
 
 def test_execution_ihMT_acq_params(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
-
-    in_mask = os.path.join(get_home(), 'ihMT', 'mask_resample.nii.gz')
-
-    in_e1_altnp = os.path.join(get_home(),
-                               'ihMT', 'echo-1_acq-altnp_ihmt.nii.gz')
-
-    in_e1_altpn = os.path.join(get_home(),
-                               'ihMT', 'echo-1_acq-altpn_ihmt.nii.gz')
-
-    in_e1_mtoff_pd = os.path.join(get_home(),
-                                  'ihMT', 'echo-1_acq-mtoff_ihmt.nii.gz')
-
-    in_e1_neg = os.path.join(get_home(),
-                             'ihMT', 'echo-1_acq-neg_ihmt.nii.gz')
-
-    in_e1_pos = os.path.join(get_home(),
-                             'ihMT', 'echo-1_acq-pos_ihmt.nii.gz')
-
-    in_e1_mtoff_t1 = os.path.join(get_home(),
-                                  'ihMT', 'echo-1_acq-T1w_ihmt.nii.gz')
 
     ret = script_runner.run('scil_mti_maps_ihMT.py', tmp_dir.name,
                             '--mask', in_mask,


### PR DESCRIPTION
# Quick description

Continuing the verification of reconst scripts.

Here, only touching the two mti_maps scripts. I did not succeed to encapsulate any parts of code that could be testable.
However, ~160 lines of codes in both scripts were exactly copy-pasted. I tried to at least put them together. Tell me if you don't agree.

Also, in the tests, the same filenames were copy-pasted many times. Simplifying by defining them once at the top. Easier to read.

## Type of change

Check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Cleaning scripts.

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [ ] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
