### PR TITLE
Split load_and_verify_mti function

### DIFF
--- a/scilpy/io/mti.py
+++ b/scilpy/io/mti.py
@@ -206,7 +206,8 @@ def _parse_acquisition_parameters(args):
 
 def _prepare_B1_map(args, flip_angles, extended_dir, affine):
     """
-    Common verifications and loading for both MT and ihMT scripts.
+    Prepare the B1 map for MTI B1+ inhomogeneity correction. Flip angles might
+    also be affected.
 
     Parameters
     ----------

--- a/scilpy/io/mti.py
+++ b/scilpy/io/mti.py
@@ -125,13 +125,14 @@ def load_and_verify_mti(args, parser, input_maps_lists, extended_dir, affine,
 
     # Set TR and FlipAngle parameters. Required with --in_mtoff_t1, in which
     # case one of --in_aqc_parameters or --in_jsons is set.
-    rep_times, flip_angles = _parse_acquisition_parameters
+    rep_times, flip_angles = _parse_acquisition_parameters(args)
 
     # Fix issue from the presence of invalid value and division by zero
     np.seterr(divide='ignore', invalid='ignore')
 
     # Load B1 image
-    B1_map, flip_angles = _prepare_B1_map(args, flip_angles)
+    B1_map, flip_angles = _prepare_B1_map(args, flip_angles, extended_dir,
+                                          affine)
 
     # Define contrasts maps names
     if args.filtering:

--- a/scripts/scil_mti_maps_MT.py
+++ b/scripts/scil_mti_maps_MT.py
@@ -138,7 +138,9 @@ def _build_arg_parser():
                         'calculation of MTsat. \nAcquisition '
                         'parameters should also be set with this image.')
 
+    # Other MTI arguments are gathered here.
     add_common_args_mti(p)
+
     add_verbose_arg(p)
     add_overwrite_arg(p)
 

--- a/scripts/scil_mti_maps_MT.py
+++ b/scripts/scil_mti_maps_MT.py
@@ -84,7 +84,7 @@ import sys
 import nibabel as nib
 import numpy as np
 
-from scilpy.io.mti import add_common_args_mti, verifications_and_loading_mti
+from scilpy.io.mti import add_common_args_mti, load_and_verify_mti
 from scilpy.io.utils import (add_overwrite_arg,
                              assert_inputs_exist, add_verbose_arg,
                              assert_output_dirs_exist_and_empty)
@@ -186,8 +186,8 @@ def main():
 
     # Other checks, loading, saving contrast_maps.
     single_echo, flip_angles, rep_times, B1_map, contrast_maps = \
-        verifications_and_loading_mti(args, parser, input_maps_lists,
-                                      extended_dir, affine, contrast_names)
+        load_and_verify_mti(args, parser, input_maps_lists, extended_dir,
+                            affine, contrast_names)
 
     # Compute MTR
     if 'positive' in contrast_names_og and 'negative' in contrast_names_og:

--- a/scripts/scil_mti_maps_ihMT.py
+++ b/scripts/scil_mti_maps_ihMT.py
@@ -90,7 +90,7 @@ import os
 import nibabel as nib
 import numpy as np
 
-from scilpy.io.mti import add_common_args_mti, verifications_and_loading_mti
+from scilpy.io.mti import add_common_args_mti, load_and_verify_mti
 from scilpy.io.utils import (add_overwrite_arg,
                              assert_inputs_exist, add_verbose_arg,
                              assert_output_dirs_exist_and_empty)
@@ -203,8 +203,8 @@ def main():
 
     # Other checks, loading, saving contrast_maps.
     single_echo, flip_angles, rep_times, B1_map, contrast_maps = \
-        verifications_and_loading_mti(args, parser, input_maps_lists,
-                                      extended_dir, affine, contrast_names)
+        load_and_verify_mti(args, parser, input_maps_lists, extended_dir,
+                            affine, contrast_names)
 
     # Compute ratio maps
     MTR, ihMTR = compute_ratio_map((contrast_maps[2] + contrast_maps[3]) / 2,

--- a/scripts/scil_mti_maps_ihMT.py
+++ b/scripts/scil_mti_maps_ihMT.py
@@ -157,7 +157,9 @@ def _build_arg_parser():
                         'calculation of MTsat and ihMTsat. \nAcquisition '
                         'parameters should also be set with this image.')
 
+    # Other MTI arguments are gathered here.
     add_common_args_mti(p)
+
     add_verbose_arg(p)
     add_overwrite_arg(p)
 


### PR DESCRIPTION
# Quick description

New little PR! First, I changed the name of the function `io.mti.verifications_and_loading_mti` to `io.mti.load_and_verify_mti`. Then, I simply added two new local functions `_parse_acquisition_parameters` and `_prepare_B1_map`, making the big function less big.

...

## Type of change

Check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [ ] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
