### PR TITLE
Verify mask fit with reference in get_data_as_mask

### DIFF
--- a/scilpy/image/volume_operations.py
+++ b/scilpy/image/volume_operations.py
@@ -308,7 +308,7 @@ def compute_snr(dwi, bval, bvec, b0_thr, mask,
     """
     data = dwi.get_fdata(dtype=np.float32)
     affine = dwi.affine
-    mask = get_data_as_mask(mask, dtype=bool)
+    mask = get_data_as_mask(mask, dtype=bool, ref_shape=data.shape)
 
     if split_shells:
         centroids, shell_indices = identify_shells(bval, tol=40.0,
@@ -343,8 +343,8 @@ def compute_snr(dwi, bval, bvec, b0_thr, mask,
         nib.save(nib.Nifti1Image(noise_mask, affine),
                  basename + '_noise_mask.nii.gz')
     elif noise_mask:
-        noise_mask = get_data_as_mask(noise_mask,
-                                      dtype=bool).squeeze()
+        noise_mask = get_data_as_mask(noise_mask, dtype=bool,
+                                      ref_shape=data.shape).squeeze()
     elif noise_map:
         data_noisemap = noise_map.get_fdata(dtype=np.float32)
 

--- a/scilpy/image/volume_operations.py
+++ b/scilpy/image/volume_operations.py
@@ -308,7 +308,7 @@ def compute_snr(dwi, bval, bvec, b0_thr, mask,
     """
     data = dwi.get_fdata(dtype=np.float32)
     affine = dwi.affine
-    mask = get_data_as_mask(mask, dtype=bool, ref_shape=data.shape)
+    mask = get_data_as_mask(mask, dtype=bool)
 
     if split_shells:
         centroids, shell_indices = identify_shells(bval, tol=40.0,
@@ -343,8 +343,7 @@ def compute_snr(dwi, bval, bvec, b0_thr, mask,
         nib.save(nib.Nifti1Image(noise_mask, affine),
                  basename + '_noise_mask.nii.gz')
     elif noise_mask:
-        noise_mask = get_data_as_mask(noise_mask, dtype=bool,
-                                      ref_shape=data.shape).squeeze()
+        noise_mask = get_data_as_mask(noise_mask, dtype=bool).squeeze()
     elif noise_map:
         data_noisemap = noise_map.get_fdata(dtype=np.float32)
 

--- a/scilpy/io/image.py
+++ b/scilpy/io/image.py
@@ -88,7 +88,7 @@ def assert_same_resolution(images):
             raise Exception("Images are not of the same resolution/affine")
 
 
-def get_data_as_mask(mask_img, dtype=np.uint8, ref_img=None, ref_shape=None):
+def get_data_as_mask(mask_img, dtype=np.uint8):
     """
     Get data as mask (force type np.uint8 or bool), check data type before
     casting.
@@ -99,11 +99,6 @@ def get_data_as_mask(mask_img, dtype=np.uint8, ref_img=None, ref_shape=None):
         Mask image.
     dtype: type or str
         Data type for the output data (default: uint8)
-    ref_img: nibabel.nitfi1.Nifti1Image
-        Reference image. If given, mask must be compatible.
-    ref_shape: shape
-        Alternative to ref_image. The shape of the associated data. If given,
-        verifies that the mask shape fits with the ref_shape.
 
     Return
     ------
@@ -115,16 +110,6 @@ def get_data_as_mask(mask_img, dtype=np.uint8, ref_img=None, ref_shape=None):
             issubclass(np.dtype(dtype).type, np.dtype(bool).type)):
         raise IOError('Output data type must be uint8 or bool. '
                       'Current data type is {}.'.format(dtype))
-
-    # Verify that shape is ok
-    if ref_img is not None:
-        if not is_header_compatible(mask_img, ref_img):
-            raise IOError("Mask is not of the same resolution/affine as data.")
-    elif ref_shape is not None:
-        if not np.array_equal(mask_img.shape, ref_shape[0:3]):
-            raise IOError("Mask is not the same shape as data. Got {}, and "
-                          "data is of shape {}"
-                          .format(mask_img.shape, ref_shape))
 
     # Verify that loaded datatype is ok
     curr_type = mask_img.get_data_dtype().type

--- a/scilpy/io/utils.py
+++ b/scilpy/io/utils.py
@@ -702,9 +702,8 @@ def assert_roi_radii_format(parser):
     return roi_radii
 
 
-def is_header_compatible_multiple_files(parser, list_files,
-                                        verbose_all_compatible=False,
-                                        reference=None):
+def assert_headers_compatible(parser, required, optional=None,
+                              verbose_all_compatible=False, reference=None):
     """
     Verifies the compatibility between the first item in list_files
     and the remaining files in list.
@@ -713,8 +712,10 @@ def is_header_compatible_multiple_files(parser, list_files,
     ---------
     parser: argument parser
         Will raise an error if a file is not compatible.
-    list_files: List[str]
+    required: List[str]
         List of files to test
+    optional: List[str or None]
+        List of files. May contain None, they will be discarted.
     verbose_all_compatible: bool
         If true will print a message when everything is okay
     reference: str
@@ -722,8 +723,21 @@ def is_header_compatible_multiple_files(parser, list_files,
     """
     all_valid = True
 
-    # Gather "headers" for all files to compare against
-    # eachother later
+    # Format required and optional to lists if a single filename was sent.
+    if isinstance(required, str):
+        required = [required]
+    if optional is None:
+        optional = []
+    elif isinstance(optional, str):
+        optional = [optional]
+    else:
+        optional = [f for f in optional if f is not None]
+    list_files = required + optional
+
+    if len(list_files) <= 1:
+        return
+
+    # Gather "headers" for all files to compare against each other later
     headers = []
     for filepath in list_files:
         _, in_extension = split_name_with_nii(filepath)

--- a/scilpy/io/utils.py
+++ b/scilpy/io/utils.py
@@ -702,8 +702,7 @@ def assert_roi_radii_format(parser):
     return roi_radii
 
 
-def assert_headers_compatible(parser, required, optional=None,
-                              verbose_all_compatible=False, reference=None):
+def assert_headers_compatible(parser, required, optional=None, reference=None):
     """
     Verifies the compatibility between the first item in list_files
     and the remaining files in list.
@@ -716,8 +715,6 @@ def assert_headers_compatible(parser, required, optional=None,
         List of files to test
     optional: List[str or None]
         List of files. May contain None, they will be discarted.
-    verbose_all_compatible: bool
-        If true will print a message when everything is okay
     reference: str
         Reference for any .tck passed in `list_files`
     """
@@ -754,15 +751,18 @@ def assert_headers_compatible(parser, required, optional=None,
             parser.error('{} does not have a supported extension.'.format(
                 filepath))
 
+    # Verify again that we have more than one header (ex, if not all tck files)
+    if len(headers) <= 1:
+        return
+
     for curr in headers[1:]:
         if not is_header_compatible(headers[0], curr):
-            print('ERROR:\"{}\" and \"{}\" do not have compatible '
-                  'headers.'.format(headers[0], curr))
+            # Not raising error now. Allows to show all errors.
+            logging.error('ERROR:\"{}\" and \"{}\" do not have compatible '
+                          'headers.'.format(headers[0], curr))
             all_valid = False
 
-    if all_valid and verbose_all_compatible:
-        print('All input files have compatible headers.')
-    elif not all_valid:
+    if not all_valid:
         parser.error('Not all input files have compatible headers.')
 
 

--- a/scilpy/io/utils.py
+++ b/scilpy/io/utils.py
@@ -734,6 +734,9 @@ def assert_headers_compatible(parser, required, optional=None,
         optional = [f for f in optional if f is not None]
     list_files = required + optional
 
+    if reference is not None:
+        list_files.append(reference)
+
     if len(list_files) <= 1:
         return
 
@@ -744,12 +747,9 @@ def assert_headers_compatible(parser, required, optional=None,
         if in_extension in ['.trk', '.nii', '.nii.gz']:
             headers.append(filepath)
         elif in_extension == '.tck':
-            if reference:
-                headers.append(reference)
-            else:
+            if reference is None:
                 parser.error(
-                    '{} must be provided with a reference.'.format(
-                        filepath))
+                    '{} must be provided with a reference.'.format(filepath))
         else:
             parser.error('{} does not have a supported extension.'.format(
                 filepath))

--- a/scilpy/reconst/mti.py
+++ b/scilpy/reconst/mti.py
@@ -191,7 +191,7 @@ def threshold_map(computed_map,  in_mask,
     # Load and apply sum of T1 probability maps on myelin maps
     if in_mask is not None:
         mask_image = nib.load(in_mask)
-        mask_data = get_data_as_mask(mask_image, ref_shape=computed_map.shape)
+        mask_data = get_data_as_mask(mask_image)
         computed_map[np.where(mask_data == 0)] = 0
 
     # Apply threshold based on combination of specific contrast maps

--- a/scilpy/reconst/mti.py
+++ b/scilpy/reconst/mti.py
@@ -191,7 +191,7 @@ def threshold_map(computed_map,  in_mask,
     # Load and apply sum of T1 probability maps on myelin maps
     if in_mask is not None:
         mask_image = nib.load(in_mask)
-        mask_data = get_data_as_mask(mask_image)
+        mask_data = get_data_as_mask(mask_image, ref_shape=computed_map.shape)
         computed_map[np.where(mask_data == 0)] = 0
 
     # Apply threshold based on combination of specific contrast maps

--- a/scilpy/segment/tractogram_from_roi.py
+++ b/scilpy/segment/tractogram_from_roi.py
@@ -353,7 +353,7 @@ def _extract_vb_one_bundle(
     mask_1_img = nib.load(head_filename)
     mask_2_img = nib.load(tail_filename)
     mask_1 = get_data_as_mask(mask_1_img)
-    mask_2 = get_data_as_mask(mask_2_img)
+    mask_2 = get_data_as_mask(mask_2_img, ref_img=mask_1_img)
 
     if dilate_endpoints:
         mask_1 = binary_dilation(mask_1, iterations=dilate_endpoints)
@@ -501,7 +501,7 @@ def _extract_ib_one_bundle(sft, mask_1_filename, mask_2_filename,
     mask_1_img = nib.load(mask_1_filename)
     mask_2_img = nib.load(mask_2_filename)
     mask_1 = get_data_as_mask(mask_1_img)
-    mask_2 = get_data_as_mask(mask_2_img)
+    mask_2 = get_data_as_mask(mask_2_img, ref_img=mask_1_img)
 
     if dilate_endpoints:
         mask_1 = binary_dilation(mask_1, iterations=dilate_endpoints)

--- a/scilpy/segment/tractogram_from_roi.py
+++ b/scilpy/segment/tractogram_from_roi.py
@@ -353,7 +353,7 @@ def _extract_vb_one_bundle(
     mask_1_img = nib.load(head_filename)
     mask_2_img = nib.load(tail_filename)
     mask_1 = get_data_as_mask(mask_1_img)
-    mask_2 = get_data_as_mask(mask_2_img, ref_img=mask_1_img)
+    mask_2 = get_data_as_mask(mask_2_img)
 
     if dilate_endpoints:
         mask_1 = binary_dilation(mask_1, iterations=dilate_endpoints)
@@ -501,7 +501,7 @@ def _extract_ib_one_bundle(sft, mask_1_filename, mask_2_filename,
     mask_1_img = nib.load(mask_1_filename)
     mask_2_img = nib.load(mask_2_filename)
     mask_1 = get_data_as_mask(mask_1_img)
-    mask_2 = get_data_as_mask(mask_2_img, ref_img=mask_1_img)
+    mask_2 = get_data_as_mask(mask_2_img)
 
     if dilate_endpoints:
         mask_1 = binary_dilation(mask_1, iterations=dilate_endpoints)

--- a/scripts/scil_aodf_metrics.py
+++ b/scripts/scil_aodf_metrics.py
@@ -155,7 +155,8 @@ def main():
         parser.error('Invalid SH image. A full SH basis is expected.')
 
     if args.mask:
-        mask = get_data_as_mask(nib.load(args.mask), dtype=bool)
+        mask = get_data_as_mask(nib.load(args.mask), dtype=bool,
+                                ref_img=sh_img)
     else:
         mask = np.sum(np.abs(sh), axis=-1) > 0
 

--- a/scripts/scil_aodf_metrics.py
+++ b/scripts/scil_aodf_metrics.py
@@ -43,6 +43,7 @@ from scilpy.io.utils import (add_processes_arg,
                              add_sh_basis_args,
                              add_verbose_arg,
                              assert_inputs_exist,
+                             assert_headers_compatible,
                              assert_outputs_exist,
                              add_overwrite_arg,
                              parse_sh_basis_arg)
@@ -142,6 +143,8 @@ def main():
 
     assert_inputs_exist(parser, inputs)
     assert_outputs_exist(parser, args, arglist)
+    if args.mask:
+        assert_headers_compatible(parser, inputs)
 
     # Loading
     sh_img = nib.load(args.in_sh)
@@ -155,8 +158,7 @@ def main():
         parser.error('Invalid SH image. A full SH basis is expected.')
 
     if args.mask:
-        mask = get_data_as_mask(nib.load(args.mask), dtype=bool,
-                                ref_img=sh_img)
+        mask = get_data_as_mask(nib.load(args.mask), dtype=bool)
     else:
         mask = np.sum(np.abs(sh), axis=-1) > 0
 

--- a/scripts/scil_aodf_metrics.py
+++ b/scripts/scil_aodf_metrics.py
@@ -39,14 +39,10 @@ from scilpy.reconst.sh import peaks_from_sh
 from scilpy.reconst.utils import get_sh_order_and_fullness
 from scilpy.reconst.aodf import (compute_asymmetry_index,
                                  compute_odd_power_map)
-from scilpy.io.utils import (add_processes_arg,
-                             add_sh_basis_args,
-                             add_verbose_arg,
-                             assert_inputs_exist,
-                             assert_headers_compatible,
-                             assert_outputs_exist,
-                             add_overwrite_arg,
-                             parse_sh_basis_arg)
+from scilpy.io.utils import (add_processes_arg, add_sh_basis_args,
+                             add_verbose_arg, assert_inputs_exist,
+                             assert_headers_compatible, assert_outputs_exist,
+                             add_overwrite_arg, parse_sh_basis_arg)
 from scilpy.io.image import get_data_as_mask
 
 
@@ -137,14 +133,9 @@ def main():
         parser.error('When using --not_all, you need to specify at least '
                      'one file to output.')
 
-    inputs = [args.in_sh]
-    if args.mask:
-        inputs.append(args.mask)
-
-    assert_inputs_exist(parser, inputs)
+    assert_inputs_exist(parser, args.in_sh, args.mask)
     assert_outputs_exist(parser, args, arglist)
-    if args.mask:
-        assert_headers_compatible(parser, inputs)
+    assert_headers_compatible(parser, args.in_sh, args.mask)
 
     # Loading
     sh_img = nib.load(args.in_sh)

--- a/scripts/scil_aodf_metrics.py
+++ b/scripts/scil_aodf_metrics.py
@@ -69,22 +69,22 @@ def _build_arg_parser():
                                 formatter_class=argparse.RawTextHelpFormatter)
     p.add_argument('in_sh', help='Input SH image.')
 
-    p.add_argument('--mask', default='',
+    p.add_argument('--mask',
                    help='Optional mask.')
 
     # outputs
-    p.add_argument('--asi_map', default='',
+    p.add_argument('--asi_map',
                    help='Output asymmetry index (ASI) map.')
     p.add_argument('--odd_power_map', default='',
                    help='Output odd power map.')
-    p.add_argument('--peaks', default='',
+    p.add_argument('--peaks',
                    help='Output filename for the extracted peaks.')
-    p.add_argument('--peak_values', default='',
+    p.add_argument('--peak_values',
                    help='Output filename for the extracted peaks values.')
-    p.add_argument('--peak_indices', default='',
+    p.add_argument('--peak_indices',
                    help='Output filename for the generated peaks indices on '
                         'the sphere.')
-    p.add_argument('--nufid', default='',
+    p.add_argument('--nufid',
                    help='Output filename for the nufid file.')
     p.add_argument('--not_all', action='store_true',
                    help='If set, only saves the files specified using the '
@@ -134,7 +134,7 @@ def main():
                      'one file to output.')
 
     assert_inputs_exist(parser, args.in_sh, args.mask)
-    assert_outputs_exist(parser, args, arglist)
+    assert_outputs_exist(parser, args, [], arglist)
     assert_headers_compatible(parser, args.in_sh, args.mask)
 
     # Loading

--- a/scripts/scil_bingham_metrics.py
+++ b/scripts/scil_bingham_metrics.py
@@ -23,11 +23,12 @@ import nibabel as nib
 import time
 import argparse
 import logging
-from scilpy.io.image import get_data_as_mask
 
+from scilpy.io.image import get_data_as_mask
 from scilpy.io.utils import (add_overwrite_arg, add_processes_arg,
                              add_verbose_arg, assert_inputs_exist,
-                             assert_outputs_exist, validate_nbr_processes)
+                             assert_outputs_exist, validate_nbr_processes,
+                             assert_headers_compatible)
 from scilpy.reconst.bingham import (compute_fiber_density,
                                     compute_fiber_spread,
                                     compute_fiber_fraction)
@@ -94,11 +95,12 @@ def main():
     outputs = [args.out_fd, args.out_fs, args.out_ff]
     assert_inputs_exist(parser, args.in_bingham, args.mask)
     assert_outputs_exist(parser, args, [], optional=outputs)
+    assert_headers_compatible(parser, args.in_bingham, args.mask)
 
     bingham_im = nib.load(args.in_bingham)
     bingham = bingham_im.get_fdata()
-    mask = get_data_as_mask(nib.load(args.mask), dtype=bool,
-                            ref_img=bingham_im) if args.mask else None
+    mask = get_data_as_mask(nib.load(args.mask),
+                            dtype=bool) if args.mask else None
 
     nbr_processes = validate_nbr_processes(parser, args)
 

--- a/scripts/scil_bingham_metrics.py
+++ b/scripts/scil_bingham_metrics.py
@@ -97,8 +97,8 @@ def main():
 
     bingham_im = nib.load(args.in_bingham)
     bingham = bingham_im.get_fdata()
-    mask = get_data_as_mask(nib.load(args.mask), dtype=bool)\
-        if args.mask else None
+    mask = get_data_as_mask(nib.load(args.mask), dtype=bool,
+                            ref_img=bingham_im) if args.mask else None
 
     nbr_processes = validate_nbr_processes(parser, args)
 

--- a/scripts/scil_btensor_metrics.py
+++ b/scripts/scil_btensor_metrics.py
@@ -52,8 +52,7 @@ from scilpy.io.image import get_data_as_mask
 from scilpy.io.utils import (add_overwrite_arg, assert_inputs_exist,
                              assert_outputs_exist, add_processes_arg,
                              add_verbose_arg, add_skip_b0_check_arg,
-                             add_tolerance_arg,
-                             assert_headers_compatible)
+                             add_tolerance_arg, assert_headers_compatible)
 from scilpy.reconst.divide import fit_gamma, gamma_fit2metrics
 
 
@@ -160,9 +159,9 @@ def main():
                      'one file to output.')
 
     assert_inputs_exist(parser, args.in_dwis + args.in_bvals + args.in_bvecs,
-                        args.mask)
+                        [args.mask, args.fa])
     assert_outputs_exist(parser, args, arglist)
-    assert_headers_compatible(parser, args.in_dwis, args.mask)
+    assert_headers_compatible(parser, args.in_dwis, [args.mask, args.fa])
 
     if args.op and not args.fa:
         parser.error('Computation of the OP requires a precomputed '

--- a/scripts/scil_btensor_metrics.py
+++ b/scripts/scil_btensor_metrics.py
@@ -199,9 +199,8 @@ def main():
             'No mask provided. The fit might not converge due to noise. '
             'Please provide a mask if it is the case.')
     else:
-        mask = get_data_as_mask(nib.load(args.mask), dtype=bool)
-        if mask.shape != data.shape[:-1]:
-            raise ValueError("Mask is not the same shape as data.")
+        mask = get_data_as_mask(nib.load(args.mask), dtype=bool,
+                                ref_shape=data.shape)
 
     if args.fa is not None:
         vol = nib.load(args.fa)

--- a/scripts/scil_btensor_metrics.py
+++ b/scripts/scil_btensor_metrics.py
@@ -52,7 +52,8 @@ from scilpy.io.image import get_data_as_mask
 from scilpy.io.utils import (add_overwrite_arg, assert_inputs_exist,
                              assert_outputs_exist, add_processes_arg,
                              add_verbose_arg, add_skip_b0_check_arg,
-                             add_tolerance_arg)
+                             add_tolerance_arg,
+                             assert_headers_compatible)
 from scilpy.reconst.divide import fit_gamma, gamma_fit2metrics
 
 
@@ -158,9 +159,10 @@ def main():
         parser.error('When using --not_all, you need to specify at least '
                      'one file to output.')
 
-    assert_inputs_exist(parser, [],
-                        optional=args.in_dwis + args.in_bvals + args.in_bvecs)
+    assert_inputs_exist(parser, args.in_dwis + args.in_bvals + args.in_bvecs,
+                        args.mask)
     assert_outputs_exist(parser, args, arglist)
+    assert_headers_compatible(parser, args.in_dwis, args.mask)
 
     if args.op and not args.fa:
         parser.error('Computation of the OP requires a precomputed '
@@ -199,8 +201,7 @@ def main():
             'No mask provided. The fit might not converge due to noise. '
             'Please provide a mask if it is the case.')
     else:
-        mask = get_data_as_mask(nib.load(args.mask), dtype=bool,
-                                ref_shape=data.shape)
+        mask = get_data_as_mask(nib.load(args.mask), dtype=bool)
 
     if args.fa is not None:
         vol = nib.load(args.fa)

--- a/scripts/scil_bundle_compute_centroid.py
+++ b/scripts/scil_bundle_compute_centroid.py
@@ -46,7 +46,7 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
-    assert_inputs_exist(parser, args.in_bundle)
+    assert_inputs_exist(parser, args.in_bundle, args.reference)
     assert_outputs_exist(parser, args, args.out_centroid)
 
     if args.nb_points < 2:

--- a/scripts/scil_bundle_diameter.py
+++ b/scripts/scil_bundle_diameter.py
@@ -213,7 +213,8 @@ def main():
     tmp = args.in_bundles + args.in_labels
     args.in_labels = args.in_bundles[(len(tmp) // 2):] + args.in_labels
     args.in_bundles = args.in_bundles[0:len(tmp) // 2]
-    assert_inputs_exist(parser, args.in_bundles+args.in_labels)
+    assert_inputs_exist(parser, args.in_bundles + args.in_labels,
+                        args.reference)
     assert_output_dirs_exist_and_empty(parser, args, [],
                                        optional=args.save_rendering)
 

--- a/scripts/scil_bundle_filter_by_occurence.py
+++ b/scripts/scil_bundle_filter_by_occurence.py
@@ -70,7 +70,7 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
-    assert_inputs_exist(parser, args.in_bundles)
+    assert_inputs_exist(parser, args.in_bundles, args.reference)
     output_streamlines_filename = '{}streamlines.trk'.format(
         args.output_prefix)
     output_voxels_filename = '{}voxels.nii.gz'.format(args.output_prefix)

--- a/scripts/scil_bundle_filter_by_occurence.py
+++ b/scripts/scil_bundle_filter_by_occurence.py
@@ -19,17 +19,15 @@ import logging
 
 from dipy.io.stateful_tractogram import StatefulTractogram
 from dipy.io.streamline import save_tractogram
-from dipy.io.utils import is_header_compatible, get_reference_info
+from dipy.io.utils import get_reference_info
 import nibabel as nib
 import numpy as np
 from scipy.sparse import dok_matrix
 
 from scilpy.io.streamlines import load_tractogram_with_reference
-from scilpy.io.utils import (add_overwrite_arg,
-                             add_reference_arg,
-                             add_verbose_arg,
-                             assert_inputs_exist,
-                             assert_outputs_exist)
+from scilpy.io.utils import (add_overwrite_arg, add_reference_arg,
+                             add_verbose_arg, assert_inputs_exist,
+                             assert_outputs_exist, assert_headers_compatible)
 from scilpy.tractanalysis.streamlines_metrics import compute_tract_counts_map
 from scilpy.tractograms.tractogram_operations import (
     intersection_robust, union_robust)
@@ -76,6 +74,8 @@ def main():
     output_voxels_filename = '{}voxels.nii.gz'.format(args.output_prefix)
     assert_outputs_exist(parser, args, [output_voxels_filename,
                                         output_streamlines_filename])
+    assert_headers_compatible(parser, args.in_bundles,
+                              reference=args.reference)
 
     if not 0 <= args.ratio_voxels <= 1 or not 0 <= args.ratio_streamlines <= 1:
         parser.error('Ratios must be between 0 and 1.')
@@ -88,9 +88,6 @@ def main():
         tmp_sft = load_tractogram_with_reference(parser, args, name)
         tmp_sft.to_vox()
         tmp_sft.to_corner()
-
-        if not is_header_compatible(args.reference, tmp_sft):
-            raise ValueError('Headers are not compatible.')
         sft_list.append(tmp_sft)
         fusion_streamlines.append(tmp_sft.streamlines)
 

--- a/scripts/scil_bundle_generate_priors.py
+++ b/scripts/scil_bundle_generate_priors.py
@@ -100,6 +100,7 @@ def main():
     sh_order = find_order_from_nb_coeff(sh_shape)
     sh_basis, is_legacy = parse_sh_basis_arg(args)
     img_mask = nib.load(args.in_mask)
+    mask_data = get_data_as_mask(img_mask, ref_img=img_sh)
 
     sft = load_tractogram_with_reference(parser, args, args.in_bundle)
     sft.to_vox()
@@ -114,9 +115,8 @@ def main():
         todi_obj.smooth_todi_spatial(sigma=args.todi_sigma)
 
         # Fancy masking of 1d indices to limit spatial dilation to WM
-        sub_mask_3d = np.logical_and(get_data_as_mask(img_mask),
-                                     todi_obj.reshape_to_3d(
-                                         todi_obj.get_mask()))
+        sub_mask_3d = np.logical_and(
+            mask_data, todi_obj.reshape_to_3d(todi_obj.get_mask()))
         sub_mask_1d = sub_mask_3d.flatten()[todi_obj.get_mask()]
         todi_sf = todi_obj.get_todi()[sub_mask_1d] ** 2
 
@@ -169,8 +169,7 @@ def main():
         endpoints_mask[tuple(streamline[0])] = 1
         endpoints_mask[tuple(streamline[-1])] = 1
 
-    in_mask_data = get_data_as_mask(img_mask)
-    nib.save(nib.Nifti1Image(endpoints_mask*in_mask_data,
+    nib.save(nib.Nifti1Image(endpoints_mask * mask_data,
                              img_mask.affine), out_endpoints_mask)
 
 

--- a/scripts/scil_bundle_generate_priors.py
+++ b/scripts/scil_bundle_generate_priors.py
@@ -26,7 +26,8 @@ from scilpy.io.utils import (add_overwrite_arg,
                              add_verbose_arg,
                              assert_inputs_exist,
                              assert_outputs_exist,
-                             parse_sh_basis_arg)
+                             parse_sh_basis_arg,
+                             assert_headers_compatible)
 from scilpy.reconst.utils import find_order_from_nb_coeff
 from scilpy.tractanalysis.todi import TrackOrientationDensityImaging
 
@@ -78,6 +79,7 @@ def main():
 
     required = [args.in_bundle, args.in_fodf, args.in_mask]
     assert_inputs_exist(parser, required)
+    assert_headers_compatible(parser, required)
 
     out_efod = os.path.join(args.out_dir,
                             '{0}efod.nii.gz'.format(args.out_prefix))
@@ -100,7 +102,7 @@ def main():
     sh_order = find_order_from_nb_coeff(sh_shape)
     sh_basis, is_legacy = parse_sh_basis_arg(args)
     img_mask = nib.load(args.in_mask)
-    mask_data = get_data_as_mask(img_mask, ref_img=img_sh)
+    mask_data = get_data_as_mask(img_mask)
 
     sft = load_tractogram_with_reference(parser, args, args.in_bundle)
     sft.to_vox()

--- a/scripts/scil_bundle_generate_priors.py
+++ b/scripts/scil_bundle_generate_priors.py
@@ -78,8 +78,8 @@ def main():
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
     required = [args.in_bundle, args.in_fodf, args.in_mask]
-    assert_inputs_exist(parser, required)
-    assert_headers_compatible(parser, required)
+    assert_inputs_exist(parser, required, args.reference)
+    assert_headers_compatible(parser, required, reference=args.reference)
 
     out_efod = os.path.join(args.out_dir,
                             '{0}efod.nii.gz'.format(args.out_prefix))

--- a/scripts/scil_bundle_mean_fixel_afd.py
+++ b/scripts/scil_bundle_mean_fixel_afd.py
@@ -63,7 +63,8 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
-    assert_inputs_exist(parser, [args.in_bundle, args.in_fodf])
+    assert_inputs_exist(parser, [args.in_bundle, args.in_fodf],
+                        args.reference)
     assert_outputs_exist(parser, args, [args.afd_mean_map])
 
     sft = load_tractogram_with_reference(parser, args, args.in_bundle)

--- a/scripts/scil_bundle_mean_fixel_afd.py
+++ b/scripts/scil_bundle_mean_fixel_afd.py
@@ -23,7 +23,7 @@ from scilpy.io.streamlines import load_tractogram_with_reference
 from scilpy.io.utils import (add_overwrite_arg, add_sh_basis_args,
                              add_reference_arg, add_verbose_arg,
                              assert_inputs_exist, assert_outputs_exist,
-                             parse_sh_basis_arg)
+                             parse_sh_basis_arg, assert_headers_compatible)
 from scilpy.tractanalysis.afd_along_streamlines \
     import afd_map_along_streamlines
 
@@ -66,6 +66,8 @@ def main():
     assert_inputs_exist(parser, [args.in_bundle, args.in_fodf],
                         args.reference)
     assert_outputs_exist(parser, args, [args.afd_mean_map])
+    assert_headers_compatible(parser, [args.in_bundle, args.in_fodf],
+                              reference=args.reference)
 
     sft = load_tractogram_with_reference(parser, args, args.in_bundle)
     fodf_img = nib.load(args.in_fodf)

--- a/scripts/scil_bundle_mean_fixel_bingham_metric.py
+++ b/scripts/scil_bundle_mean_fixel_bingham_metric.py
@@ -73,9 +73,9 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
-    assert_inputs_exist(parser, [args.in_bundle,
-                                 args.in_bingham,
-                                 args.in_bingham_metric])
+    assert_inputs_exist(parser, [args.in_bundle, args.in_bingham,
+                                 args.in_bingham_metric],
+                        args.reference)
     assert_outputs_exist(parser, args, [args.out_mean_map])
 
     sft = load_tractogram_with_reference(parser, args, args.in_bundle)

--- a/scripts/scil_bundle_mean_fixel_bingham_metric.py
+++ b/scripts/scil_bundle_mean_fixel_bingham_metric.py
@@ -32,10 +32,9 @@ import nibabel as nib
 import numpy as np
 
 from scilpy.io.streamlines import load_tractogram_with_reference
-from scilpy.io.utils import (add_overwrite_arg,
-                             add_reference_arg,
-                             add_verbose_arg,
-                             assert_inputs_exist, assert_outputs_exist)
+from scilpy.io.utils import (add_overwrite_arg, add_reference_arg,
+                             add_verbose_arg, assert_inputs_exist,
+                             assert_outputs_exist, assert_headers_compatible)
 from scilpy.tractanalysis.bingham_metric_along_streamlines \
     import bingham_metric_map_along_streamlines
 
@@ -77,6 +76,9 @@ def main():
                                  args.in_bingham_metric],
                         args.reference)
     assert_outputs_exist(parser, args, [args.out_mean_map])
+    assert_headers_compatible(parser, [args.in_bundle, args.in_bingham,
+                                       args.in_bingham_metric],
+                              reference=args.reference)
 
     sft = load_tractogram_with_reference(parser, args, args.in_bundle)
     bingham_img = nib.load(args.in_bingham)

--- a/scripts/scil_bundle_pairwise_comparison.py
+++ b/scripts/scil_bundle_pairwise_comparison.py
@@ -286,7 +286,7 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
-    assert_inputs_exist(parser, args.in_bundles)
+    assert_inputs_exist(parser, args.in_bundles, args.reference)
     assert_outputs_exist(parser, args, [args.out_json])
 
     if args.ratio and not args.single_compare:

--- a/scripts/scil_bundle_pairwise_comparison.py
+++ b/scripts/scil_bundle_pairwise_comparison.py
@@ -43,7 +43,7 @@ from scilpy.io.utils import (add_json_args,
                              assert_inputs_exist,
                              assert_outputs_exist,
                              link_bundles_and_reference,
-                             validate_nbr_processes)
+                             validate_nbr_processes, assert_headers_compatible)
 from scilpy.tractanalysis.reproducibility_measures \
     import (compute_dice_voxel,
             compute_bundle_adjacency_streamlines,
@@ -166,10 +166,6 @@ def compute_all_measures(args):
     disable_streamline_distance = args[3]
     ratio = args[4]
 
-    if not is_header_compatible(reference_1, reference_2):
-        raise ValueError('{} and {} have incompatible headers'.format(
-            filename_1, filename_2))
-
     data_tuple_1 = load_data_tmp_saving([filename_1, reference_1, False,
                                          disable_streamline_distance])
     if data_tuple_1 is None:
@@ -288,6 +284,8 @@ def main():
 
     assert_inputs_exist(parser, args.in_bundles, args.reference)
     assert_outputs_exist(parser, args, [args.out_json])
+    assert_headers_compatible(parser, args.in_bundles,
+                              reference=args.reference)
 
     if args.ratio and not args.single_compare:
         parser.error('Can only compute ratio if also using `single_compare`')

--- a/scripts/scil_bundle_score_many_bundles_one_tractogram.py
+++ b/scripts/scil_bundle_score_many_bundles_one_tractogram.py
@@ -94,7 +94,7 @@ def _build_arg_parser():
 
 def load_and_verify_everything(parser, args):
 
-    assert_inputs_exist(parser, [args.gt_config])
+    assert_inputs_exist(parser, args.gt_config, args.reference)
     if not os.path.isdir(args.bundles_dir):
         parser.error("Bundles dir ({}) does not exist."
                      .format(args.bundles_dir))

--- a/scripts/scil_bundle_score_same_bundle_many_segmentations.py
+++ b/scripts/scil_bundle_score_same_bundle_many_segmentations.py
@@ -217,9 +217,8 @@ def main():
     else:
         gs_binary_3d = get_data_as_mask(nib.load(args.voxels_measures[0]))
         gs_binary_3d[gs_binary_3d > 0] = 1
-        tracking_mask_data = get_data_as_mask(nib.load(
-                                                args.voxels_measures[1]))
-        tracking_mask_data[tracking_mask_data > 0] = 1
+        tracking_mask_data = get_data_as_mask(
+            nib.load(args.voxels_measures[1]), ref_shape=gs_binary_3d.shape)
 
     if nbr_cpu == 1:
         voxels_dict = []

--- a/scripts/scil_bundle_score_same_bundle_many_segmentations.py
+++ b/scripts/scil_bundle_score_same_bundle_many_segmentations.py
@@ -49,7 +49,7 @@ from scilpy.io.utils import (add_json_args,
                              assert_inputs_exist,
                              assert_outputs_exist,
                              link_bundles_and_reference,
-                             validate_nbr_processes)
+                             validate_nbr_processes, assert_headers_compatible)
 from scilpy.io.streamlines import load_tractogram_with_reference
 from scilpy.tractanalysis.streamlines_metrics import compute_tract_counts_map
 from scilpy.tractanalysis.reproducibility_measures import binary_classification
@@ -161,6 +161,8 @@ def main():
 
     assert_inputs_exist(parser, args.in_bundles, args.reference)
     assert_outputs_exist(parser, args, args.out_json)
+    assert_headers_compatible(parser, args.in_bundles,
+                              reference=args.reference)
 
     if (not args.streamlines_measures) and (not args.voxels_measures):
         parser.error('At least one of the two modes is needed')

--- a/scripts/scil_bundle_score_same_bundle_many_segmentations.py
+++ b/scripts/scil_bundle_score_same_bundle_many_segmentations.py
@@ -218,7 +218,7 @@ def main():
         gs_binary_3d = get_data_as_mask(nib.load(args.voxels_measures[0]))
         gs_binary_3d[gs_binary_3d > 0] = 1
         tracking_mask_data = get_data_as_mask(
-            nib.load(args.voxels_measures[1]), ref_shape=gs_binary_3d.shape)
+            nib.load(args.voxels_measures[1]))
 
     if nbr_cpu == 1:
         voxels_dict = []

--- a/scripts/scil_bundle_score_same_bundle_many_segmentations.py
+++ b/scripts/scil_bundle_score_same_bundle_many_segmentations.py
@@ -159,7 +159,7 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
-    assert_inputs_exist(parser, args.in_bundles)
+    assert_inputs_exist(parser, args.in_bundles, args.reference)
     assert_outputs_exist(parser, args, args.out_json)
 
     if (not args.streamlines_measures) and (not args.voxels_measures):

--- a/scripts/scil_bundle_shape_measures.py
+++ b/scripts/scil_bundle_shape_measures.py
@@ -199,7 +199,7 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
-    assert_inputs_exist(parser, args.in_bundles)
+    assert_inputs_exist(parser, args.in_bundles, args.reference)
     assert_outputs_exist(parser, args, [], args.out_json)
 
     nbr_cpu = validate_nbr_processes(parser, args)

--- a/scripts/scil_bundle_shape_measures.py
+++ b/scripts/scil_bundle_shape_measures.py
@@ -46,15 +46,11 @@ from dipy.tracking.metrics import mean_curvature
 from dipy.tracking.utils import length
 import numpy as np
 
-from scilpy.io.utils import (add_json_args,
-                             add_verbose_arg,
-                             add_overwrite_arg,
-                             add_processes_arg,
-                             add_reference_arg,
-                             assert_inputs_exist,
-                             assert_outputs_exist,
-                             link_bundles_and_reference,
-                             validate_nbr_processes)
+from scilpy.io.utils import (add_json_args, add_verbose_arg,
+                             add_overwrite_arg, add_processes_arg,
+                             add_reference_arg, assert_inputs_exist,
+                             assert_outputs_exist, link_bundles_and_reference,
+                             validate_nbr_processes, assert_headers_compatible)
 
 from scilpy.tractanalysis.reproducibility_measures \
     import (approximate_surface_node,
@@ -201,6 +197,8 @@ def main():
 
     assert_inputs_exist(parser, args.in_bundles, args.reference)
     assert_outputs_exist(parser, args, [], args.out_json)
+    assert_headers_compatible(parser, args.in_bundles,
+                              reference=args.reference)
 
     nbr_cpu = validate_nbr_processes(parser, args)
     bundles_references_tuple_extended = link_bundles_and_reference(

--- a/scripts/scil_clean_qbx_clusters.py
+++ b/scripts/scil_clean_qbx_clusters.py
@@ -151,7 +151,7 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
-    assert_inputs_exist(parser, args.in_bundles)
+    assert_inputs_exist(parser, args.in_bundles, args.reference)
     assert_outputs_exist(parser, args, [args.out_accepted, args.out_rejected])
 
     if args.out_accepted_dir:

--- a/scripts/scil_clean_qbx_clusters.py
+++ b/scripts/scil_clean_qbx_clusters.py
@@ -24,7 +24,6 @@ import logging
 from fury import window, actor, interactor
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
 from dipy.io.streamline import save_tractogram
-from dipy.io.utils import is_header_compatible
 
 from scilpy.io.streamlines import load_tractogram_with_reference
 from scilpy.io.utils import (add_bbox_arg,
@@ -33,7 +32,8 @@ from scilpy.io.utils import (add_bbox_arg,
                              add_verbose_arg,
                              assert_inputs_exist,
                              assert_outputs_exist,
-                             assert_output_dirs_exist_and_empty)
+                             assert_output_dirs_exist_and_empty,
+                             assert_headers_compatible)
 
 
 def _build_arg_parser():
@@ -153,6 +153,8 @@ def main():
 
     assert_inputs_exist(parser, args.in_bundles, args.reference)
     assert_outputs_exist(parser, args, [args.out_accepted, args.out_rejected])
+    assert_headers_compatible(parser, args.in_bundles,
+                              reference=args.reference)
 
     if args.out_accepted_dir:
         assert_output_dirs_exist_and_empty(parser, args,
@@ -181,8 +183,6 @@ def main():
     for filename in args.in_bundles:
         basename = os.path.basename(filename)
         sft = load_tractogram_with_reference(parser, args, filename)
-        if not is_header_compatible(ref_bundle, sft):
-            return
         if len(sft) >= args.min_cluster_size:
             sft_accepted_on_size.append(sft)
             filename_accepted_on_size.append(basename)

--- a/scripts/scil_denoising_nlmeans.py
+++ b/scripts/scil_denoising_nlmeans.py
@@ -21,7 +21,8 @@ from scilpy.io.utils import (add_processes_arg,
                              add_overwrite_arg,
                              add_verbose_arg,
                              assert_inputs_exist,
-                             assert_outputs_exist)
+                             assert_outputs_exist,
+                             assert_headers_compatible)
 
 
 def _build_arg_parser():
@@ -77,8 +78,9 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
-    assert_inputs_exist(parser, args.in_image)
+    assert_inputs_exist(parser, args.in_image, args.mask)
     assert_outputs_exist(parser, args, args.out_image, args.logfile)
+    assert_headers_compatible(parser, args.in_image, args.mask)
 
     if args.logfile is not None:
         logging.getLogger().addHandler(logging.FileHandler(args.logfile,
@@ -93,7 +95,7 @@ def main():
         else:
             mask[data > 0] = 1
     else:
-        mask = get_data_as_mask(nib.load(args.mask), dtype=bool, ref_img=vol)
+        mask = get_data_as_mask(nib.load(args.mask), dtype=bool)
 
     sigma = args.sigma
 

--- a/scripts/scil_denoising_nlmeans.py
+++ b/scripts/scil_denoising_nlmeans.py
@@ -93,7 +93,7 @@ def main():
         else:
             mask[data > 0] = 1
     else:
-        mask = get_data_as_mask(nib.load(args.mask), dtype=bool)
+        mask = get_data_as_mask(nib.load(args.mask), dtype=bool, ref_img=vol)
 
     sigma = args.sigma
 

--- a/scripts/scil_dki_metrics.py
+++ b/scripts/scil_dki_metrics.py
@@ -59,7 +59,8 @@ from scilpy.image.volume_operations import smooth_to_fwhm
 from scilpy.io.image import get_data_as_mask
 from scilpy.io.utils import (add_overwrite_arg, add_skip_b0_check_arg,
                              add_verbose_arg, assert_inputs_exist,
-                             assert_outputs_exist, add_tolerance_arg, )
+                             assert_outputs_exist, add_tolerance_arg,
+                             assert_headers_compatible, )
 from scilpy.gradients.bvec_bval_tools import (check_b0_threshold,
                                               is_normalized_bvecs,
                                               identify_shells,
@@ -174,13 +175,14 @@ def main():
     assert_inputs_exist(
         parser, [args.in_dwi, args.in_bval, args.in_bvec], args.mask)
     assert_outputs_exist(parser, args, outputs)
+    assert_headers_compatible(parser, args.in_dwi, args.mask)
 
     # Loading
     img = nib.load(args.in_dwi)
     data = img.get_fdata(dtype=np.float32)
     affine = img.affine
-    mask = get_data_as_mask(nib.load(args.mask), dtype=bool,
-                            ref_img=img) if args.mask else None
+    mask = get_data_as_mask(nib.load(args.mask),
+                            dtype=bool) if args.mask else None
 
     bvals, bvecs = read_bvals_bvecs(args.in_bval, args.in_bvec)
     if not is_normalized_bvecs(bvecs):

--- a/scripts/scil_dki_metrics.py
+++ b/scripts/scil_dki_metrics.py
@@ -60,7 +60,7 @@ from scilpy.io.image import get_data_as_mask
 from scilpy.io.utils import (add_overwrite_arg, add_skip_b0_check_arg,
                              add_verbose_arg, assert_inputs_exist,
                              assert_outputs_exist, add_tolerance_arg,
-                             assert_headers_compatible, )
+                             assert_headers_compatible)
 from scilpy.gradients.bvec_bval_tools import (check_b0_threshold,
                                               is_normalized_bvecs,
                                               identify_shells,

--- a/scripts/scil_dki_metrics.py
+++ b/scripts/scil_dki_metrics.py
@@ -179,11 +179,8 @@ def main():
     img = nib.load(args.in_dwi)
     data = img.get_fdata(dtype=np.float32)
     affine = img.affine
-    if args.mask is None:
-        mask = None
-    else:
-        mask_img = nib.load(args.mask)
-        mask = get_data_as_mask(mask_img, dtype=bool)
+    mask = get_data_as_mask(nib.load(args.mask), dtype=bool,
+                            ref_img=img) if args.mask else None
 
     bvals, bvecs = read_bvals_bvecs(args.in_bval, args.in_bvec)
     if not is_normalized_bvecs(bvecs):

--- a/scripts/scil_dti_metrics.py
+++ b/scripts/scil_dti_metrics.py
@@ -34,7 +34,6 @@ import numpy as np
 from dipy.core.gradients import gradient_table
 import dipy.denoise.noise_estimate as ne
 from dipy.io.gradients import read_bvals_bvecs
-from dipy.io.utils import is_header_compatible
 from dipy.reconst.dti import (TensorModel, color_fa, fractional_anisotropy,
                               geodesic_anisotropy, mean_diffusivity,
                               axial_diffusivity, norm,

--- a/scripts/scil_dti_metrics.py
+++ b/scripts/scil_dti_metrics.py
@@ -34,6 +34,7 @@ import numpy as np
 from dipy.core.gradients import gradient_table
 import dipy.denoise.noise_estimate as ne
 from dipy.io.gradients import read_bvals_bvecs
+from dipy.io.utils import is_header_compatible
 from dipy.reconst.dti import (TensorModel, color_fa, fractional_anisotropy,
                               geodesic_anisotropy, mean_diffusivity,
                               axial_diffusivity, norm,
@@ -46,7 +47,8 @@ from scilpy.dwi.operations import compute_residuals, \
 from scilpy.io.image import get_data_as_mask
 from scilpy.io.utils import (add_b0_thresh_arg, add_overwrite_arg,
                              add_skip_b0_check_arg, add_verbose_arg,
-                             assert_inputs_exist, assert_outputs_exist)
+                             assert_inputs_exist, assert_outputs_exist,
+                             assert_headers_compatible)
 from scilpy.io.tensor import convert_tensor_from_dipy_format, \
     supported_tensor_formats, tensor_format_description
 from scilpy.gradients.bvec_bval_tools import (check_b0_threshold,
@@ -250,13 +252,14 @@ def main():
     assert_inputs_exist(
         parser, [args.in_dwi, args.in_bval, args.in_bvec], args.mask)
     assert_outputs_exist(parser, args, outputs)
+    assert_headers_compatible(parser, args.in_dwi, args.mask)
 
     # Loading
     img = nib.load(args.in_dwi)
     data = img.get_fdata(dtype=np.float32)
     affine = img.affine
-    mask = get_data_as_mask(nib.load(args.mask), dtype=bool,
-                            ref_img=img) if args.mask else None
+    mask = get_data_as_mask(nib.load(args.mask),
+                            dtype=bool) if args.mask else None
 
     logging.info('Tensor estimation with the {} method...'.format(args.method))
     bvals, bvecs = read_bvals_bvecs(args.in_bval, args.in_bvec)

--- a/scripts/scil_dti_metrics.py
+++ b/scripts/scil_dti_metrics.py
@@ -255,10 +255,8 @@ def main():
     img = nib.load(args.in_dwi)
     data = img.get_fdata(dtype=np.float32)
     affine = img.affine
-    if args.mask is None:
-        mask = None
-    else:
-        mask = get_data_as_mask(nib.load(args.mask), dtype=bool)
+    mask = get_data_as_mask(nib.load(args.mask), dtype=bool,
+                            ref_img=img) if args.mask else None
 
     logging.info('Tensor estimation with the {} method...'.format(args.method))
     bvals, bvecs = read_bvals_bvecs(args.in_bval, args.in_bvec)

--- a/scripts/scil_dwi_apply_bias_field.py
+++ b/scripts/scil_dwi_apply_bias_field.py
@@ -61,8 +61,7 @@ def main():
     bias_field_data = bias_field_img.get_fdata(dtype=np.float32)
 
     if args.mask:
-        mask_img = nib.load(args.mask)
-        mask_data = get_data_as_mask(mask_img)
+        mask_data = get_data_as_mask(nib.load(args.mask), ref_img=dwi_img)
     else:
         mask_data = np.average(dwi_data, axis=-1) != 0
 

--- a/scripts/scil_dwi_apply_bias_field.py
+++ b/scripts/scil_dwi_apply_bias_field.py
@@ -17,10 +17,9 @@ import numpy as np
 
 from scilpy.dwi.operations import apply_bias_field
 from scilpy.io.image import get_data_as_mask
-from scilpy.io.utils import (add_overwrite_arg,
-                             add_verbose_arg,
-                             assert_inputs_exist,
-                             assert_outputs_exist, assert_headers_compatible)
+from scilpy.io.utils import (add_overwrite_arg, add_verbose_arg,
+                             assert_inputs_exist, assert_outputs_exist,
+                             assert_headers_compatible)
 
 
 def _build_arg_parser():

--- a/scripts/scil_dwi_apply_bias_field.py
+++ b/scripts/scil_dwi_apply_bias_field.py
@@ -20,7 +20,7 @@ from scilpy.io.image import get_data_as_mask
 from scilpy.io.utils import (add_overwrite_arg,
                              add_verbose_arg,
                              assert_inputs_exist,
-                             assert_outputs_exist)
+                             assert_outputs_exist, assert_headers_compatible)
 
 
 def _build_arg_parser():
@@ -53,6 +53,8 @@ def main():
 
     assert_inputs_exist(parser, [args.in_dwi, args.in_bias_field], args.mask)
     assert_outputs_exist(parser, args, args.out_name)
+    assert_headers_compatible(parser, [args.in_dwi, args.in_bias_field],
+                              args.mask)
 
     dwi_img = nib.load(args.in_dwi)
     dwi_data = dwi_img.get_fdata(dtype=np.float32)
@@ -61,7 +63,7 @@ def main():
     bias_field_data = bias_field_img.get_fdata(dtype=np.float32)
 
     if args.mask:
-        mask_data = get_data_as_mask(nib.load(args.mask), ref_img=dwi_img)
+        mask_data = get_data_as_mask(nib.load(args.mask))
     else:
         mask_data = np.average(dwi_data, axis=-1) != 0
 

--- a/scripts/scil_dwi_powder_average.py
+++ b/scripts/scil_dwi_powder_average.py
@@ -84,12 +84,8 @@ def main():
     img = nib.load(args.in_dwi)
     data = img.get_fdata(dtype=np.float32)
     affine = img.affine
-    if args.mask is None:
-        mask = None
-    else:
-        mask_img = nib.load(args.mask)
-        assert_same_resolution((img, mask_img))
-        mask = get_data_as_mask(mask_img, dtype='uint8')
+    mask = get_data_as_mask(nib.load(args.mask), dtype='uint8',
+                            ref_img=img) if args.mask else None
 
     # Read bvals (bvecs not needed at this point)
     logging.info('Performing powder average')

--- a/scripts/scil_dwi_powder_average.py
+++ b/scripts/scil_dwi_powder_average.py
@@ -26,9 +26,10 @@ import numpy as np
 from dipy.core.gradients import get_bval_indices
 from dipy.io.gradients import read_bvals_bvecs
 
-from scilpy.io.image import (get_data_as_mask, assert_same_resolution)
+from scilpy.io.image import get_data_as_mask
 from scilpy.io.utils import (add_overwrite_arg, assert_inputs_exist,
-                             assert_outputs_exist, add_verbose_arg)
+                             assert_outputs_exist, add_verbose_arg,
+                             assert_headers_compatible)
 
 
 def _build_arg_parser():
@@ -74,18 +75,15 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
-    inputs = [args.in_dwi, args.in_bval]
-    if args.mask:
-        inputs.append(args.mask)
-
-    assert_inputs_exist(parser, inputs)
+    assert_inputs_exist(parser, [args.in_dwi, args.in_bval], args.mask)
     assert_outputs_exist(parser, args, args.out_avg)
+    assert_headers_compatible(parser, args.in_dwi, args.mask)
 
     img = nib.load(args.in_dwi)
     data = img.get_fdata(dtype=np.float32)
     affine = img.affine
-    mask = get_data_as_mask(nib.load(args.mask), dtype='uint8',
-                            ref_img=img) if args.mask else None
+    mask = get_data_as_mask(nib.load(args.mask),
+                            dtype='uint8') if args.mask else None
 
     # Read bvals (bvecs not needed at this point)
     logging.info('Performing powder average')

--- a/scripts/scil_dwi_to_sh.py
+++ b/scripts/scil_dwi_to_sh.py
@@ -14,7 +14,6 @@ from dipy.core.gradients import gradient_table
 from dipy.io.gradients import read_bvals_bvecs
 import nibabel as nib
 import numpy as np
-from dipy.io.utils import is_header_compatible
 
 from scilpy.gradients.bvec_bval_tools import check_b0_threshold
 from scilpy.io.image import get_data_as_mask

--- a/scripts/scil_dwi_to_sh.py
+++ b/scripts/scil_dwi_to_sh.py
@@ -78,9 +78,8 @@ def main():
 
     sh_basis, is_legacy = parse_sh_basis_arg(args)
 
-    mask = None
-    if args.mask:
-        mask = get_data_as_mask(nib.load(args.mask), dtype=bool)
+    mask = get_data_as_mask(nib.load(args.mask), dtype=bool,
+                            ref_img=vol) if args.mask else None
 
     sh = compute_sh_coefficients(dwi, gtab, args.b0_threshold,
                                  args.sh_order, sh_basis, args.smooth,

--- a/scripts/scil_dwi_to_sh.py
+++ b/scripts/scil_dwi_to_sh.py
@@ -14,13 +14,15 @@ from dipy.core.gradients import gradient_table
 from dipy.io.gradients import read_bvals_bvecs
 import nibabel as nib
 import numpy as np
+from dipy.io.utils import is_header_compatible
 
 from scilpy.gradients.bvec_bval_tools import check_b0_threshold
 from scilpy.io.image import get_data_as_mask
 from scilpy.io.utils import (add_b0_thresh_arg, add_overwrite_arg,
                              add_sh_basis_args, add_skip_b0_check_arg,
                              add_verbose_arg, assert_inputs_exist,
-                             assert_outputs_exist, parse_sh_basis_arg)
+                             assert_outputs_exist, parse_sh_basis_arg,
+                             assert_headers_compatible)
 from scilpy.reconst.sh import compute_sh_coefficients
 
 
@@ -62,8 +64,10 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
-    assert_inputs_exist(parser, [args.in_dwi, args.in_bval, args.in_bvec])
+    assert_inputs_exist(parser, [args.in_dwi, args.in_bval, args.in_bvec],
+                        args.mask)
     assert_outputs_exist(parser, args, args.out_sh)
+    assert_headers_compatible(parser, args.in_dwi, args.mask)
 
     vol = nib.load(args.in_dwi)
     dwi = vol.get_fdata(dtype=np.float32)
@@ -78,8 +82,8 @@ def main():
 
     sh_basis, is_legacy = parse_sh_basis_arg(args)
 
-    mask = get_data_as_mask(nib.load(args.mask), dtype=bool,
-                            ref_img=vol) if args.mask else None
+    mask = get_data_as_mask(nib.load(args.mask),
+                            dtype=bool) if args.mask else None
 
     sh = compute_sh_coefficients(dwi, gtab, args.b0_threshold,
                                  args.sh_order, sh_basis, args.smooth,

--- a/scripts/scil_fodf_memsmt.py
+++ b/scripts/scil_fodf_memsmt.py
@@ -175,12 +175,8 @@ def main():
         tol=args.tolerance, skip_b0_check=args.skip_b0_check)
 
     # Checking mask
-    if args.mask is None:
-        mask = None
-    else:
-        mask = get_data_as_mask(nib.load(args.mask), dtype=bool)
-        if mask.shape != data.shape[:-1]:
-            raise ValueError("Mask is not the same shape as data.")
+    mask = get_data_as_mask(nib.load(args.mask), dtype=bool,
+                            ref_shape=data.shape) if args.mask else None
 
     # Checking data and sh_order
     verify_data_vs_sh_order(data, args.sh_order)

--- a/scripts/scil_fodf_memsmt.py
+++ b/scripts/scil_fodf_memsmt.py
@@ -55,7 +55,7 @@ from scilpy.io.utils import (add_overwrite_arg, add_processes_arg,
                              add_sh_basis_args, add_skip_b0_check_arg,
                              add_tolerance_arg, add_verbose_arg,
                              assert_inputs_exist, assert_outputs_exist,
-                             parse_sh_basis_arg)
+                             parse_sh_basis_arg, assert_headers_compatible)
 from scilpy.reconst.fodf import (fit_from_model,
                                  verify_failed_voxels_shm_coeff,
                                  verify_frf_files)
@@ -152,6 +152,7 @@ def main():
     required += [args.in_wm_frf, args.in_gm_frf, args.in_csf_frf]
     assert_inputs_exist(parser, required, optional=args.mask)
     assert_outputs_exist(parser, args, arglist)
+    assert_headers_compatible(parser, args.in_dwis, args.mask)
 
     if not (len(args.in_dwis) == len(args.in_bvals)
             == len(args.in_bvecs) == len(args.in_bdeltas)):
@@ -175,8 +176,8 @@ def main():
         tol=args.tolerance, skip_b0_check=args.skip_b0_check)
 
     # Checking mask
-    mask = get_data_as_mask(nib.load(args.mask), dtype=bool,
-                            ref_shape=data.shape) if args.mask else None
+    mask = get_data_as_mask(nib.load(args.mask),
+                            dtype=bool) if args.mask else None
 
     # Checking data and sh_order
     verify_data_vs_sh_order(data, args.sh_order)

--- a/scripts/scil_fodf_metrics.py
+++ b/scripts/scil_fodf_metrics.py
@@ -140,13 +140,8 @@ def main():
     vol = nib.load(args.in_fODF)
     data = vol.get_fdata(dtype=np.float32)
     affine = vol.affine
-
-    if args.mask is None:
-        mask = None
-    else:
-        mask = get_data_as_mask(nib.load(args.mask), dtype=bool)
-        if mask.shape != data.shape[:-1]:
-            raise ValueError("Mask is not the same shape as data.")
+    mask = get_data_as_mask(nib.load(args.mask), dtype=bool,
+                            ref_img=vol) if args.mask else None
 
     sphere = get_sphere(args.sphere)
     sh_basis, is_legacy = parse_sh_basis_arg(args)

--- a/scripts/scil_fodf_metrics.py
+++ b/scripts/scil_fodf_metrics.py
@@ -40,7 +40,6 @@ import nibabel as nib
 
 from dipy.data import get_sphere
 from dipy.direction.peaks import reshape_peaks_for_visualization
-from dipy.io.utils import is_header_compatible
 
 from scilpy.io.image import get_data_as_mask
 from scilpy.io.utils import (add_overwrite_arg, add_sh_basis_args,

--- a/scripts/scil_fodf_metrics.py
+++ b/scripts/scil_fodf_metrics.py
@@ -40,12 +40,13 @@ import nibabel as nib
 
 from dipy.data import get_sphere
 from dipy.direction.peaks import reshape_peaks_for_visualization
+from dipy.io.utils import is_header_compatible
 
 from scilpy.io.image import get_data_as_mask
 from scilpy.io.utils import (add_overwrite_arg, add_sh_basis_args,
                              add_processes_arg, add_verbose_arg,
                              assert_inputs_exist, assert_outputs_exist,
-                             parse_sh_basis_arg)
+                             parse_sh_basis_arg, assert_headers_compatible)
 from scilpy.reconst.sh import peaks_from_sh, maps_from_sh
 
 
@@ -133,15 +134,16 @@ def main():
         parser.error('When using --not_all, you need to specify at least '
                      'one file to output.')
 
-    assert_inputs_exist(parser, args.in_fODF)
+    assert_inputs_exist(parser, args.in_fODF, args.mask)
     assert_outputs_exist(parser, args, arglist)
+    assert_headers_compatible(parser, args.in_fODF, args.mask)
 
     # Loading
     vol = nib.load(args.in_fODF)
     data = vol.get_fdata(dtype=np.float32)
     affine = vol.affine
-    mask = get_data_as_mask(nib.load(args.mask), dtype=bool,
-                            ref_img=vol) if args.mask else None
+    mask = get_data_as_mask(nib.load(args.mask),
+                            dtype=bool) if args.mask else None
 
     sphere = get_sphere(args.sphere)
     sh_basis, is_legacy = parse_sh_basis_arg(args)

--- a/scripts/scil_fodf_msmt.py
+++ b/scripts/scil_fodf_msmt.py
@@ -143,12 +143,8 @@ def main():
     sh_basis, is_legacy = parse_sh_basis_arg(args)
 
     # Checking mask
-    if args.mask is None:
-        mask = None
-    else:
-        mask = get_data_as_mask(nib.load(args.mask), dtype=bool)
-        if mask.shape != data.shape[:-1]:
-            raise ValueError("Mask is not the same shape as data.")
+    mask = get_data_as_mask(nib.load(args.mask), dtype=bool,
+                            ref_img=vol) if args.mask else None
 
     # Checking bvals, bvecs values and loading gtab
     if not is_normalized_bvecs(bvecs):

--- a/scripts/scil_fodf_msmt.py
+++ b/scripts/scil_fodf_msmt.py
@@ -37,12 +37,11 @@ from scilpy.io.utils import (add_overwrite_arg, add_processes_arg,
                              assert_inputs_exist, assert_outputs_exist,
                              add_sh_basis_args, add_skip_b0_check_arg,
                              add_verbose_arg, add_tolerance_arg,
-                             parse_sh_basis_arg)
+                             parse_sh_basis_arg, assert_headers_compatible)
 from scilpy.reconst.fodf import (fit_from_model,
                                  verify_failed_voxels_shm_coeff,
                                  verify_frf_files)
 from scilpy.reconst.sh import convert_sh_basis, verify_data_vs_sh_order
-
 
 
 def _build_arg_parser():
@@ -126,8 +125,9 @@ def main():
 
     assert_inputs_exist(parser, [args.in_dwi, args.in_bval, args.in_bvec,
                                  args.in_wm_frf, args.in_gm_frf,
-                                 args.in_csf_frf])
+                                 args.in_csf_frf], args.mask)
     assert_outputs_exist(parser, args, arglist)
+    assert_headers_compatible(parser, args.in_dwi, args.mask)
 
     # Loading data
     wm_frf = np.loadtxt(args.in_wm_frf)
@@ -143,8 +143,8 @@ def main():
     sh_basis, is_legacy = parse_sh_basis_arg(args)
 
     # Checking mask
-    mask = get_data_as_mask(nib.load(args.mask), dtype=bool,
-                            ref_img=vol) if args.mask else None
+    mask = get_data_as_mask(nib.load(args.mask),
+                            dtype=bool) if args.mask else None
 
     # Checking bvals, bvecs values and loading gtab
     if not is_normalized_bvecs(bvecs):

--- a/scripts/scil_fodf_ssst.py
+++ b/scripts/scil_fodf_ssst.py
@@ -81,12 +81,8 @@ def main():
     bvals, bvecs = read_bvals_bvecs(args.in_bval, args.in_bvec)
 
     # Checking mask
-    if args.mask is None:
-        mask = None
-    else:
-        mask = get_data_as_mask(nib.load(args.mask), dtype=bool)
-        if mask.shape != data.shape[:-1]:
-            raise ValueError("Mask is not the same shape as data.")
+    mask = get_data_as_mask(nib.load(args.mask), dtype=bool,
+                            ref_img=vol) if args.mask else None
 
     sh_order = args.sh_order
     sh_basis, is_legacy = parse_sh_basis_arg(args)

--- a/scripts/scil_fodf_ssst.py
+++ b/scripts/scil_fodf_ssst.py
@@ -73,7 +73,7 @@ def main():
     assert_inputs_exist(parser, [args.in_dwi, args.in_bval, args.in_bvec,
                                  args.frf_file], args.mask)
     assert_outputs_exist(parser, args, args.out_fODF)
-    assert_headers_compatible(args.in_dwi, args.mask)
+    assert_headers_compatible(parser, args.in_dwi, args.mask)
 
     # Loading data
     full_frf = np.loadtxt(args.frf_file)

--- a/scripts/scil_fodf_ssst.py
+++ b/scripts/scil_fodf_ssst.py
@@ -27,7 +27,7 @@ from scilpy.io.utils import (add_b0_thresh_arg, add_overwrite_arg,
                              add_processes_arg, add_sh_basis_args,
                              add_skip_b0_check_arg, add_verbose_arg,
                              assert_inputs_exist, assert_outputs_exist,
-                             parse_sh_basis_arg)
+                             parse_sh_basis_arg, assert_headers_compatible)
 from scilpy.reconst.fodf import fit_from_model
 from scilpy.reconst.sh import convert_sh_basis
 
@@ -71,8 +71,9 @@ def main():
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
     assert_inputs_exist(parser, [args.in_dwi, args.in_bval, args.in_bvec,
-                                 args.frf_file])
+                                 args.frf_file], args.mask)
     assert_outputs_exist(parser, args, args.out_fODF)
+    assert_headers_compatible(args.in_dwi, args.mask)
 
     # Loading data
     full_frf = np.loadtxt(args.frf_file)
@@ -81,8 +82,8 @@ def main():
     bvals, bvecs = read_bvals_bvecs(args.in_bval, args.in_bvec)
 
     # Checking mask
-    mask = get_data_as_mask(nib.load(args.mask), dtype=bool,
-                            ref_img=vol) if args.mask else None
+    mask = get_data_as_mask(nib.load(args.mask),
+                            dtype=bool) if args.mask else None
 
     sh_order = args.sh_order
     sh_basis, is_legacy = parse_sh_basis_arg(args)

--- a/scripts/scil_fodf_to_bingham.py
+++ b/scripts/scil_fodf_to_bingham.py
@@ -89,8 +89,8 @@ def main():
 
     sh_im = nib.load(args.in_sh)
     data = sh_im.get_fdata()
-    mask = get_data_as_mask(nib.load(args.mask), dtype=bool)\
-        if args.mask else None
+    mask = get_data_as_mask(nib.load(args.mask), dtype=bool,
+                            ref_img=sh_im) if args.mask else None
 
     # validate number of processes
     nbr_processes = validate_nbr_processes(parser, args)

--- a/scripts/scil_fodf_to_bingham.py
+++ b/scripts/scil_fodf_to_bingham.py
@@ -20,14 +20,10 @@ import time
 import argparse
 import logging
 
-from dipy.io.utils import is_header_compatible
-
-from scilpy.io.utils import (add_overwrite_arg,
-                             add_processes_arg,
-                             add_verbose_arg,
-                             assert_inputs_exist,
-                             assert_outputs_exist,
-                             validate_nbr_processes, assert_headers_compatible)
+from scilpy.io.utils import (add_overwrite_arg, add_processes_arg,
+                             add_verbose_arg, assert_inputs_exist,
+                             assert_outputs_exist, validate_nbr_processes,
+                             assert_headers_compatible)
 from scilpy.io.image import get_data_as_mask
 from scilpy.reconst.bingham import (bingham_fit_sh)
 

--- a/scripts/scil_fodf_to_bingham.py
+++ b/scripts/scil_fodf_to_bingham.py
@@ -20,12 +20,14 @@ import time
 import argparse
 import logging
 
+from dipy.io.utils import is_header_compatible
+
 from scilpy.io.utils import (add_overwrite_arg,
                              add_processes_arg,
                              add_verbose_arg,
                              assert_inputs_exist,
                              assert_outputs_exist,
-                             validate_nbr_processes)
+                             validate_nbr_processes, assert_headers_compatible)
 from scilpy.io.image import get_data_as_mask
 from scilpy.reconst.bingham import (bingham_fit_sh)
 
@@ -86,11 +88,12 @@ def main():
 
     assert_inputs_exist(parser, args.in_sh, args.mask)
     assert_outputs_exist(parser, args, args.out_bingham)
+    assert_headers_compatible(parser, args.in_sh, args.mask)
 
     sh_im = nib.load(args.in_sh)
     data = sh_im.get_fdata()
-    mask = get_data_as_mask(nib.load(args.mask), dtype=bool,
-                            ref_img=sh_im) if args.mask else None
+    mask = get_data_as_mask(nib.load(args.mask),
+                            dtype=bool) if args.mask else None
 
     # validate number of processes
     nbr_processes = validate_nbr_processes(parser, args)

--- a/scripts/scil_frf_memsmt.py
+++ b/scripts/scil_frf_memsmt.py
@@ -53,7 +53,8 @@ from scilpy.io.image import get_data_as_mask
 from scilpy.io.utils import (add_overwrite_arg, add_verbose_arg,
                              assert_inputs_exist, assert_outputs_exist,
                              assert_roi_radii_format, add_skip_b0_check_arg,
-                             add_tolerance_arg)
+                             add_tolerance_arg,
+                             assert_headers_compatible)
 from scilpy.reconst.frf import compute_msmt_frf
 
 
@@ -179,12 +180,12 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
-    assert_inputs_exist(parser, [],
-                        optional=list(np.concatenate((args.in_dwis,
-                                                      args.in_bvals,
-                                                      args.in_bvecs))))
+    masks = [args.mask, args.mask_wm, args.mask_gm, args.mask_csf]
+    assert_inputs_exist(parser, args.in_dwis + args.in_bvals + args.in_bvecs,
+                        optional=masks)
     assert_outputs_exist(parser, args, [args.out_wm_frf, args.out_gm_frf,
                                         args.out_csf_frf])
+    assert_headers_compatible(parser, args.in_dwis, masks)
 
     if not (len(args.in_dwis) == len(args.in_bvals)
             == len(args.in_bvecs) == len(args.in_bdeltas)):
@@ -227,14 +228,14 @@ def main():
         bvecs_dti = None
         btens_dti = None
 
-    mask = get_data_as_mask(nib.load(args.mask), dtype=bool,
-                            ref_shape=data.shape) if args.mask else None
-    mask_wm = get_data_as_mask(nib.load(args.mask_wm), dtype=bool,
-                               ref_shape=data.shape) if args.mask_wm else None
-    mask_gm = get_data_as_mask(nib.load(args.mask_gm), dtype=bool,
-                               ref_shape=data.shape) if args.mask_gm else None
-    mask_csf = get_data_as_mask(nib.load(args.mask_csf), dtype=bool,
-                                ref_shape=data.shape) if args.mask_csf else None
+    mask = get_data_as_mask(nib.load(args.mask),
+                            dtype=bool) if args.mask else None
+    mask_wm = get_data_as_mask(nib.load(args.mask_wm),
+                               dtype=bool) if args.mask_wm else None
+    mask_gm = get_data_as_mask(nib.load(args.mask_gm),
+                               dtype=bool) if args.mask_gm else None
+    mask_csf = get_data_as_mask(nib.load(args.mask_csf),
+                                dtype=bool) if args.mask_csf else None
 
     responses, frf_masks = compute_msmt_frf(data, gtab.bvals, gtab.bvecs,
                                             btens=gtab.btens,

--- a/scripts/scil_frf_memsmt.py
+++ b/scripts/scil_frf_memsmt.py
@@ -227,20 +227,14 @@ def main():
         bvecs_dti = None
         btens_dti = None
 
-    mask = None
-    if args.mask is not None:
-        mask = get_data_as_mask(nib.load(args.mask), dtype=bool)
-        if mask.shape != data.shape[:-1]:
-            raise ValueError("Mask is not the same shape as data.")
-    mask_wm = None
-    mask_gm = None
-    mask_csf = None
-    if args.mask_wm:
-        mask_wm = get_data_as_mask(nib.load(args.mask_wm), dtype=bool)
-    if args.mask_gm:
-        mask_gm = get_data_as_mask(nib.load(args.mask_gm), dtype=bool)
-    if args.mask_csf:
-        mask_csf = get_data_as_mask(nib.load(args.mask_csf), dtype=bool)
+    mask = get_data_as_mask(nib.load(args.mask), dtype=bool,
+                            ref_shape=data.shape) if args.mask else None
+    mask_wm = get_data_as_mask(nib.load(args.mask_wm), dtype=bool,
+                               ref_shape=data.shape) if args.mask_wm else None
+    mask_gm = get_data_as_mask(nib.load(args.mask_gm), dtype=bool,
+                               ref_shape=data.shape) if args.mask_gm else None
+    mask_csf = get_data_as_mask(nib.load(args.mask_csf), dtype=bool,
+                                ref_shape=data.shape) if args.mask_csf else None
 
     responses, frf_masks = compute_msmt_frf(data, gtab.bvals, gtab.bvecs,
                                             btens=gtab.btens,

--- a/scripts/scil_frf_msmt.py
+++ b/scripts/scil_frf_msmt.py
@@ -176,20 +176,14 @@ def main():
         bvals_dti = None
         bvecs_dti = None
 
-    mask = None
-    if args.mask is not None:
-        mask = get_data_as_mask(nib.load(args.mask), dtype=bool)
-        if mask.shape != data.shape[:-1]:
-            raise ValueError("Mask is not the same shape as data.")
-    mask_wm = None
-    mask_gm = None
-    mask_csf = None
-    if args.mask_wm:
-        mask_wm = get_data_as_mask(nib.load(args.mask_wm), dtype=bool)
-    if args.mask_gm:
-        mask_gm = get_data_as_mask(nib.load(args.mask_gm), dtype=bool)
-    if args.mask_csf:
-        mask_csf = get_data_as_mask(nib.load(args.mask_csf), dtype=bool)
+    mask = get_data_as_mask(nib.load(args.mask), dtype=bool,
+                            ref_img=vol) if args.mask else None
+    mask_wm = get_data_as_mask(nib.load(args.mask_wm), dtype=bool,
+                               ref_img=vol) if args.mask_wm else None
+    mask_gm = get_data_as_mask(nib.load(args.mask_gm), dtype=bool,
+                               ref_img=vol) if args.mask_gm else None
+    mask_csf = get_data_as_mask(nib.load(args.mask_csf), dtype=bool,
+                                ref_img=vol) if args.mask_csf else None
 
     # Processing
     responses, frf_masks = compute_msmt_frf(data, bvals, bvecs,

--- a/scripts/scil_frf_msmt.py
+++ b/scripts/scil_frf_msmt.py
@@ -38,7 +38,8 @@ from scilpy.gradients.bvec_bval_tools import check_b0_threshold
 from scilpy.io.image import get_data_as_mask
 from scilpy.io.utils import (add_overwrite_arg, add_skip_b0_check_arg,
                              add_verbose_arg, assert_inputs_exist,
-                             assert_outputs_exist, assert_roi_radii_format)
+                             assert_outputs_exist, assert_roi_radii_format,
+                             assert_headers_compatible)
 from scilpy.reconst.frf import compute_msmt_frf
 
 
@@ -147,9 +148,13 @@ def main():
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
     # Verifications
-    assert_inputs_exist(parser, [args.in_dwi, args.in_bval, args.in_bvec])
+    masks = [args.mask, args.mask_wm, args.mask_gm, args.mask_csf]
+    assert_inputs_exist(parser, [args.in_dwi, args.in_bval, args.in_bvec],
+                        optional=masks)
     assert_outputs_exist(parser, args, [args.out_wm_frf, args.out_gm_frf,
                                         args.out_csf_frf])
+    assert_headers_compatible(parser, [args.in_bundle, args.in_fodf],
+                              optional=masks)
 
     roi_radii = assert_roi_radii_format(parser)
 

--- a/scripts/scil_frf_msmt.py
+++ b/scripts/scil_frf_msmt.py
@@ -153,8 +153,7 @@ def main():
                         optional=masks)
     assert_outputs_exist(parser, args, [args.out_wm_frf, args.out_gm_frf,
                                         args.out_csf_frf])
-    assert_headers_compatible(parser, [args.in_bundle, args.in_fodf],
-                              optional=masks)
+    assert_headers_compatible(parser, args.in_dwi, optional=masks)
 
     roi_radii = assert_roi_radii_format(parser)
 

--- a/scripts/scil_frf_msmt.py
+++ b/scripts/scil_frf_msmt.py
@@ -176,14 +176,14 @@ def main():
         bvals_dti = None
         bvecs_dti = None
 
-    mask = get_data_as_mask(nib.load(args.mask), dtype=bool,
-                            ref_img=vol) if args.mask else None
-    mask_wm = get_data_as_mask(nib.load(args.mask_wm), dtype=bool,
-                               ref_img=vol) if args.mask_wm else None
-    mask_gm = get_data_as_mask(nib.load(args.mask_gm), dtype=bool,
-                               ref_img=vol) if args.mask_gm else None
-    mask_csf = get_data_as_mask(nib.load(args.mask_csf), dtype=bool,
-                                ref_img=vol) if args.mask_csf else None
+    mask = get_data_as_mask(nib.load(args.mask),
+                            dtype=bool) if args.mask else None
+    mask_wm = get_data_as_mask(nib.load(args.mask_wm),
+                               dtype=bool) if args.mask_wm else None
+    mask_gm = get_data_as_mask(nib.load(args.mask_gm),
+                               dtype=bool) if args.mask_gm else None
+    mask_csf = get_data_as_mask(nib.load(args.mask_csf),
+                                dtype=bool) if args.mask_csf else None
 
     # Processing
     responses, frf_masks = compute_msmt_frf(data, bvals, bvecs,

--- a/scripts/scil_frf_ssst.py
+++ b/scripts/scil_frf_ssst.py
@@ -22,7 +22,8 @@ from scilpy.io.image import get_data_as_mask
 from scilpy.io.utils import (add_b0_thresh_arg, add_overwrite_arg,
                              add_skip_b0_check_arg, add_verbose_arg,
                              assert_inputs_exist, assert_outputs_exist,
-                             assert_roi_radii_format)
+                             assert_roi_radii_format,
+                             assert_headers_compatible)
 from scilpy.reconst.frf import compute_ssst_frf
 
 
@@ -90,8 +91,10 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
-    assert_inputs_exist(parser, [args.in_dwi, args.in_bval, args.in_bvec])
+    assert_inputs_exist(parser, [args.in_dwi, args.in_bval, args.in_bvec],
+                        [args.mask, args.mask_wm])
     assert_outputs_exist(parser, args, args.frf_file)
+    assert_headers_compatible(parser, args.in_dwi, [args.mask, args.mask_wm])
 
     roi_radii = assert_roi_radii_format(parser)
 
@@ -103,10 +106,10 @@ def main():
                                            b0_thr=args.b0_threshold,
                                            skip_b0_check=args.skip_b0_check)
 
-    mask = get_data_as_mask(nib.load(args.mask), dtype=bool,
-                            ref_img=vol) if args.mask else None
-    mask_wm = get_data_as_mask(nib.load(args.mask_wm), dtype=bool,
-                               ref_img=vol) if args.mask_wm else None
+    mask = get_data_as_mask(nib.load(args.mask),
+                            dtype=bool) if args.mask else None
+    mask_wm = get_data_as_mask(nib.load(args.mask_wm),
+                               dtype=bool) if args.mask_wm else None
 
     full_response = compute_ssst_frf(
         data, bvals, bvecs, args.b0_threshold, mask=mask,

--- a/scripts/scil_frf_ssst.py
+++ b/scripts/scil_frf_ssst.py
@@ -102,13 +102,11 @@ def main():
     args.b0_threshold = check_b0_threshold(bvals.min(),
                                            b0_thr=args.b0_threshold,
                                            skip_b0_check=args.skip_b0_check)
-    mask = None
-    if args.mask:
-        mask = get_data_as_mask(nib.load(args.mask), dtype=bool)
 
-    mask_wm = None
-    if args.mask_wm:
-        mask_wm = get_data_as_mask(nib.load(args.mask_wm), dtype=bool)
+    mask = get_data_as_mask(nib.load(args.mask), dtype=bool,
+                            ref_img=vol) if args.mask else None
+    mask_wm = get_data_as_mask(nib.load(args.mask_wm), dtype=bool,
+                               ref_img=vol) if args.mask_wm else None
 
     full_response = compute_ssst_frf(
         data, bvals, bvecs, args.b0_threshold, mask=mask,

--- a/scripts/scil_gradients_validate_correct.py
+++ b/scripts/scil_gradients_validate_correct.py
@@ -31,7 +31,8 @@ import numpy as np
 import nibabel as nib
 
 from scilpy.io.utils import (add_overwrite_arg, assert_inputs_exist,
-                             assert_outputs_exist, add_verbose_arg)
+                             assert_outputs_exist, add_verbose_arg,
+                             assert_headers_compatible)
 from scilpy.io.image import get_data_as_mask
 from scilpy.reconst.fiber_coherence import compute_fiber_coherence_table
 
@@ -82,6 +83,8 @@ def main():
 
     assert_inputs_exist(parser, inputs, optional=optional)
     assert_outputs_exist(parser, args, args.out_bvec)
+    assert_headers_compatible(parser, [args.in_peaks, args.in_FA],
+                              optional=optional)
 
     _, bvecs = read_bvals_bvecs(None, args.in_bvec)
     fa = nib.load(args.in_FA).get_fdata()

--- a/scripts/scil_gradients_validate_correct.py
+++ b/scripts/scil_gradients_validate_correct.py
@@ -101,7 +101,7 @@ def main():
 
     peaks = np.squeeze(peaks)
     if args.mask:
-        mask = get_data_as_mask(nib.load(args.mask))
+        mask = get_data_as_mask(nib.load(args.mask), ref_shape=peaks.shape)
         fa[np.logical_not(mask)] = 0
         peaks[np.logical_not(mask)] = 0
 

--- a/scripts/scil_gradients_validate_correct.py
+++ b/scripts/scil_gradients_validate_correct.py
@@ -78,13 +78,11 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
-    inputs = [args.in_bvec, args.in_peaks, args.in_FA]
-    optional = [args.mask]
-
-    assert_inputs_exist(parser, inputs, optional=optional)
+    assert_inputs_exist(parser, [args.in_bvec, args.in_peaks, args.in_FA],
+                        optional=args.mask)
     assert_outputs_exist(parser, args, args.out_bvec)
     assert_headers_compatible(parser, [args.in_peaks, args.in_FA],
-                              optional=optional)
+                              optional=args.mask)
 
     _, bvecs = read_bvals_bvecs(None, args.in_bvec)
     fa = nib.load(args.in_FA).get_fdata()

--- a/scripts/scil_header_validate_compatibility.py
+++ b/scripts/scil_header_validate_compatibility.py
@@ -17,7 +17,7 @@ from scilpy.io.utils import (
     add_reference_arg,
     add_verbose_arg,
     assert_inputs_exist,
-    is_header_compatible_multiple_files)
+    assert_headers_compatible)
 
 
 def _build_arg_parser():
@@ -39,9 +39,9 @@ def main():
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
     assert_inputs_exist(parser, args.in_files)
-    is_header_compatible_multiple_files(parser, args.in_files,
-                                        verbose_all_compatible=True,
-                                        reference=args.reference)
+    assert_headers_compatible(parser, args.in_files,
+                              verbose_all_compatible=True,
+                              reference=args.reference)
 
 
 if __name__ == "__main__":

--- a/scripts/scil_header_validate_compatibility.py
+++ b/scripts/scil_header_validate_compatibility.py
@@ -38,7 +38,7 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
-    assert_inputs_exist(parser, args.in_files)
+    assert_inputs_exist(parser, args.in_files, args.reference)
     assert_headers_compatible(parser, args.in_files,
                               verbose_all_compatible=True,
                               reference=args.reference)

--- a/scripts/scil_header_validate_compatibility.py
+++ b/scripts/scil_header_validate_compatibility.py
@@ -40,8 +40,10 @@ def main():
 
     assert_inputs_exist(parser, args.in_files, args.reference)
     assert_headers_compatible(parser, args.in_files,
-                              verbose_all_compatible=True,
                               reference=args.reference)
+
+    # If we come here, it means there was no error.
+    print('All input files have compatible headers.')
 
 
 if __name__ == "__main__":

--- a/scripts/scil_labels_dilate.py
+++ b/scripts/scil_labels_dilate.py
@@ -83,11 +83,8 @@ def main():
     data = get_data_as_labels(volume_nib)
     vox_size = np.reshape(volume_nib.header.get_zooms(), (1, 3))
 
-    if args.mask:
-        mask_nib = nib.load(args.mask)
-        mask_data = get_data_as_mask(mask_nib)
-    else:
-        mask_data = None
+    mask_data = get_data_as_mask(nib.load(args.mask),
+                                 ref_img=volume_nib) if args.mask else None
 
     data = dilate_labels(data, vox_size, args.distance, args.nbr_processes,
                          labels_to_dilate=args.labels_to_dilate,

--- a/scripts/scil_labels_dilate.py
+++ b/scripts/scil_labels_dilate.py
@@ -27,7 +27,7 @@ from scilpy.image.labels import get_data_as_labels, dilate_labels
 from scilpy.io.image import get_data_as_mask
 from scilpy.io.utils import (add_overwrite_arg, add_processes_arg,
                              assert_inputs_exist, add_verbose_arg,
-                             assert_outputs_exist)
+                             assert_outputs_exist, assert_headers_compatible)
 
 EPILOG = """
     References:
@@ -74,6 +74,7 @@ def main():
 
     assert_inputs_exist(parser, args.in_file, optional=args.mask)
     assert_outputs_exist(parser, args, args.out_file)
+    assert_headers_compatible(parser, args.in_file, optional=args.mask)
 
     if args.nbr_processes is None:
         args.nbr_processes = -1
@@ -83,8 +84,7 @@ def main():
     data = get_data_as_labels(volume_nib)
     vox_size = np.reshape(volume_nib.header.get_zooms(), (1, 3))
 
-    mask_data = get_data_as_mask(nib.load(args.mask),
-                                 ref_img=volume_nib) if args.mask else None
+    mask_data = get_data_as_mask(nib.load(args.mask)) if args.mask else None
 
     data = dilate_labels(data, vox_size, args.distance, args.nbr_processes,
                          labels_to_dilate=args.labels_to_dilate,

--- a/scripts/scil_lesions_info.py
+++ b/scripts/scil_lesions_info.py
@@ -81,7 +81,7 @@ def main():
 
     assert_inputs_exist(parser, [args.in_lesion],
                         optional=[args.bundle, args.bundle_mask,
-                                  args.bundle_labels_map])
+                                  args.bundle_labels_map, args.reference])
     assert_outputs_exist(parser, args, args.out_json,
                          optional=[args.out_lesion_stats,
                                    args.out_streamlines_stats])

--- a/scripts/scil_lesions_info.py
+++ b/scripts/scil_lesions_info.py
@@ -30,7 +30,7 @@ from scilpy.io.utils import (add_overwrite_arg,
                              add_json_args,
                              assert_outputs_exist,
                              add_verbose_arg,
-                             add_reference_arg)
+                             add_reference_arg, assert_headers_compatible)
 from scilpy.segment.streamlines import filter_grid_roi
 from scilpy.tractanalysis.streamlines_metrics import compute_tract_counts_map
 from scilpy.utils.filenames import split_name_with_nii
@@ -85,6 +85,10 @@ def main():
     assert_outputs_exist(parser, args, args.out_json,
                          optional=[args.out_lesion_stats,
                                    args.out_streamlines_stats])
+    assert_headers_compatible(parser, args.in_lesion,
+                              optional=[args.bundle, args.bundle_mask,
+                                        args.bundle_labels_map],
+                              reference=args.reference)
 
     lesion_img = nib.load(args.in_lesion)
     lesion_data = get_data_as_mask(lesion_img, dtype=bool)
@@ -102,7 +106,7 @@ def main():
         bundle_name, _ = split_name_with_nii(
             os.path.basename(args.bundle_mask))
         map_img = nib.load(args.bundle_mask)
-        map_data = get_data_as_mask(map_img, ref_img=lesion_img)
+        map_data = get_data_as_mask(map_img)
     else:
         bundle_name, _ = split_name_with_nii(os.path.basename(
             args.bundle_labels_map))

--- a/scripts/scil_lesions_info.py
+++ b/scripts/scil_lesions_info.py
@@ -102,7 +102,7 @@ def main():
         bundle_name, _ = split_name_with_nii(
             os.path.basename(args.bundle_mask))
         map_img = nib.load(args.bundle_mask)
-        map_data = get_data_as_mask(map_img)
+        map_data = get_data_as_mask(map_img, ref_img=lesion_img)
     else:
         bundle_name, _ = split_name_with_nii(os.path.basename(
             args.bundle_labels_map))

--- a/scripts/scil_lesions_info.py
+++ b/scripts/scil_lesions_info.py
@@ -25,12 +25,10 @@ import scipy.ndimage as ndi
 from scilpy.image.labels import get_data_as_labels
 from scilpy.io.image import get_data_as_mask
 from scilpy.io.streamlines import load_tractogram_with_reference
-from scilpy.io.utils import (add_overwrite_arg,
-                             assert_inputs_exist,
-                             add_json_args,
-                             assert_outputs_exist,
-                             add_verbose_arg,
-                             add_reference_arg, assert_headers_compatible)
+from scilpy.io.utils import (add_overwrite_arg, assert_inputs_exist,
+                             add_json_args, assert_outputs_exist,
+                             add_verbose_arg, add_reference_arg,
+                             assert_headers_compatible)
 from scilpy.segment.streamlines import filter_grid_roi
 from scilpy.tractanalysis.streamlines_metrics import compute_tract_counts_map
 from scilpy.utils.filenames import split_name_with_nii
@@ -79,7 +77,7 @@ def main():
             and (not args.bundle_labels_map):
         parser.error('One of the option --bundle or --map must be used')
 
-    assert_inputs_exist(parser, [args.in_lesion],
+    assert_inputs_exist(parser, args.in_lesion,
                         optional=[args.bundle, args.bundle_mask,
                                   args.bundle_labels_map, args.reference])
     assert_outputs_exist(parser, args, args.out_json,

--- a/scripts/scil_outlier_rejection.py
+++ b/scripts/scil_outlier_rejection.py
@@ -53,7 +53,7 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
-    assert_inputs_exist(parser, args.in_bundle)
+    assert_inputs_exist(parser, args.in_bundle, args.reference)
     assert_outputs_exist(parser, args, args.out_bundle, args.remaining_bundle)
     if args.alpha <= 0 or args.alpha > 1:
         parser.error('--alpha should be ]0, 1]')

--- a/scripts/scil_qball_metrics.py
+++ b/scripts/scil_qball_metrics.py
@@ -142,13 +142,8 @@ def main():
     sphere = get_sphere('symmetric724')
     sh_basis, _ = parse_sh_basis_arg(args)
 
-    mask = None
-    if args.mask:
-        mask = get_data_as_mask(nib.load(args.mask))
-
-        # Sanity check on shape of mask
-        if mask.shape != data.shape[:-1]:
-            raise ValueError('Mask shape does not match data shape.')
+    mask = get_data_as_mask(nib.load(args.mask),
+                            ref_img=img) if args.mask else None
 
     if args.use_qball:
         model = QballModel(gtab, sh_order=args.sh_order,

--- a/scripts/scil_qball_metrics.py
+++ b/scripts/scil_qball_metrics.py
@@ -118,7 +118,7 @@ def main():
 
     assert_inputs_exist(parser, [args.in_dwi, args.in_bval, args.in_bvec],
                         args.mask)
-    assert_outputs_exist(parser, args, arglist)
+    assert_outputs_exist(parser, args, [], optional=arglist)
     assert_headers_compatible(parser, args.in_dwi, args.mask)
 
     nbr_processes = validate_nbr_processes(parser, args)

--- a/scripts/scil_qball_metrics.py
+++ b/scripts/scil_qball_metrics.py
@@ -37,7 +37,8 @@ from scilpy.io.utils import (add_b0_thresh_arg, add_overwrite_arg,
                              add_processes_arg, add_sh_basis_args,
                              add_skip_b0_check_arg, add_verbose_arg,
                              assert_inputs_exist, assert_outputs_exist,
-                             parse_sh_basis_arg, validate_nbr_processes)
+                             parse_sh_basis_arg, validate_nbr_processes,
+                             assert_headers_compatible)
 
 
 DEFAULT_SMOOTH = 0.006
@@ -115,8 +116,10 @@ def main():
         parser.error('When using --not_all, you need to specify at least one '
                      'file to output.')
 
-    assert_inputs_exist(parser, [args.in_dwi, args.in_bval, args.in_bvec])
-    assert_outputs_exist(parser, args, [], optional=arglist)
+    assert_inputs_exist(parser, [args.in_dwi, args.in_bval, args.in_bvec],
+                        args.mask)
+    assert_outputs_exist(parser, args, arglist)
+    assert_headers_compatible(parser, args.in_dwi, args.mask)
 
     nbr_processes = validate_nbr_processes(parser, args)
     parallel = nbr_processes > 1
@@ -142,8 +145,7 @@ def main():
     sphere = get_sphere('symmetric724')
     sh_basis, _ = parse_sh_basis_arg(args)
 
-    mask = get_data_as_mask(nib.load(args.mask),
-                            ref_img=img) if args.mask else None
+    mask = get_data_as_mask(nib.load(args.mask)) if args.mask else None
 
     if args.use_qball:
         model = QballModel(gtab, sh_order=args.sh_order,

--- a/scripts/scil_score_tractogram.py
+++ b/scripts/scil_score_tractogram.py
@@ -173,7 +173,7 @@ def load_and_verify_everything(parser, args):
     args.json_prefix = os.path.join(args.out_dir, args.json_prefix)
     json_outputs = [args.json_prefix + 'processing_stats.json',
                     args.json_prefix + 'results.json']
-    assert_inputs_exist(parser, args.gt_config)
+    assert_inputs_exist(parser, args.gt_config, args.reference)
     assert_output_dirs_exist_and_empty(parser, args, args.out_dir,
                                        create_dir=True)
     assert_outputs_exist(parser, args, json_outputs)

--- a/scripts/scil_sh_to_rish.py
+++ b/scripts/scil_sh_to_rish.py
@@ -28,7 +28,8 @@ import numpy as np
 
 from scilpy.io.image import get_data_as_mask
 from scilpy.io.utils import (add_overwrite_arg, assert_inputs_exist,
-                             assert_outputs_exist, add_verbose_arg)
+                             assert_outputs_exist, add_verbose_arg,
+                             assert_headers_compatible)
 from scilpy.reconst.sh import compute_rish
 
 
@@ -60,12 +61,13 @@ def main():
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
     assert_inputs_exist(parser, args.in_sh, optional=args.mask)
+    assert_headers_compatible(parser, args.in_sh, optional=args.mask)
 
     # Load data
     sh_img = nib.load(args.in_sh)
     sh = sh_img.get_fdata(dtype=np.float32)
-    mask = get_data_as_mask(nib.load(args.mask), dtype=bool,
-                            ref_img=sh_img) if args.mask else None
+    mask = get_data_as_mask(nib.load(args.mask),
+                            dtype=bool) if args.mask else None
 
     # Precompute output filenames to check if they exist
     sh_order = order_from_ncoef(sh.shape[-1], full_basis=args.full_basis)

--- a/scripts/scil_sh_to_rish.py
+++ b/scripts/scil_sh_to_rish.py
@@ -64,9 +64,8 @@ def main():
     # Load data
     sh_img = nib.load(args.in_sh)
     sh = sh_img.get_fdata(dtype=np.float32)
-    mask = None
-    if args.mask:
-        mask = get_data_as_mask(nib.load(args.mask), dtype=bool)
+    mask = get_data_as_mask(nib.load(args.mask), dtype=bool,
+                            ref_img=sh_img) if args.mask else None
 
     # Precompute output filenames to check if they exist
     sh_order = order_from_ncoef(sh.shape[-1], full_basis=args.full_basis)

--- a/scripts/scil_tracking_local.py
+++ b/scripts/scil_tracking_local.py
@@ -174,10 +174,6 @@ def main():
                         "Ignoring.")
         args.save_seeds = False
 
-    logging.debug("Loading masks and finding seeds.")
-    mask_img = nib.load(args.in_mask)
-    mask_data = get_data_as_mask(mask_img, dtype=bool)
-
     # Make sure the data is isotropic. Else, the strategy used
     # when providing information to dipy (i.e. working as if in voxel space)
     # will not yield correct results. Tracking is performed in voxel space
@@ -187,6 +183,10 @@ def main():
                        odf_sh_img.header.get_zooms()[0], atol=1e-03):
         parser.error(
             'ODF SH file is not isotropic. Tracking cannot be ran robustly.')
+
+    logging.debug("Loading masks and finding seeds.")
+    mask_data = get_data_as_mask(nib.load(args.in_mask), dtype=bool,
+                                 ref_img=odf_sh_img)
 
     if args.npv:
         nb_seeds = args.npv

--- a/scripts/scil_tracking_local.py
+++ b/scripts/scil_tracking_local.py
@@ -66,10 +66,12 @@ from dipy.tracking import utils as track_utils
 import nibabel as nib
 from nibabel.streamlines import detect_format, TrkFile
 import numpy as np
+
 from scilpy.io.image import get_data_as_mask
 from scilpy.io.utils import (add_sphere_arg, add_verbose_arg,
                              assert_inputs_exist, assert_outputs_exist,
-                             parse_sh_basis_arg, verify_compression_th)
+                             parse_sh_basis_arg, verify_compression_th,
+                             assert_headers_compatible)
 from scilpy.tracking.utils import (add_mandatory_options_tracking,
                                    add_out_options, add_seeding_options,
                                    add_tracking_options,
@@ -157,6 +159,8 @@ def main():
 
     assert_inputs_exist(parser, [args.in_odf, args.in_seed, args.in_mask])
     assert_outputs_exist(parser, args, args.out_tractogram)
+    assert_headers_compatible(parser,
+                              [args.in_odf, args.in_seed, args.in_mask])
 
     if not nib.streamlines.is_supported(args.out_tractogram):
         parser.error('Invalid output streamline file format (must be trk or ' +
@@ -185,8 +189,7 @@ def main():
             'ODF SH file is not isotropic. Tracking cannot be ran robustly.')
 
     logging.debug("Loading masks and finding seeds.")
-    mask_data = get_data_as_mask(nib.load(args.in_mask), dtype=bool,
-                                 ref_img=odf_sh_img)
+    mask_data = get_data_as_mask(nib.load(args.in_mask), dtype=bool)
 
     if args.npv:
         nb_seeds = args.npv

--- a/scripts/scil_tracking_pft.py
+++ b/scripts/scil_tracking_pft.py
@@ -250,7 +250,7 @@ def main():
     vox_step_size = args.step_size / voxel_size
     seed_img = nib.load(args.in_seed)
     seeds = track_utils.random_seeds_from_mask(
-        get_data_as_mask(seed_img, dtype=bool),
+        get_data_as_mask(seed_img, dtype=bool, ref_img=fodf_sh_img),
         np.eye(4),
         seeds_count=nb_seeds,
         seed_count_per_voxel=seed_per_vox,

--- a/scripts/scil_tracking_pft_maps_edit.py
+++ b/scripts/scil_tracking_pft_maps_edit.py
@@ -57,8 +57,8 @@ def main():
     map_exc = nib.load(args.map_exclude)
     map_exc_data = map_exc.get_fdata(dtype=np.float32)
 
-    additional_mask = nib.load(args.additional_mask)
-    additional_mask_data = get_data_as_mask(additional_mask)
+    additional_mask_data = get_data_as_mask(nib.load(args.additional_mask),
+                                            ref_img=map_inc)
 
     map_inc_data[additional_mask_data > 0] = 0
     map_exc_data[additional_mask_data > 0] = 0

--- a/scripts/scil_tracking_pft_maps_edit.py
+++ b/scripts/scil_tracking_pft_maps_edit.py
@@ -14,10 +14,9 @@ import nibabel as nib
 import numpy as np
 
 from scilpy.io.image import get_data_as_mask
-from scilpy.io.utils import (add_overwrite_arg,
-                             add_verbose_arg,
-                             assert_inputs_exist,
-                             assert_outputs_exist)
+from scilpy.io.utils import (add_overwrite_arg, add_verbose_arg,
+                             assert_inputs_exist, assert_outputs_exist,
+                             assert_headers_compatible)
 
 
 def _build_arg_parser():
@@ -50,6 +49,8 @@ def main():
                                  args.additional_mask])
     assert_outputs_exist(parser, args, [args.map_include_corr,
                                         args.map_exclude_corr])
+    assert_headers_compatible(parser, [args.map_include, args.map_exclude,
+                                 args.additional_mask])
 
     map_inc = nib.load(args.map_include)
     map_inc_data = map_inc.get_fdata(dtype=np.float32)
@@ -57,8 +58,7 @@ def main():
     map_exc = nib.load(args.map_exclude)
     map_exc_data = map_exc.get_fdata(dtype=np.float32)
 
-    additional_mask_data = get_data_as_mask(nib.load(args.additional_mask),
-                                            ref_img=map_inc)
+    additional_mask_data = get_data_as_mask(nib.load(args.additional_mask))
 
     map_inc_data[additional_mask_data > 0] = 0
     map_exc_data[additional_mask_data > 0] = 0

--- a/scripts/scil_tractogram_apply_transform.py
+++ b/scripts/scil_tractogram_apply_transform.py
@@ -105,7 +105,8 @@ def main():
 
     assert_inputs_exist(parser, [args.in_moving_tractogram,
                                  args.in_target_file,
-                                 args.in_transfo], args.in_deformation)
+                                 args.in_transfo],
+                        [args.in_deformation, args.reference])
     assert_outputs_exist(parser, args, args.out_tractogram)
 
     args.bbox_check = False  # Adding manually bbox_check argument.

--- a/scripts/scil_tractogram_apply_transform_to_hdf5.py
+++ b/scripts/scil_tractogram_apply_transform_to_hdf5.py
@@ -71,7 +71,8 @@ def main():
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
     assert_inputs_exist(parser, [args.in_hdf5, args.in_target_file,
-                                 args.in_transfo], args.in_deformation)
+                                 args.in_transfo],
+                        [args.in_deformation, args.reference])
     assert_outputs_exist(parser, args, args.out_hdf5)
 
     # HDF5 will not overwrite the file

--- a/scripts/scil_tractogram_assign_custom_color.py
+++ b/scripts/scil_tractogram_assign_custom_color.py
@@ -172,7 +172,7 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
-    assert_inputs_exist(parser, args.in_tractogram)
+    assert_inputs_exist(parser, args.in_tractogram, args.reference)
     assert_outputs_exist(parser, args, args.out_tractogram,
                          optional=args.out_colorbar)
 

--- a/scripts/scil_tractogram_assign_uniform_color.py
+++ b/scripts/scil_tractogram_assign_uniform_color.py
@@ -27,7 +27,7 @@ from scilpy.io.utils import (assert_inputs_exist,
                              assert_outputs_exist,
                              add_overwrite_arg,
                              add_verbose_arg,
-                             add_reference_arg)
+                             add_reference_arg, assert_headers_compatible)
 
 
 def _build_arg_parser():
@@ -71,6 +71,8 @@ def main():
         parser.error('Using multiple inputs, use --out_suffix.')
 
     assert_inputs_exist(parser, args.in_tractograms, args.reference)
+    assert_headers_compatible(parser, args.in_tractograms,
+                              reference=args.reference)
 
     if args.out_suffix:
         if args.out_tractogram:

--- a/scripts/scil_tractogram_assign_uniform_color.py
+++ b/scripts/scil_tractogram_assign_uniform_color.py
@@ -70,7 +70,7 @@ def main():
     if len(args.in_tractograms) > 1 and args.out_tractogram:
         parser.error('Using multiple inputs, use --out_suffix.')
 
-    assert_inputs_exist(parser, args.in_tractograms)
+    assert_inputs_exist(parser, args.in_tractograms, args.reference)
 
     if args.out_suffix:
         if args.out_tractogram:

--- a/scripts/scil_tractogram_compute_TODI.py
+++ b/scripts/scil_tractogram_compute_TODI.py
@@ -133,7 +133,7 @@ def main():
         todi_obj.smooth_todi_spatial()
 
     if args.mask:
-        mask = get_data_as_mask(nib.load(args.mask))
+        mask = get_data_as_mask(nib.load(args.mask), ref_shape=data_shape)
         todi_obj.mask_todi(mask)
 
     logging.info('Saving Outputs ...')

--- a/scripts/scil_tractogram_compute_TODI.py
+++ b/scripts/scil_tractogram_compute_TODI.py
@@ -21,7 +21,7 @@ from scilpy.io.streamlines import load_tractogram_with_reference
 from scilpy.io.utils import (add_overwrite_arg, add_reference_arg,
                              add_sh_basis_args, add_verbose_arg,
                              assert_inputs_exist, assert_outputs_exist,
-                             parse_sh_basis_arg)
+                             parse_sh_basis_arg, assert_headers_compatible)
 from scilpy.tractanalysis.todi import TrackOrientationDensityImaging
 
 
@@ -92,6 +92,8 @@ def main():
 
     assert_inputs_exist(parser, args.in_tractogram,
                         [args.mask, args.reference])
+    assert_headers_compatible(parser, args.in_tractogram, args.mask,
+                              reference=args.reference)
 
     output_file_list = []
     if args.out_mask:
@@ -133,7 +135,7 @@ def main():
         todi_obj.smooth_todi_spatial()
 
     if args.mask:
-        mask = get_data_as_mask(nib.load(args.mask), ref_shape=data_shape)
+        mask = get_data_as_mask(nib.load(args.mask))
         todi_obj.mask_todi(mask)
 
     logging.info('Saving Outputs ...')

--- a/scripts/scil_tractogram_cut_streamlines.py
+++ b/scripts/scil_tractogram_cut_streamlines.py
@@ -34,7 +34,8 @@ from scilpy.io.streamlines import load_tractogram_with_reference
 from scilpy.io.utils import (add_overwrite_arg,
                              add_reference_arg,
                              add_verbose_arg,
-                             assert_inputs_exist, assert_outputs_exist)
+                             assert_inputs_exist, assert_outputs_exist,
+                             assert_headers_compatible)
 from scilpy.tractograms.streamline_and_mask_operations import \
     cut_outside_of_mask_streamlines, cut_between_mask_two_blobs_streamlines
 from scilpy.tractograms.streamline_operations import \
@@ -74,6 +75,8 @@ def main():
 
     assert_inputs_exist(parser, [args.in_tractogram, args.in_mask])
     assert_outputs_exist(parser, args, args.out_tractogram)
+    assert_headers_compatible(parser, [args.in_tractogram, args.in_mask],
+                              reference=args.reference)
 
     sft = load_tractogram_with_reference(parser, args, args.in_tractogram)
     if args.step_size is not None:

--- a/scripts/scil_tractogram_cut_streamlines.py
+++ b/scripts/scil_tractogram_cut_streamlines.py
@@ -31,11 +31,9 @@ import scipy.ndimage as ndi
 
 from scilpy.io.image import get_data_as_mask
 from scilpy.io.streamlines import load_tractogram_with_reference
-from scilpy.io.utils import (add_overwrite_arg,
-                             add_reference_arg,
-                             add_verbose_arg,
-                             assert_inputs_exist, assert_outputs_exist,
-                             assert_headers_compatible)
+from scilpy.io.utils import (add_overwrite_arg, add_reference_arg,
+                             add_verbose_arg, assert_inputs_exist,
+                             assert_outputs_exist, assert_headers_compatible)
 from scilpy.tractograms.streamline_and_mask_operations import \
     cut_outside_of_mask_streamlines, cut_between_mask_two_blobs_streamlines
 from scilpy.tractograms.streamline_operations import \

--- a/scripts/scil_tractogram_cut_streamlines.py
+++ b/scripts/scil_tractogram_cut_streamlines.py
@@ -73,7 +73,8 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
-    assert_inputs_exist(parser, [args.in_tractogram, args.in_mask])
+    assert_inputs_exist(parser, [args.in_tractogram, args.in_mask],
+                        args.reference)
     assert_outputs_exist(parser, args, args.out_tractogram)
     assert_headers_compatible(parser, [args.in_tractogram, args.in_mask],
                               reference=args.reference)

--- a/scripts/scil_tractogram_detect_loops.py
+++ b/scripts/scil_tractogram_detect_loops.py
@@ -80,7 +80,7 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
-    assert_inputs_exist(parser, args.in_tractogram)
+    assert_inputs_exist(parser, args.in_tractogram, args.reference)
     assert_outputs_exist(parser, args, args.out_tractogram,
                          optional=args.looping_tractogram)
     check_tracts_same_format(parser, [args.in_tractogram, args.out_tractogram,

--- a/scripts/scil_tractogram_dpp_math.py
+++ b/scripts/scil_tractogram_dpp_math.py
@@ -106,7 +106,7 @@ def main():
     if args.verbose:
         logging.getLogger().setLevel(logging.INFO)
 
-    assert_inputs_exist(parser, args.in_tractogram)
+    assert_inputs_exist(parser, args.in_tractogram, args.reference)
     assert_outputs_exist(parser, args, args.out_tractogram)
 
     # Load the input files.

--- a/scripts/scil_tractogram_extract_ushape.py
+++ b/scripts/scil_tractogram_extract_ushape.py
@@ -65,7 +65,7 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
-    assert_inputs_exist(parser, args.in_tractogram)
+    assert_inputs_exist(parser, args.in_tractogram, args.reference)
     assert_outputs_exist(parser, args, args.out_tractogram,
                          optional=args.remaining_tractogram)
     check_tracts_same_format(parser, [args.in_tractogram, args.out_tractogram,

--- a/scripts/scil_tractogram_filter_by_anatomy.py
+++ b/scripts/scil_tractogram_filter_by_anatomy.py
@@ -52,7 +52,6 @@ import os
 import importlib.resources as resources
 
 from dipy.io.streamline import save_tractogram
-from dipy.io.utils import is_header_compatible
 import nibabel as nib
 import numpy as np
 from scipy.spatial import cKDTree
@@ -66,7 +65,7 @@ from scilpy.io.utils import (add_json_args,
                              add_verbose_arg,
                              assert_inputs_exist,
                              assert_output_dirs_exist_and_empty,
-                             validate_nbr_processes)
+                             validate_nbr_processes, assert_headers_compatible)
 from scilpy.image.labels import get_data_as_labels
 from scilpy.segment.streamlines import filter_grid_roi
 from scilpy.tractanalysis.features import remove_loops_and_sharp_turns
@@ -277,11 +276,12 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
-    assert_inputs_exist(parser, args.in_tractogram)
-    assert_inputs_exist(parser, args.in_wmparc)
-    assert_output_dirs_exist_and_empty(parser, args,
-                                       args.out_path,
+    assert_inputs_exist(parser, [args.in_tractogram, args.in_wmparc],
+                        args.csf_bin)
+    assert_output_dirs_exist_and_empty(parser, args, args.out_path,
                                        create_dir=True)
+    assert_headers_compatible(parser, [args.in_tractogram, args.in_wmparc],
+                              args.csf_bin, reference=args.reference)
 
     nbr_cpu = validate_nbr_processes(parser, args)
 
@@ -296,14 +296,8 @@ def main():
     sft.to_corner()
 
     img_wmparc = nib.load(args.in_wmparc)
-    if not is_header_compatible(img_wmparc, sft):
-        parser.error('Headers from the tractogram and the wmparc are '
-                     'not compatible.')
     if args.csf_bin:
         img_csf = nib.load(args.csf_bin)
-        if not is_header_compatible(img_csf, sft):
-            parser.error('Headers from the tractogram and the CSF mask are '
-                         'not compatible.')
 
     if args.minL == 0 and np.isinf(args.maxL):
         logging.info("You have not specified minL nor maxL. Output will "

--- a/scripts/scil_tractogram_filter_by_anatomy.py
+++ b/scripts/scil_tractogram_filter_by_anatomy.py
@@ -277,7 +277,7 @@ def main():
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
     assert_inputs_exist(parser, [args.in_tractogram, args.in_wmparc],
-                        args.csf_bin)
+                        [args.csf_bin, args.reference])
     assert_output_dirs_exist_and_empty(parser, args, args.out_path,
                                        create_dir=True)
     assert_headers_compatible(parser, [args.in_tractogram, args.in_wmparc],

--- a/scripts/scil_tractogram_filter_by_length.py
+++ b/scripts/scil_tractogram_filter_by_length.py
@@ -56,7 +56,7 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
-    assert_inputs_exist(parser, args.in_tractogram)
+    assert_inputs_exist(parser, args.in_tractogram, args.reference)
     assert_outputs_exist(parser, args, args.out_tractogram)
 
     if args.minL == 0 and np.isinf(args.maxL):

--- a/scripts/scil_tractogram_filter_by_orientation.py
+++ b/scripts/scil_tractogram_filter_by_orientation.py
@@ -88,7 +88,7 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
-    assert_inputs_exist(parser, args.in_tractogram)
+    assert_inputs_exist(parser, args.in_tractogram, args.reference)
     assert_outputs_exist(parser, args, args.out_tractogram, args.save_rejected)
 
     if args.min_x == 0 and np.isinf(args.max_x) and \

--- a/scripts/scil_tractogram_filter_by_roi.py
+++ b/scripts/scil_tractogram_filter_by_roi.py
@@ -242,7 +242,7 @@ def main():
 
     # Todo. Prepare now the names of other files (ex, ROI) and verify if
     #  exist and compatible.
-    assert_inputs_exist(parser, args.in_tractogram)
+    assert_inputs_exist(parser, args.in_tractogram, args.reference)
     assert_outputs_exist(parser, args, args.out_tractogram, args.save_rejected)
 
     if overwrite_distance:

--- a/scripts/scil_tractogram_filter_by_roi.py
+++ b/scripts/scil_tractogram_filter_by_roi.py
@@ -240,6 +240,8 @@ def main():
 
     overwrite_distance = check_overwrite_distance(parser, args)
 
+    # Todo. Prepare now the names of other files (ex, ROI) and verify if
+    #  exist and compatible.
     assert_inputs_exist(parser, args.in_tractogram)
     assert_outputs_exist(parser, args, args.out_tractogram, args.save_rejected)
 

--- a/scripts/scil_tractogram_flip.py
+++ b/scripts/scil_tractogram_flip.py
@@ -51,7 +51,7 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
-    assert_inputs_exist(parser, args.in_tractogram)
+    assert_inputs_exist(parser, args.in_tractogram, args.reference)
     assert_outputs_exist(parser, args, args.out_tractogram)
 
     sft = load_tractogram_with_reference(parser, args, args.in_tractogram)

--- a/scripts/scil_tractogram_math.py
+++ b/scripts/scil_tractogram_math.py
@@ -57,7 +57,7 @@ from scilpy.io.utils import (add_bbox_arg,
                              add_verbose_arg,
                              assert_inputs_exist,
                              assert_outputs_exist,
-                             is_header_compatible_multiple_files)
+                             assert_headers_compatible)
 from scilpy.tractograms.lazy_tractogram_operations import lazy_concatenate
 from scilpy.tractograms.tractogram_operations import (
     perform_tractogram_operation_on_sft, concatenate_sft)
@@ -117,7 +117,7 @@ def main():
     assert_outputs_exist(parser, args, args.out_tractogram,
                          optional=args.save_indices)
 
-    is_header_compatible_multiple_files(
+    assert_headers_compatible(
         parser, args.in_tractograms, verbose_all_compatible=args.verbose,
         reference=args.reference)
 

--- a/scripts/scil_tractogram_math.py
+++ b/scripts/scil_tractogram_math.py
@@ -116,10 +116,8 @@ def main():
     assert_inputs_exist(parser, args.in_tractograms, args.reference)
     assert_outputs_exist(parser, args, args.out_tractogram,
                          optional=args.save_indices)
-
-    assert_headers_compatible(
-        parser, args.in_tractograms, verbose_all_compatible=args.verbose,
-        reference=args.reference)
+    assert_headers_compatible(parser, args.in_tractograms,
+                              reference=args.reference)
 
     if args.operation == 'lazy_concatenate':
         logging.info('Using lazy_concatenate, no spatial or metadata related '

--- a/scripts/scil_tractogram_math.py
+++ b/scripts/scil_tractogram_math.py
@@ -113,7 +113,7 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
-    assert_inputs_exist(parser, args.in_tractograms)
+    assert_inputs_exist(parser, args.in_tractograms, args.reference)
     assert_outputs_exist(parser, args, args.out_tractogram,
                          optional=args.save_indices)
 

--- a/scripts/scil_tractogram_print_info.py
+++ b/scripts/scil_tractogram_print_info.py
@@ -47,7 +47,7 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
-    assert_inputs_exist(parser, args.in_tractogram)
+    assert_inputs_exist(parser, args.in_tractogram, args.reference)
 
     sft = load_tractogram_with_reference(parser, args, args.in_tractogram)
 

--- a/scripts/scil_tractogram_project_map_to_streamlines.py
+++ b/scripts/scil_tractogram_project_map_to_streamlines.py
@@ -87,8 +87,8 @@ def main():
     parser = _build_arg_parser()
     args = parser.parse_args()
 
-    assert_inputs_exist(parser, [args.in_tractogram] + args.in_maps)
-
+    assert_inputs_exist(parser, [args.in_tractogram] + args.in_maps,
+                        args.reference)
     assert_outputs_exist(parser, args, [args.out_tractogram])
 
     if args.verbose:

--- a/scripts/scil_tractogram_project_streamlines_to_map.py
+++ b/scripts/scil_tractogram_project_streamlines_to_map.py
@@ -173,7 +173,7 @@ def main():
 
     # -------- General checks ----------
     assert_inputs_exist(parser, [args.in_bundle],
-                        args.load_dps + args.load_dpp)
+                        args.load_dps + args.load_dpp + [args.reference])
 
     # Find all final output files (one per metric).
     if args.load_dps or args.load_dpp:

--- a/scripts/scil_tractogram_qbx.py
+++ b/scripts/scil_tractogram_qbx.py
@@ -58,7 +58,7 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
-    assert_inputs_exist(parser, args.in_tractogram)
+    assert_inputs_exist(parser, args.in_tractogram, args.reference)
     assert_outputs_exist(parser, args, [], optional=args.out_centroids)
     assert_output_dirs_exist_and_empty(parser, args,
                                        args.out_clusters_dir,

--- a/scripts/scil_tractogram_register.py
+++ b/scripts/scil_tractogram_register.py
@@ -63,7 +63,9 @@ def main():
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
     assert_inputs_exist(parser, [args.moving_tractogram,
-                                 args.static_tractogram])
+                                 args.static_tractogram],
+                        [args.moving_tractogram_ref,
+                         args.static_tractogram_ref])
 
     if args.only_rigid:
         matrix_filename = os.path.splitext(args.out_name)[0] + '_rigid.txt'

--- a/scripts/scil_tractogram_resample.py
+++ b/scripts/scil_tractogram_resample.py
@@ -122,7 +122,7 @@ def main():
              args.streamline_wise_std <= 0):
         parser.error('STD needs to be above 0.')
 
-    assert_inputs_exist(parser, args.in_tractogram)
+    assert_inputs_exist(parser, args.in_tractogram, args.reference)
     assert_outputs_exist(parser, args, args.out_tractogram)
 
     logging.info("Loading sft.")

--- a/scripts/scil_tractogram_resample_nb_points.py
+++ b/scripts/scil_tractogram_resample_nb_points.py
@@ -49,7 +49,7 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
-    assert_inputs_exist(parser, args.in_tractogram)
+    assert_inputs_exist(parser, args.in_tractogram, args.reference)
     assert_outputs_exist(parser, args, args.out_tractogram)
 
     sft = load_tractogram_with_reference(parser, args, args.in_tractogram)

--- a/scripts/scil_tractogram_segment_bundles.py
+++ b/scripts/scil_tractogram_segment_bundles.py
@@ -101,8 +101,8 @@ def main():
                                                     args.in_directory, x))]
 
     assert_inputs_exist(parser, args.in_tractograms +
-                        [args.in_config_file,
-                         args.in_transfo])
+                        [args.in_config_file, args.in_transfo],
+                        args.reference)
 
     for in_tractogram in args.in_tractograms:
         ext = os.path.splitext(in_tractogram)[1]

--- a/scripts/scil_tractogram_segment_one_bundles.py
+++ b/scripts/scil_tractogram_segment_one_bundles.py
@@ -98,7 +98,8 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
-    assert_inputs_exist(parser, [args.in_tractogram, args.in_transfo])
+    assert_inputs_exist(parser, [args.in_tractogram, args.in_transfo],
+                        args.reference)
     assert_outputs_exist(parser, args, args.out_tractogram)
 
     wb_file = load_tractogram_with_reference(parser, args, args.in_tractogram)

--- a/scripts/scil_tractogram_shuffle.py
+++ b/scripts/scil_tractogram_shuffle.py
@@ -43,7 +43,7 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
-    assert_inputs_exist(parser, args.in_tractogram)
+    assert_inputs_exist(parser, args.in_tractogram, args.reference)
     assert_outputs_exist(parser, args, args.out_tractogram)
 
     sft = load_tractogram_with_reference(parser, args, args.in_tractogram)

--- a/scripts/scil_tractogram_smooth.py
+++ b/scripts/scil_tractogram_smooth.py
@@ -79,7 +79,7 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
-    assert_inputs_exist(parser, args.in_tractogram)
+    assert_inputs_exist(parser, args.in_tractogram, args.reference)
     assert_outputs_exist(parser, args, args.out_tractogram)
 
     sft = load_tractogram_with_reference(parser, args, args.in_tractogram)

--- a/scripts/scil_tractogram_split.py
+++ b/scripts/scil_tractogram_split.py
@@ -84,7 +84,7 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
-    assert_inputs_exist(parser, args.in_tractogram)
+    assert_inputs_exist(parser, args.in_tractogram, args.reference)
     _, out_extension = os.path.splitext(args.in_tractogram)
 
     assert_output_dirs_exist_and_empty(parser, args, [], optional=args.out_dir)

--- a/scripts/scil_tractogram_uniformize_endpoints.py
+++ b/scripts/scil_tractogram_uniformize_endpoints.py
@@ -78,7 +78,7 @@ def main():
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
     assert_inputs_exist(parser, args.in_bundle,
-                        args.target_roi + [args.reference])
+                        args.target_roi or [] + [args.reference])
     assert_outputs_exist(parser, args, args.out_bundle)
     assert_headers_compatible(parser, args.in_bundle, args.target_roi,
                               reference=args.reference)

--- a/scripts/scil_tractogram_uniformize_endpoints.py
+++ b/scripts/scil_tractogram_uniformize_endpoints.py
@@ -31,7 +31,7 @@ from scilpy.io.utils import (add_overwrite_arg,
                              add_reference_arg,
                              add_verbose_arg,
                              assert_outputs_exist,
-                             assert_inputs_exist)
+                             assert_inputs_exist, assert_headers_compatible)
 from scilpy.utils.streamlines import (uniformize_bundle_sft,
                                       uniformize_bundle_sft_using_mask)
 
@@ -77,8 +77,11 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
-    assert_inputs_exist(parser, args.in_bundle, args.reference)
+    assert_inputs_exist(parser, args.in_bundle,
+                        args.target_roi + [args.reference])
     assert_outputs_exist(parser, args, args.out_bundle)
+    assert_headers_compatible(parser, args.in_bundle, args.target_roi,
+                              reference=args.reference)
 
     sft = load_tractogram_with_reference(parser, args, args.in_bundle)
     if args.auto:

--- a/scripts/scil_tractogram_uniformize_endpoints.py
+++ b/scripts/scil_tractogram_uniformize_endpoints.py
@@ -77,7 +77,7 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
-    assert_inputs_exist(parser, args.in_bundle)
+    assert_inputs_exist(parser, args.in_bundle, args.reference)
     assert_outputs_exist(parser, args, args.out_bundle)
 
     sft = load_tractogram_with_reference(parser, args, args.in_bundle)

--- a/scripts/scil_visualize_bundles_mosaic.py
+++ b/scripts/scil_visualize_bundles_mosaic.py
@@ -175,7 +175,8 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
-    assert_inputs_exist(parser, args.in_bundles + [args.in_volume])
+    assert_inputs_exist(parser, args.in_bundles + [args.in_volume],
+                        args.reference)
     assert_outputs_exist(parser, args, args.out_image)
     assert_headers_compatible(parser, args.in_bundles + [args.in_volume],
                               reference=args.reference)

--- a/scripts/scil_visualize_bundles_mosaic.py
+++ b/scripts/scil_visualize_bundles_mosaic.py
@@ -11,7 +11,6 @@ import logging
 import os
 import random
 
-from dipy.io.utils import is_header_compatible
 from fury import actor, window
 import nibabel as nib
 import numpy as np
@@ -21,13 +20,13 @@ from PIL import ImageFont
 from PIL import ImageDraw
 
 from scilpy.io.image import get_data_as_mask
-from scilpy.io.streamlines import load_tractogram_with_reference
 from scilpy.io.utils import (add_overwrite_arg,
                              add_reference_arg,
                              add_verbose_arg,
                              assert_inputs_exist,
                              assert_outputs_exist,
-                             assert_output_dirs_exist_and_empty)
+                             assert_output_dirs_exist_and_empty,
+                             assert_headers_compatible)
 from scilpy.utils.filenames import split_name_with_nii
 
 
@@ -176,8 +175,10 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
-    assert_inputs_exist(parser, args.in_volume)
+    assert_inputs_exist(parser, args.in_bundles + [args.in_volume])
     assert_outputs_exist(parser, args, args.out_image)
+    assert_headers_compatible(parser, args.in_bundles + [args.in_volume],
+                              reference=args.reference)
 
     output_names = ['axial_superior', 'axial_inferior',
                     'coronal_posterior', 'coronal_anterior',
@@ -186,19 +187,6 @@ def main():
         output_names = ['axial_superior',
                         'coronal_posterior',
                         'sagittal_left']
-
-    for filename in args.in_bundles:
-        _, ext = os.path.splitext(filename)
-        if ext == '.tck':
-            tractogram = load_tractogram_with_reference(parser, args, filename)
-        else:
-            tractogram = filename
-        if not is_header_compatible(args.in_volume, tractogram):
-            parser.error('{} does not have a compatible header with {}'.format(
-                filename, args.in_volume))
-        # Delete temporary tractogram
-        else:
-            del tractogram
 
     output_dir = os.path.dirname(args.out_image)
     if output_dir:

--- a/scripts/scil_visualize_fodf.py
+++ b/scripts/scil_visualize_fodf.py
@@ -219,14 +219,13 @@ def _get_data_from_inputs(args):
         bg = nib.nifti1.load(args.background).get_fdata(dtype=np.float32)
         data['bg'] = bg
     if args.in_transparency_mask:
-        assert_same_resolution([args.in_transparency_mask, args.in_fodf])
         transparency_mask = get_data_as_mask(
-            nib.nifti1.load(args.in_transparency_mask), dtype=bool
-        )
+            nib.nifti1.load(args.in_transparency_mask), dtype=bool,
+            ref_shape=fodf.shape)
         data['transparency_mask'] = transparency_mask
     if args.mask:
-        assert_same_resolution([args.mask, args.in_fodf])
-        mask = get_data_as_mask(nib.nifti1.load(args.mask), dtype=bool)
+        mask = get_data_as_mask(nib.nifti1.load(args.mask), dtype=bool,
+                                ref_shape=fodf.shape)
         data['mask'] = mask
     if args.peaks:
         assert_same_resolution([args.peaks, args.in_fodf])

--- a/scripts/scil_visualize_histogram.py
+++ b/scripts/scil_visualize_histogram.py
@@ -68,13 +68,10 @@ def main():
     metric_img_data = metric_img.get_fdata(dtype=np.float32)
 
     # Load mask image
-    mask_img = nib.load(args.in_mask)
-    mask_img_data = get_data_as_mask(mask_img)
-
-    assert_same_resolution((metric_img, mask_img))
+    mask = get_data_as_mask(nib.load(args.in_mask), ref_img=metric_img)
 
     # Select value from mask
-    curr_data = metric_img_data[np.where(mask_img_data > 0)]
+    curr_data = metric_img_data[mask]
 
     # Display figure
     fig, ax = plt.subplots()

--- a/scripts/scil_visualize_histogram.py
+++ b/scripts/scil_visualize_histogram.py
@@ -20,7 +20,8 @@ import numpy as np
 
 from scilpy.io.image import (get_data_as_mask, assert_same_resolution)
 from scilpy.io.utils import (add_overwrite_arg, assert_inputs_exist,
-                             assert_outputs_exist, add_verbose_arg)
+                             assert_outputs_exist, add_verbose_arg,
+                             assert_headers_compatible)
 
 
 def _build_arg_parser():
@@ -62,13 +63,14 @@ def main():
 
     assert_inputs_exist(parser, [args.in_metric, args.in_mask])
     assert_outputs_exist(parser, args, args.out_png)
+    assert_headers_compatible(parser, [args.in_metric, args.in_mask])
 
     # Load metric image
     metric_img = nib.load(args.in_metric)
     metric_img_data = metric_img.get_fdata(dtype=np.float32)
 
     # Load mask image
-    mask = get_data_as_mask(nib.load(args.in_mask), ref_img=metric_img)
+    mask = get_data_as_mask(nib.load(args.in_mask))
 
     # Select value from mask
     curr_data = metric_img_data[mask]

--- a/scripts/scil_visualize_histogram.py
+++ b/scripts/scil_visualize_histogram.py
@@ -73,7 +73,7 @@ def main():
     mask = get_data_as_mask(nib.load(args.in_mask))
 
     # Select value from mask
-    curr_data = metric_img_data[mask]
+    curr_data = metric_img_data[np.where(mask > 0)]
 
     # Display figure
     fig, ax = plt.subplots()

--- a/scripts/scil_visualize_scatterplot.py
+++ b/scripts/scil_visualize_scatterplot.py
@@ -168,8 +168,7 @@ def main():
         if args.label is None:
             args.label = 'Masking data'
         # Load and apply binary mask
-        mask_image = nib.load(args.in_bin_mask)
-        mask_data = get_data_as_mask(mask_image)
+        mask_data = get_data_as_mask(nib.load(args.in_bin_mask))
         for curr_map in maps_data:
             curr_map[np.where(mask_data == 0)] = np.nan
 

--- a/scripts/scil_visualize_scatterplot.py
+++ b/scripts/scil_visualize_scatterplot.py
@@ -50,8 +50,7 @@ import numpy as np
 
 from scilpy.image.labels import get_data_as_labels
 from scilpy.io.image import get_data_as_mask
-from scilpy.io.utils import (add_overwrite_arg,
-                             add_verbose_arg,
+from scilpy.io.utils import (add_overwrite_arg, add_verbose_arg,
                              assert_inputs_exist, assert_headers_compatible)
 
 

--- a/scripts/scil_visualize_scatterplot.py
+++ b/scripts/scil_visualize_scatterplot.py
@@ -52,7 +52,7 @@ from scilpy.image.labels import get_data_as_labels
 from scilpy.io.image import get_data_as_mask
 from scilpy.io.utils import (add_overwrite_arg,
                              add_verbose_arg,
-                             assert_inputs_exist)
+                             assert_inputs_exist, assert_headers_compatible)
 
 
 def _build_arg_parser():
@@ -143,17 +143,18 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
-    assert_inputs_exist(parser, [args.in_x_map, args.in_y_map])
+    maps = [args.in_x_map, args.in_y_map]
+    assert_inputs_exist(parser, maps,
+                        optional=args.in_prob_maps +
+                        [args.in_bin_mask, args.in_atlas, args.atlas_lut])
+    assert_headers_compatible(parser, maps,
+                              optional=args.in_prob_maps +
+                                       [args.in_bin_mask, args.in_atlas])
 
     if args.out_dir is None:
         args.out_dir = './'
 
-    if args.in_atlas:
-        assert_inputs_exist(parser, args.atlas_lut)
-
     # Load x and y images
-    maps = [args.in_x_map, args.in_y_map]
-
     maps_data = []
     for curr_map in maps:
         maps_image = nib.load(curr_map)

--- a/scripts/scil_visualize_scatterplot.py
+++ b/scripts/scil_visualize_scatterplot.py
@@ -144,12 +144,13 @@ def main():
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
     maps = [args.in_x_map, args.in_y_map]
+    prob_maps = args.in_prob_maps or []
     assert_inputs_exist(parser, maps,
-                        optional=args.in_prob_maps +
+                        optional=prob_maps +
                         [args.in_bin_mask, args.in_atlas, args.atlas_lut])
     assert_headers_compatible(parser, maps,
-                              optional=args.in_prob_maps +
-                                       [args.in_bin_mask, args.in_atlas])
+                              optional=prob_maps +
+                              [args.in_bin_mask, args.in_atlas])
 
     if args.out_dir is None:
         args.out_dir = './'

--- a/scripts/scil_volume_stats_in_ROI.py
+++ b/scripts/scil_volume_stats_in_ROI.py
@@ -26,7 +26,7 @@ from scilpy.io.utils import (add_overwrite_arg,
                              add_json_args,
                              add_verbose_arg,
                              assert_inputs_exist,
-                             is_header_compatible_multiple_files)
+                             assert_headers_compatible)
 from scilpy.utils.filenames import split_name_with_nii
 from scilpy.utils.metrics_tools import get_roi_metrics_mean_std
 
@@ -73,8 +73,11 @@ def main():
         list_metrics_files = glob.glob(os.path.join(args.metrics_dir,
                                                     '*nii.gz'))
         assert_inputs_exist(parser, [args.in_mask] + list_metrics_files)
+        assert_headers_compatible(parser, [args.in_mask] + list_metrics_files)
     elif args.metrics_file_list:
         assert_inputs_exist(parser, [args.in_mask] + args.metrics_file_list)
+        assert_headers_compatible(parser,
+                                  [args.in_mask] + args.metrics_file_list)
 
     # Load mask and validate content depending on flags
     mask_img = nib.load(args.in_mask)
@@ -103,9 +106,6 @@ def main():
     # Load all metrics files.
     metrics_files = []
     if args.metrics_dir:
-        is_header_compatible_multiple_files(parser, [args.in_mask] +
-                                            list_metrics_files)
-
         for f in sorted(os.listdir(args.metrics_dir)):
             metric_img = nib.load(os.path.join(args.metrics_dir, f))
             if len(metric_img.shape)==3:
@@ -118,8 +118,8 @@ def main():
                 parser.error('Metric {} is not compatible ({}D image).'.format(os.path.join(args.metrics_dir, f),
                                                                                len(metric_img.shape)))
     elif args.metrics_file_list:
-        is_header_compatible_multiple_files(parser, [args.in_mask] +
-                                            args.metrics_file_list)
+        assert_headers_compatible(parser, [args.in_mask] +
+                                  args.metrics_file_list)
         for f in args.metrics_file_list:
             metric_img = nib.load(f)
             if len(metric_img.shape)==3:

--- a/scripts/tests/test_aodf_metrics.py
+++ b/scripts/tests/test_aodf_metrics.py
@@ -17,6 +17,8 @@ def test_help_option(script_runner):
 
 
 def test_execution(script_runner):
+
+    # toDo: Add --mask.
     os.chdir(os.path.expanduser(tmp_dir.name))
     in_fodf = os.path.join(
         f"{test_data_root}/fodf_descoteaux07_sub_unified_asym.nii.gz")


### PR DESCRIPTION
# Quick description

I was seeing many times the same line:

```
if args.mask is None:
    mask = None
else:
   mask = get_data_as_mask()
   verify_shape
```

Replaced by single-line with verification inside get_data_as_mask. Makes the verification more thorough (was not done in all scripts) and will help with coverage.

EDIT: 

After discussion with Arnaud, instead, not verifying shape there, but using assert_headers_compatible at the beginning.

+ added missing mask in many `assert_inputs_exit` calls.
+ added missing reference in many `assert_inputs_exit` calls.
...

## Type of change

Check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [ ] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
