### PR TITLE
Cleaning scil_gradients_validate_correct handling of peaks

### DIFF
--- a/scripts/scil_gradients_validate_correct.py
+++ b/scripts/scil_gradients_validate_correct.py
@@ -15,8 +15,10 @@ Note that peaks_v1.nii.gz is the file containing the direction associated
 to the highest eigenvalue at each voxel.
 
 It is also possible to use a file containing multiple principal directions per
-voxel, given that the amplitude of each direction is also given with the
-argument --peaks_vals.
+voxel, given that they are sorted by decreasing amplitude. In that case, the
+first direction (with the highest amplitude) will be chosen for validation.
+Only 4D data is supported, so the directions must be stored in a single
+dimension. For example, peaks.nii.gz from scil_fodf_metrics.py could be used.
 
 Formerly: scil_validate_and_correct_bvecs.py
 """
@@ -58,12 +60,9 @@ def _build_arg_parser():
     p.add_argument('--mask',
                    help='Path to an optional mask. If set, FA and Peaks will '
                         'only be used inside the mask.')
-    p.add_argument('--peaks_vals',
-                   help='Path to peaks values file. If more than one peak per '
-                        'voxel is found, the maximal peak only will be used.')
-    p.add_argument('--fa_th', default=0.2, type=float,
+    p.add_argument('--fa_threshold', default=0.2, type=float,
                    help='FA threshold. Only voxels with FA higher '
-                        'than fa_th will be considered. [%(default)s]')
+                        'than fa_threshold will be considered. [%(default)s]')
     p.add_argument('--column_wise', action='store_true',
                    help='Specify if input peaks are column-wise (..., 3, N) '
                         'instead of row-wise (..., N, 3).')
@@ -79,7 +78,7 @@ def main():
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
     inputs = [args.in_bvec, args.in_peaks, args.in_FA]
-    optional = [args.mask, args.peaks_vals]
+    optional = [args.mask]
 
     assert_inputs_exist(parser, inputs, optional=optional)
     assert_outputs_exist(parser, args, args.out_bvec)
@@ -88,6 +87,11 @@ def main():
     fa = nib.load(args.in_FA).get_fdata()
     peaks = nib.load(args.in_peaks).get_fdata()
 
+    if peaks.shape[-1] > 3:
+        logging.info('More than one principal direction per voxel was given.')
+        peaks = peaks[..., 0:3]
+        logging.info('The first peak is assumed to be the biggest.')
+
     # convert peaks to a volume of shape (H, W, D, N, 3)
     if args.column_wise:
         peaks = np.reshape(peaks, peaks.shape[:3] + (3, -1))
@@ -95,22 +99,13 @@ def main():
     else:
         peaks = np.reshape(peaks, peaks.shape[:3] + (-1, 3))
 
-    N = peaks.shape[3]
-    if N > 1:
-        if not args.peaks_vals:
-            parser.error('More than one principal direction per voxel. Specify'
-                         ' peaks values with --peaks_vals to proceed.')
-        peaks_vals = nib.load(args.peaks_vals).get_fdata()
-        indices_max = np.argmax(peaks_vals, axis=-1)[..., None, None]
-        peaks = np.take_along_axis(peaks, indices_max, axis=-2)
-
     peaks = np.squeeze(peaks)
     if args.mask:
         mask = get_data_as_mask(nib.load(args.mask))
         fa[np.logical_not(mask)] = 0
         peaks[np.logical_not(mask)] = 0
 
-    peaks[fa < args.fa_th] = 0
+    peaks[fa < args.fa_threshold] = 0
     coherence, transform = compute_fiber_coherence_table(peaks, fa)
 
     best_t = transform[np.argmax(coherence)]

--- a/scripts/tests/test_gradients_validate_correct.py
+++ b/scripts/tests/test_gradients_validate_correct.py
@@ -16,7 +16,7 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_processing(script_runner):
+def test_execution_processing_dti_peaks(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi = os.path.join(get_home(), 'processing',
                           'dwi_crop_1000.nii.gz')
@@ -33,3 +33,8 @@ def test_execution_processing(script_runner):
     ret = script_runner.run('scil_gradients_validate_correct.py', in_bvec,
                             'evecs_v1.nii.gz', 'fa.nii.gz', 'bvec_corr', '-v')
     assert ret.success
+
+
+def test_execution_processing_fodf_peaks():
+    # ToDo
+    pass


### PR DESCRIPTION
# Quick description

Small PR to remove the need for a `--peak_vals` argument in `scil_gradients_validate_correct.py` when giving multiple peaks per voxel. Since the peaks we use (from `scil_fodf_metrics.py`) are already ordered, we don't need the values to find the maximum amplitude. Also, it would work with evecs.nii.gz from `scil_dti_metrics.py`, but the format is different and we always have access to evecs_v1.nii.gz anyway, so I did not add support for it.

We will also need to add a test for multiple peaks, once we have cleaner test data.

...

## Type of change

Check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [ ] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
