### PR TITLE
Tractogram scripts part1

### DIFF
--- a/scilpy/io/hdf5.py
+++ b/scilpy/io/hdf5.py
@@ -1,0 +1,265 @@
+# -*- coding: utf-8 -*-
+
+import logging
+
+from dipy.io.stateful_tractogram import StatefulTractogram, Space, Origin
+import nibabel as nib
+from dipy.io.utils import create_nifti_header
+from nibabel.streamlines.array_sequence import ArraySequence
+import numpy as np
+
+from scilpy.io.streamlines import reconstruct_streamlines
+
+
+def reconstruct_sft_from_hdf5(hdf5_handle, group_keys, space=Space.VOX,
+                              origin=Origin.TRACKVIS, load_dps=False,
+                              load_dpp=False, ref_img=None,
+                              merge_groups=False):
+    """
+    Reconstructs one or more SFT from the HDF5 data.
+
+    Parameters
+    ----------
+    hdf5_handle: hdf5.file
+        Opened hdf5 file.
+    group_keys: str or list or None
+        Name of the streamlines group(s) in the HDF5. If None, loads all
+        groups. If more than one group, by default, will return one sft per
+        group.
+    space: Space
+        The space in which the HDF5 was saved. Default: Space.Vox
+    origin: Origin
+        The origin in which the HDF5 was saved. Default: Origin.TRACKVIS
+    load_dps: bool
+        If true, loads the data_per_streamline if present in the hdf5.
+    load_dpp: bool
+        If true, loads the data_per_point if present in the hdf5.
+    ref_img: nib.Nifti1Image
+        If set, will verify that the HDF5's header is compatible with this
+        reference.
+    merge_groups: bool
+        If true, and if groups_keys refer to more than one group, will merge
+        all bundles into one SFT. Else, returns one SFT per group.
+
+    Returns
+    -------
+    sft: StatefulTractogram or list[StatefulTractogram]
+        The tractogram(s)
+    groups_len: list[int]
+        The number of streamlines per loaded group.
+    """
+    if ref_img is not None:
+        assert_header_compatible_hdf5(hdf5_handle, ref_img)
+
+    # Prepare header
+    affine = hdf5_handle.attrs['affine']
+    dimensions = hdf5_handle.attrs['dimensions']
+    voxel_sizes = hdf5_handle.attrs['voxel_sizes']
+    header = create_nifti_header(affine, dimensions, voxel_sizes)
+
+    # Find the groups to load
+    if isinstance(group_keys, str):
+        group_keys = [group_keys]
+    elif group_keys is None:
+        group_keys = list(hdf5_handle.keys())  # Get all groups
+
+    if not isinstance(group_keys, list):
+        raise ValueError("Expecting key to be either a str, a list or None. "
+                         "(our fault. Code needs revision).")
+    if len(group_keys) == 1:
+        merge_groups = True
+
+    # Get streamlines. They have been stored inside a group (or one per
+    # bundle). Load all groups and either merge together or return many sft.
+    groups_len = []
+    streamlines = []
+    dps = []
+    for i, group_key in enumerate(group_keys):
+        if group_key not in hdf5_handle:
+            raise ValueError("Group key {} not found in the hdf5. Possible "
+                             "choices: {}"
+                             .format(group_key, list(hdf5_handle.keys())))
+
+        # Get streamlines
+        tmp_streamlines = reconstruct_streamlines_from_hdf5(
+            hdf5_handle[group_key])
+        if merge_groups:
+            streamlines.extend(tmp_streamlines)
+            groups_len.append(len(tmp_streamlines))
+        else:
+            streamlines.append(tmp_streamlines)
+
+        if len(tmp_streamlines) > 0:
+            # Load dps / dpp
+            if i == 0 or not merge_groups:
+                dps.append({})
+            for sub_key in hdf5_handle[group_key].keys():
+                if sub_key not in ['data', 'offsets', 'lengths']:
+                    data = hdf5_handle[group_key][sub_key]
+                    if data.shape == hdf5_handle[group_key]['offsets']:
+                        # Discovered dps
+                        if load_dps:
+                            if i == 0 or not merge_groups:
+                                dps[i][sub_key] = data
+                            else:
+                                dps[i][sub_key] = np.concatenate(
+                                    (dps[i][sub_key], data))
+                    else:
+                        if load_dpp:
+                            raise NotImplementedError(
+                                "Don't know how to load dpp yet.")
+                        raise NotImplementedError("DPP data? Other?")
+
+    # 3) Format as SFT
+    if merge_groups:
+        if len(streamlines) == 0:
+            logging.info("Empty SFT not reconstructed from hdf5.")
+            return None
+        sft = StatefulTractogram(streamlines, header, space=space,
+                                 origin=origin, data_per_streamline=dps[0])
+        return sft, groups_len
+    else:
+        sfts = []
+        for (sub_streamlines, sub_dps) in zip(streamlines, dps):
+            if len(streamlines) == 0:
+                logging.info("Empty SFT not reconstructed from hdf5.")
+            else:
+                sfts.append(
+                    StatefulTractogram(sub_streamlines, header, space=space,
+                                       origin=origin,
+                                       data_per_streamline=sub_dps))
+        return sfts, groups_len
+
+
+def assert_header_compatible_hdf5(hdf5_handle, ref):
+    """
+    Parameters
+    ----------
+    hdf5_handle: hdf5.file
+        Opened hdf5 handle.
+    ref: Either a tuple (affine, dimension) or a nib.Nifti1Image reference.
+    """
+    if isinstance(ref, tuple) or isinstance(ref, list):
+        ref_affine, ref_dimension = ref
+        name = 'reference'
+    else:
+        # Expecting nibabel reference
+        ref_affine = ref.affine
+        ref_dimension = ref.shape
+        name = ref.filename
+
+    affine = hdf5_handle.attrs['affine']
+    dimensions = hdf5_handle.attrs['dimensions']
+    if not (np.allclose(affine, ref_affine, atol=1e-03)
+            and np.array_equal(dimensions, ref_dimension[0:3])):
+        raise IOError('HDF5 file does not have a compatible header with'
+                      ' {}'.format(name))
+
+
+def reconstruct_streamlines_from_hdf5(hdf5_group):
+    """
+    Function to reconstruct streamlines from hdf5, mainly to facilitate
+    decomposition into thousands of connections and decrease I/O usage.
+
+    Parameters
+    ----------
+    hdf5_group: h5py.group
+        Handle to the hdf5 group. Ex: hdf5_file[bundle_key].
+
+    Returns
+    -------
+    streamlines : list of np.ndarray
+        List of streamlines.
+    """
+    if 'data' not in hdf5_group:
+        raise ValueError("Expecting data in bundle's group.")
+
+    data = np.array(hdf5_group['data']).flatten()
+    offsets = np.array(hdf5_group['offsets'])
+    lengths = np.array(hdf5_group['lengths'])
+
+    return reconstruct_streamlines(data, offsets, lengths)
+
+
+def construct_hdf5_from_sft(hdf5_handle, sfts, groups_keys='streamlines',
+                            save_dps=False, save_dpp=False):
+    """
+    Create a hdf5 from a SFT.
+
+    Parameters
+    ----------
+    hdf5_handle: h5py.file
+        Opened handle to the hdf5 group.
+    sfts: StatefulTractogram or list[StatefulTractogram]
+    groups_keys: str or list[str]
+        The streamlines' hdf5 group name.
+    save_dps: bool
+        If True, save the DPS keys to hdf5.
+    save_dpp: bool
+        If True, save the DPP keys to hdf5.
+    """
+    if isinstance(sfts, StatefulTractogram):
+        sfts = [sfts]
+    if isinstance(groups_keys, list):
+        groups_keys = [groups_keys]
+
+    assert len(sfts) == len(groups_keys)
+
+    # Prepare header
+    construct_hdf5_header(hdf5_handle, sfts[0])
+
+    # Prepare streamline groups
+    for sft, group_key in zip(sfts, groups_keys):
+        sft.to_vox()
+        sft.to_corner()
+        group = hdf5_handle.create_group(group_key)
+        construct_hdf5_group_from_streamlines(
+            group, sft.streamlines,
+            sft.data_per_streamline if save_dps else None,
+            sft.data_per_point if save_dpp else None)
+
+
+def construct_hdf5_header(hdf5_handle, ref_sft):
+    ref_sft.to_vox()
+    ref_sft.to_corner()
+    hdf5_handle.attrs['affine'] = ref_sft.affine
+    hdf5_handle.attrs['dimensions'] = ref_sft.dimensions
+    hdf5_handle.attrs['voxel_sizes'] = ref_sft.voxel_sizes
+    hdf5_handle.attrs['voxel_order'] = ref_sft.voxel_order
+
+
+def construct_hdf5_group_from_streamlines(hdf5_group, streamlines,
+                                          dps=None, dpp=None):
+    """
+    Create a hdf5 group from streamlines.
+
+    Parameters
+    ----------
+    hdf5_group: h5py.group
+        Handle to the hdf5 group. Ex: hdf5_file[bundle_key].
+    streamlines: ArraySequence
+        The streamlines. Expecting streamlines in voxel space, corner origin.
+    dps: dict or None
+        The data_per_streamline
+    dpp: dict or None
+        The data_per_point
+    """
+    hdf5_group.create_dataset('data', data=streamlines.get_data(),
+                              dtype=np.float32)
+    hdf5_group.create_dataset('offsets', data=streamlines.copy()._offsets,
+                              dtype=np.int64)
+    hdf5_group.create_dataset('lengths', data=streamlines.copy()._lengths,
+                              dtype=np.int32)
+    if dps is not None:
+        for dps_key, dps_value in dps.items():
+            if dps_key not in ['data', 'offsets', 'lengths']:
+                hdf5_group.create_dataset(dps_key, data=dps_value,
+                                          dtype=np.float32)
+            else:
+                raise ValueError("Please do not use data_per_streamline keys "
+                                 "'data', 'offsets' or 'lengths', this "
+                                 "causes unclear management in the hdf5.")
+
+    if dpp is not None:
+        raise NotImplementedError(
+            "NOT IMPLEMENTED: Cannot save data_per_point in the hdf5 yet.")

--- a/scilpy/io/streamlines.py
+++ b/scilpy/io/streamlines.py
@@ -6,8 +6,8 @@ import os
 import tempfile
 
 from dipy.io.streamline import load_tractogram
-import nibabel as nib
 from dipy.io.utils import is_header_compatible
+import nibabel as nib
 from nibabel.streamlines.array_sequence import ArraySequence
 import numpy as np
 
@@ -314,42 +314,6 @@ def reconstruct_streamlines_from_memmap(memmap_filenames, indices=None,
     lengths = np.memmap(memmap_filenames[2],  dtype='int32', mode='r')
 
     return reconstruct_streamlines(data, offsets, lengths, indices=indices)
-
-
-def reconstruct_streamlines_from_hdf5(hdf5_filename, key=None):
-    """
-    Function to reconstruct streamlines from hdf5, mainly to facilitate
-    decomposition into thousand of connections and decrease I/O usage.
-
-    Parameters
-    ----------
-    hdf5_filename: str
-        Filepath to the hdf5 file.
-    key: str
-        Key of the connection of interest (LABEL1_LABEL2).
-
-    Returns
-    -------
-    streamlines : list of np.ndarray
-        List of streamlines.
-    """
-
-    hdf5_file = hdf5_filename
-
-    if key is not None:
-        if key not in hdf5_file:
-            return []
-        group = hdf5_file[key]
-        if 'data' not in group:
-            return []
-    else:
-        group = hdf5_file
-
-    data = np.array(group['data']).flatten()
-    offsets = np.array(group['offsets'])
-    lengths = np.array(group['lengths'])
-
-    return reconstruct_streamlines(data, offsets, lengths)
 
 
 def reconstruct_streamlines(data, offsets, lengths, indices=None):

--- a/scilpy/tractograms/streamline_and_mask_operations.py
+++ b/scilpy/tractograms/streamline_and_mask_operations.py
@@ -128,7 +128,8 @@ def cut_outside_of_mask_streamlines(sft, binary_mask, min_len=0):
     new_streamlines = _cut_streamlines_with_masks(
         streamlines, binary_mask, binary_mask)
 
-    new_sft = StatefulTractogram.from_sft(new_streamlines, sft)
+    new_sft = StatefulTractogram.from_sft(
+        new_streamlines, sft, data_per_streamline=sft.data_per_streamline)
     return filter_streamlines_by_length(new_sft, min_length=min_len)
 
 
@@ -166,7 +167,8 @@ def cut_between_mask_two_blobs_streamlines(sft, binary_mask, min_len=0):
     # New endpoints may be generated
     new_streamlines = _cut_streamlines_with_masks(streamlines, roi_data_1,
                                                   roi_data_2)
-    new_sft = StatefulTractogram.from_sft(new_streamlines, sft)
+    new_sft = StatefulTractogram.from_sft(
+        new_streamlines, sft, data_per_streamline=sft.data_per_streamline)
     return filter_streamlines_by_length(new_sft, min_length=min_len)
 
 

--- a/scilpy/tractograms/tests/test_streamline_and_mask_operations.py
+++ b/scilpy/tractograms/tests/test_streamline_and_mask_operations.py
@@ -113,17 +113,15 @@ def test_cut_outside_of_mask_streamlines():
 
     sft, reference, _, _, center_roi = _setup_files()
 
-    cut_sft = cut_outside_of_mask_streamlines(
-        sft, center_roi)
+    cut_sft = cut_outside_of_mask_streamlines(sft, center_roi)
+    cut_sft.to_vox()
+    cut_sft.to_corner()
 
     in_result = os.path.join(SCILPY_HOME, 'tractograms',
                              'streamline_and_mask_operations',
                              'bundle_4_cut_center.tck')
 
     res = load_tractogram(in_result, reference)
-    # `cut_outside_of_mask_streamlines` always returns a voxel space sft
-    # with streamlines in corner, so move the expected result to the same
-    # space.
     res.to_vox()
     res.to_corner()
     assert np.allclose(cut_sft.streamlines._data, res.streamlines._data)
@@ -136,10 +134,11 @@ def test_cut_between_mask_two_blobs_streamlines():
     """
 
     sft, reference, head_tail_rois, *_ = _setup_files()
-    # head_tail_rois is a mask with two rois that correspond
-    # to the bundle's endpoints.
-    cut_sft = cut_between_mask_two_blobs_streamlines(
-        sft, head_tail_rois)
+    # head_tail_rois is a mask with two rois that correspond to the bundle's
+    # endpoints.
+    cut_sft = cut_between_mask_two_blobs_streamlines(sft, head_tail_rois)
+    cut_sft.to_vox()
+    cut_sft.to_corner()
 
     # The expected result is the input bundle.
     in_result = os.path.join(SCILPY_HOME, 'tractograms',
@@ -147,9 +146,6 @@ def test_cut_between_mask_two_blobs_streamlines():
                              'bundle_4.tck')
 
     res = load_tractogram(in_result, reference)
-    # `cut_between_mask_two_blobs_streamlines` always returns a voxel space sft
-    # with streamlines in corner, so move the expected result to the same
-    # space.
     res.to_vox()
     res.to_corner()
     # The streamlines should not have changed.
@@ -163,19 +159,18 @@ def test_cut_between_mask_two_blobs_streamlines_offset():
     """
 
     sft, reference, _, head_tail_offset_rois, _ = _setup_files()
-    # head_tail_offset_rois is a mask with two rois that are not
-    # exactly at the endpoints of the bundle.
+    # head_tail_offset_rois is a mask with two rois that are not exactly at the
+    # endpoints of the bundle.
     cut_sft = cut_between_mask_two_blobs_streamlines(
         sft, head_tail_offset_rois)
+    cut_sft.to_vox()
+    cut_sft.to_corner()
 
     in_result = os.path.join(SCILPY_HOME, 'tractograms',
                              'streamline_and_mask_operations',
                              'bundle_4_cut_endpoints.tck')
 
     res = load_tractogram(in_result, reference)
-    # `cut_between_mask_two_blobs_streamlines` always returns a voxel space sft
-    # with streamlines in corner, so move the expected result to the same
-    # space.
     res.to_vox()
     res.to_corner()
     assert np.allclose(cut_sft.streamlines._data, res.streamlines._data)

--- a/scilpy/viz/utils.py
+++ b/scilpy/viz/utils.py
@@ -154,3 +154,32 @@ def clip_and_normalize_data_for_cmap(
     data -= lbound
     data = data / ubound if ubound > 0 else data
     return data, lbound, ubound
+
+
+def format_hexadecimal_color_to_rgb(color):
+    """
+    Convert a hexadecimal color name (either "#RRGGBB" or 0xRRGGBB) to RGB
+    values.
+
+    Parameters
+    ----------
+    color: str
+        The hexadecimal name
+
+    Returns
+    -------
+    (R, G, B): int values.
+    """
+    if len(color) == 7:
+        color = '0x' + color.lstrip('#')
+
+    if len(color) == 8:
+        color_int = int(color, 0)
+        red = color_int >> 16
+        green = (color_int & 0x00FF00) >> 8
+        blue = color_int & 0x0000FF
+    else:
+        raise ValueError('Hexadecimal RGB color should be formatted as '
+                         '"#RRGGBB" or 0xRRGGBB.')
+
+    return red, green, blue

--- a/scripts/scil_bundle_mean_fixel_afd_from_hdf5.py
+++ b/scripts/scil_bundle_mean_fixel_afd_from_hdf5.py
@@ -26,7 +26,7 @@ import h5py
 import nibabel as nib
 import numpy as np
 
-from scilpy.io.streamlines import reconstruct_streamlines_from_hdf5
+from scilpy.io.hdf5 import reconstruct_streamlines_from_hdf5
 from scilpy.io.utils import (add_overwrite_arg,
                              add_processes_arg,
                              add_sh_basis_args,
@@ -60,7 +60,7 @@ def _afd_rd_wrapper(args):
         affine = in_hdf5_file.attrs['affine']
         dimensions = in_hdf5_file.attrs['dimensions']
         voxel_sizes = in_hdf5_file.attrs['voxel_sizes']
-        streamlines = reconstruct_streamlines_from_hdf5(in_hdf5_file, key)
+        streamlines = reconstruct_streamlines_from_hdf5(in_hdf5_file[key])
         if len(streamlines) == 0:
             return key, 0
 

--- a/scripts/scil_connectivity_compute_matrices.py
+++ b/scripts/scil_connectivity_compute_matrices.py
@@ -57,8 +57,8 @@ import numpy as np
 import scipy.ndimage as ndi
 
 from scilpy.image.labels import get_data_as_labels
+from scilpy.io.hdf5 import reconstruct_streamlines_from_hdf5
 from scilpy.io.image import get_data_as_mask
-from scilpy.io.streamlines import reconstruct_streamlines_from_hdf5
 from scilpy.io.utils import (add_overwrite_arg, add_processes_arg,
                              add_verbose_arg,
                              assert_inputs_exist, assert_outputs_exist,
@@ -97,7 +97,7 @@ def _processing_wrapper(args):
     key = '{}_{}'.format(in_label, out_label)
     if key not in hdf5_file:
         return
-    streamlines = reconstruct_streamlines_from_hdf5(hdf5_file, key)
+    streamlines = reconstruct_streamlines_from_hdf5(hdf5_file[key])
     if len(streamlines) == 0:
         return
 

--- a/scripts/scil_connectivity_hdf5_average_density_map.py
+++ b/scripts/scil_connectivity_hdf5_average_density_map.py
@@ -29,7 +29,7 @@ import h5py
 import numpy as np
 import nibabel as nib
 
-from scilpy.io.streamlines import reconstruct_streamlines_from_hdf5
+from scilpy.io.hdf5 import reconstruct_streamlines_from_hdf5
 from scilpy.io.utils import (add_overwrite_arg,
                              add_verbose_arg,
                              add_processes_arg,
@@ -76,7 +76,7 @@ def _average_wrapper(args):
                     hdf5_filename))
             # scil_tractogram_segment_bundles_for_connectivity.py saves the
             # streamlines in VOX/CORNER
-            streamlines = reconstruct_streamlines_from_hdf5(hdf5_file, key)
+            streamlines = reconstruct_streamlines_from_hdf5(hdf5_file[key])
             if len(streamlines) == 0:
                 continue
             density = compute_tract_counts_map(streamlines, dimensions)

--- a/scripts/scil_tractogram_apply_transform.py
+++ b/scripts/scil_tractogram_apply_transform.py
@@ -2,15 +2,16 @@
 # -*- coding: utf-8 -*-
 
 """
-Transform tractogram using an affine/rigid transformation and nonlinear
+Transform a tractogram using an affine/rigid transformation and nonlinear
 deformation (optional).
 
 For more information on how to use the registration script, follow this link:
 https://scilpy.readthedocs.io/en/latest/documentation/tractogram_registration.html
 
 Applying transformation to a tractogram can lead to invalid streamlines (out of
-the bounding box), three strategies are available:
-1) default, crash at saving if invalid streamlines are present.
+the bounding box), and thus three strategies are available:
+1) Do nothing, may crash at saving if invalid streamlines are present.
+   [This is the default]
 2) --keep_invalid, save invalid streamlines. Leave it to the user to run
     scil_tractogram_remove_invalid.py if needed.
 3) --remove_invalid, automatically remove invalid streamlines before saving.
@@ -21,15 +22,15 @@ the bounding box), three strategies are available:
    streamlines are kept but the points out of the bounding box are cut.
 
 Example:
-To apply a transform from ANTS to a tractogram, if the ANTS command was
+To apply a transformation from ANTs to a tractogram, if the ANTs command was
 MOVING->REFERENCE...
-1) To apply the original transform, MOVING->REFERENCE
+1) To apply the original transformation:
 scil_tractogram_apply_transform.py ${MOVING_FILE} ${REFERENCE_FILE}
                                    0GenericAffine.mat ${OUTPUT_NAME}
                                    --inverse
                                    --in_deformation 1InverseWarp.nii.gz
 
-2) To apply the inverse transform, i.e. REFERENCE->MOVING
+2) To apply the inverse transformation, i.e. REFERENCE->MOVING:
 scil_tractogram_apply_transform.py ${MOVING_FILE} ${REFERENCE_FILE}
                                    0GenericAffine.mat ${OUTPUT_NAME}
                                    --in_deformation 1Warp.nii.gz

--- a/scripts/scil_tractogram_apply_transform.py
+++ b/scripts/scil_tractogram_apply_transform.py
@@ -8,25 +8,28 @@ deformation (optional).
 For more information on how to use the registration script, follow this link:
 https://scilpy.readthedocs.io/en/latest/documentation/tractogram_registration.html
 
-Applying transformation to tractogram can lead to invalid streamlines (out of
+Applying transformation to a tractogram can lead to invalid streamlines (out of
 the bounding box), three strategies are available:
-1) default, crash at saving if invalid streamlines are present
+1) default, crash at saving if invalid streamlines are present.
 2) --keep_invalid, save invalid streamlines. Leave it to the user to run
     scil_tractogram_remove_invalid.py if needed.
 3) --remove_invalid, automatically remove invalid streamlines before saving.
-    Should not remove more than a few streamlines.
-4) --cut_invalid, automatically cut invalid streamlines before saving.
+    Should not remove more than a few streamlines. Typically, the streamlines
+    that are rejected are the ones reaching the limits of the brain, ex, near
+    the pons.
+4) --cut_invalid, automatically cut invalid streamlines before saving, i.e. the
+   streamlines are kept but the points out of the bounding box are cut.
 
 Example:
-To apply transform from ANTS to tractogram. If the ANTS commands was
-MOVING->REFERENCE, this will bring a tractogram from MOVING->REFERENCE
+To apply a transform from ANTS to a tractogram, if the ANTS command was
+MOVING->REFERENCE...
+1) To apply the original transform, MOVING->REFERENCE
 scil_tractogram_apply_transform.py ${MOVING_FILE} ${REFERENCE_FILE}
                                    0GenericAffine.mat ${OUTPUT_NAME}
                                    --inverse
                                    --in_deformation 1InverseWarp.nii.gz
 
-If the ANTS commands was MOVING->REFERENCE, this will bring a tractogram
-from REFERENCE->MOVING
+2) To apply the inverse transform, i.e. REFERENCE->MOVING
 scil_tractogram_apply_transform.py ${MOVING_FILE} ${REFERENCE_FILE}
                                    0GenericAffine.mat ${OUTPUT_NAME}
                                    --in_deformation 1Warp.nii.gz
@@ -58,7 +61,7 @@ def _build_arg_parser():
 
     p.add_argument('in_moving_tractogram',
                    help='Path of the tractogram to be transformed.\n'
-                        'Bounding box validity will not be checked (could '
+                        'Bounding box validity will not be checked (could \n'
                         'contain invalid streamlines).')
     p.add_argument('in_target_file',
                    help='Path of the reference target file (trk or nii).')
@@ -68,14 +71,17 @@ def _build_arg_parser():
     p.add_argument('out_tractogram',
                    help='Output tractogram filename (transformed data).')
 
-    p.add_argument('--inverse', action='store_true',
+    g = p.add_argument_group("Transformation options")
+    g.add_argument('--inverse', action='store_true',
                    help='Apply the inverse linear transformation.')
-    p.add_argument('--in_deformation',
+    g.add_argument('--in_deformation', metavar='file',
                    help='Path to the file containing a deformation field.')
-    p.add_argument('--reverse_operation', action='store_true',
-                   help='Apply the transformation in reverse (see doc),'
-                        'warp first, then linear.')
-    invalid = p.add_mutually_exclusive_group()
+    g.add_argument('--reverse_operation', action='store_true',
+                   help='Apply the transformation in reverse (see doc), warp\n'
+                        'first, then linear.')
+
+    g = p.add_argument_group("Management of invalid streamlines")
+    invalid = g.add_mutually_exclusive_group()
     invalid.add_argument('--cut_invalid', action='store_true',
                          help='Cut invalid streamlines rather than removing '
                               'them.\nKeep the longest segment only.')
@@ -103,6 +109,7 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
+    # Verifications
     assert_inputs_exist(parser, [args.in_moving_tractogram,
                                  args.in_target_file,
                                  args.in_transfo],
@@ -110,6 +117,8 @@ def main():
     assert_outputs_exist(parser, args, args.out_tractogram)
 
     args.bbox_check = False  # Adding manually bbox_check argument.
+
+    # Loading
     moving_sft = load_tractogram_with_reference(parser, args,
                                                 args.in_moving_tractogram)
 
@@ -119,6 +128,7 @@ def main():
         deformation_data = np.squeeze(nib.load(
             args.in_deformation).get_fdata(dtype=np.float32))
 
+    # Processing
     new_sft = transform_warp_sft(moving_sft, transfo,
                                  args.in_target_file,
                                  inverse=args.inverse,
@@ -127,11 +137,11 @@ def main():
                                  remove_invalid=args.remove_invalid,
                                  cut_invalid=args.cut_invalid)
 
-    if len(new_sft.streamlines) == 0:
-        if args.no_empty:
-            logging.info("The file {} won't be written "
-                         "(0 streamline).".format(args.out_tractogram))
-            return
+    # Saving
+    if len(new_sft.streamlines) == 0 and args.no_empty:
+        logging.info("The file {} won't be written "
+                     "(0 streamline).".format(args.out_tractogram))
+        return
 
     if args.keep_invalid:
         if not new_sft.is_bbox_in_vox_valid():

--- a/scripts/scil_tractogram_apply_transform.py
+++ b/scripts/scil_tractogram_apply_transform.py
@@ -143,15 +143,18 @@ def main():
                      "(0 streamline).".format(args.out_tractogram))
         return
 
+    # Default is to crash if invalid.
     if args.keep_invalid:
         if not new_sft.is_bbox_in_vox_valid():
             logging.warning('Saving tractogram with invalid streamlines.')
         save_tractogram(new_sft, args.out_tractogram, bbox_valid_check=False)
     else:
+        # Here, there should be no invalid streamlines left. Either option =
+        # to crash, or remove/cut, already managed.
         if not new_sft.is_bbox_in_vox_valid():
-            logging.warning('Removing invalid streamlines before '
-                            'saving tractogram.')
-            new_sft.remove_invalid_streamlines()
+            raise ValueError("The result has invalid streamlines. Please "
+                             "chose --keep_invalid, --cut_invalid or "
+                             "--remove_invalid.")
         save_tractogram(new_sft, args.out_tractogram)
 
 

--- a/scripts/scil_tractogram_assign_uniform_color.py
+++ b/scripts/scil_tractogram_assign_uniform_color.py
@@ -2,14 +2,14 @@
 # -*- coding: utf-8 -*-
 
 """
-Assign an hexadecimal RGB color to one or more Trackvis TRK tractogram.
-The hexadecimal RGB color should be formatted as 0xRRGGBB or "#RRGGBB".
+Assign an hexadecimal RGB color to one or more Trackvis (.trk) tractogram.
+(If called with .tck, the output will always be .trk, because data_per_point
+has no equivalent in tck file.)
 
 Saves the RGB values in the data_per_point 'color' with values
 (color_x, color_y, color_z).
 
-If called with .tck, the output will always be .trk, because data_per_point has
-no equivalent in tck file.
+The hexadecimal RGB color should be formatted as 0xRRGGBB or "#RRGGBB".
 
 See also: scil_tractogram_assign_custom_color.py
 
@@ -92,13 +92,14 @@ def main():
         out_filenames = [args.out_tractogram]
         _, ext = os.path.splitext(args.out_tractogram)
         if not ext == '.trk':
-            parser.error("--out_tractogram should be a .trk file.")
+            parser.error("--out_tractogram must be a .trk file.")
     else:  # args.out_suffix
         out_filenames = []
         for filename in args.in_tractograms:
             base, ext = os.path.splitext(filename)
             if not ext == '.trk':
-                logging.warning('Input is TCK file, will be converted to TRK.')
+                logging.warning('Input is a .tck file, but output will be a '
+                                '.trk file.')
             out_filenames.append('{}{}{}'
                                  .format(base, args.out_suffix, '.trk'))
     assert_outputs_exist(parser, args, out_filenames)

--- a/scripts/scil_tractogram_assign_uniform_color.py
+++ b/scripts/scil_tractogram_assign_uniform_color.py
@@ -2,14 +2,16 @@
 # -*- coding: utf-8 -*-
 
 """
-Assign an hexadecimal RGB color to a Trackvis TRK tractogram.
-The hexadecimal RGB color should be formatted as 0xRRGGBB or
-"#RRGGBB".
+Assign an hexadecimal RGB color to one or more Trackvis TRK tractogram.
+The hexadecimal RGB color should be formatted as 0xRRGGBB or "#RRGGBB".
 
-Saves the RGB values in the data_per_point (color_x, color_y, color_z).
+Saves the RGB values in the data_per_point 'color' with values
+(color_x, color_y, color_z).
 
 If called with .tck, the output will always be .trk, because data_per_point has
 no equivalent in tck file.
+
+See also: scil_tractogram_assign_custom_color.py
 
 Formerly: scil_assign_uniform_color_to_tractograms.py
 """
@@ -28,6 +30,7 @@ from scilpy.io.utils import (assert_inputs_exist,
                              add_overwrite_arg,
                              add_verbose_arg,
                              add_reference_arg, assert_headers_compatible)
+from scilpy.viz.utils import format_hexadecimal_color_to_rgb
 
 
 def _build_arg_parser():
@@ -39,21 +42,23 @@ def _build_arg_parser():
                    help='Input tractograms (.trk or .tck).')
 
     g1 = p.add_argument_group(title='Coloring Methods')
-    p1 = g1.add_mutually_exclusive_group()
+    p1 = g1.add_mutually_exclusive_group(required=True)
     p1.add_argument('--fill_color',
-                    help='Can be either hexadecimal (ie. "#RRGGBB" '
+                    help='Can be hexadecimal (ie. either "#RRGGBB" '
                          'or 0xRRGGBB).')
     p1.add_argument('--dict_colors',
                     help='Dictionnary mapping basename to color.\n'
                          'Same convention as --fill_color.')
 
     g2 = p.add_argument_group(title='Output options')
-    p2 = g2.add_mutually_exclusive_group()
+    p2 = g2.add_mutually_exclusive_group(required=True)
     p2.add_argument('--out_suffix', default='colored',
-                    help='Specify suffix to append to input basename.')
+                    help='Specify suffix to append to input basename.\n'
+                         'Mandatory choice if you run this script on multiple '
+                         'tractograms.\nMandatory choice with --dict_colors.\n'
+                         '[%(default)s]')
     p2.add_argument('--out_tractogram',
-                    help='Output filename of colored tractogram (.trk).\n'
-                         'Cannot be used with --dict_colors.')
+                    help='Output filename of colored tractogram (.trk).')
 
     add_reference_arg(p)
     add_verbose_arg(p)
@@ -67,63 +72,69 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
+    # Verifications
     if len(args.in_tractograms) > 1 and args.out_tractogram:
         parser.error('Using multiple inputs, use --out_suffix.')
+    if args.dict_colors and args.out_tractogram:
+        parser.error('Using --dict_colors, use --out_suffix.')
 
     assert_inputs_exist(parser, args.in_tractograms, args.reference)
     assert_headers_compatible(parser, args.in_tractograms,
                               reference=args.reference)
 
-    if args.out_suffix:
-        if args.out_tractogram:
-            args.out_suffix = ''
-        elif args.out_suffix[0] != '_':
-            args.out_suffix = '_'+args.out_suffix
+    if args.out_suffix and args.out_suffix[0] != '_':
+        args.out_suffix = '_' + args.out_suffix
 
-    out_filenames = []
-    for filename in args.in_tractograms:
-        base, ext = os.path.splitext(filename) if args.out_tractogram is None \
-            else os.path.splitext(args.out_tractogram)
+    if args.out_tractogram:
+        out_filenames = [args.out_tractogram]
+        _, ext = os.path.splitext(args.out_tractogram)
         if not ext == '.trk':
-            logging.warning('Input is TCK file, will be converted to TRK.')
-        out_filenames.append('{}{}{}'.format(base, args.out_suffix, '.trk'))
+            parser.error("--out_tractogram should be a .trk file.")
+    else:  # args.out_suffix
+        out_filenames = []
+        for filename in args.in_tractograms:
+            base, ext = os.path.splitext(filename)
+            if not ext == '.trk':
+                logging.warning('Input is TCK file, will be converted to TRK.')
+            out_filenames.append('{}{}{}'
+                                 .format(base, args.out_suffix, '.trk'))
     assert_outputs_exist(parser, args, out_filenames)
 
+    dict_colors = None
+    if args.dict_colors:
+        with open(args.dict_colors, 'r') as data:
+            dict_colors = json.load(data)
+
+    # Processing
     for i, filename in enumerate(args.in_tractograms):
+        color = None
+
+        # Loading
         sft = load_tractogram_with_reference(parser, args, filename)
+
+        # Processing.
         base, ext = os.path.splitext(filename)
-        out_filename = out_filenames[i]
         pos = base.index('__') if '__' in base else -2
         base = base[pos+2:]
-        color = None
+
         if args.dict_colors:
-            with open(args.dict_colors, 'r') as data:
-                dict_colors = json.load(data)
-            # Supports variation from rbx-flow
             for key in dict_colors.keys():
                 if key in base:
                     color = dict_colors[key]
-        elif args.fill_color is not None:
+            if color is None:
+                parser.error("Basename of file {} ({}) not found in your "
+                             "dict_colors keys.".format(filename, base))
+        else:  # args.fill_color is not None:
             color = args.fill_color
 
-        if color is None:
-            color = '0x000000'
+        red, green, blue = format_hexadecimal_color_to_rgb(color)
 
-        if len(color) == 7:
-            args.fill_color = '0x' + args.fill_color.lstrip('#')
-
-        if len(color) == 8:
-            color_int = int(color, 0)
-            red = color_int >> 16
-            green = (color_int & 0x00FF00) >> 8
-            blue = color_int & 0x0000FF
-        else:
-            parser.error('Hexadecimal RGB color should be formatted as '
-                         '"#RRGGBB" or 0xRRGGBB.')
         tmp = [np.tile([red, green, blue], (len(i), 1))
                for i in sft.streamlines]
         sft.data_per_point['color'] = tmp
-        save_tractogram(sft, out_filename)
+
+        # Saving
+        save_tractogram(sft, out_filenames[i])
 
 
 if __name__ == '__main__':

--- a/scripts/scil_tractogram_assign_uniform_color.py
+++ b/scripts/scil_tractogram_assign_uniform_color.py
@@ -43,21 +43,24 @@ def _build_arg_parser():
 
     g1 = p.add_argument_group(title='Coloring Methods')
     p1 = g1.add_mutually_exclusive_group(required=True)
-    p1.add_argument('--fill_color',
+    p1.add_argument('--fill_color', metavar='str',
                     help='Can be hexadecimal (ie. either "#RRGGBB" '
                          'or 0xRRGGBB).')
-    p1.add_argument('--dict_colors',
-                    help='Dictionnary mapping basename to color.\n'
-                         'Same convention as --fill_color.')
+    p1.add_argument('--dict_colors', metavar='file.json',
+                    help="Json file: dictionnary mapping each tractogram's "
+                         "basename to a color.\nDo not put your file's "
+                         "extension in your dict.\n"
+                         "Same convention as --fill_color.")
 
     g2 = p.add_argument_group(title='Output options')
     p2 = g2.add_mutually_exclusive_group(required=True)
-    p2.add_argument('--out_suffix', default='colored',
+    p2.add_argument('--out_suffix', nargs='?', const='colored',
+                    metavar='suffix',
                     help='Specify suffix to append to input basename.\n'
                          'Mandatory choice if you run this script on multiple '
                          'tractograms.\nMandatory choice with --dict_colors.\n'
                          '[%(default)s]')
-    p2.add_argument('--out_tractogram',
+    p2.add_argument('--out_tractogram', metavar='file.trk',
                     help='Output filename of colored tractogram (.trk).')
 
     add_reference_arg(p)
@@ -100,6 +103,7 @@ def main():
                                  .format(base, args.out_suffix, '.trk'))
     assert_outputs_exist(parser, args, out_filenames)
 
+    # Loading (except tractograms, in loop)
     dict_colors = None
     if args.dict_colors:
         with open(args.dict_colors, 'r') as data:
@@ -109,15 +113,13 @@ def main():
     for i, filename in enumerate(args.in_tractograms):
         color = None
 
-        # Loading
         sft = load_tractogram_with_reference(parser, args, filename)
 
-        # Processing.
-        base, ext = os.path.splitext(filename)
-        pos = base.index('__') if '__' in base else -2
-        base = base[pos+2:]
-
         if args.dict_colors:
+            base, ext = os.path.splitext(filename)
+            pos = base.index('__') if '__' in base else -2
+            base = base[pos + 2:]
+
             for key in dict_colors.keys():
                 if key in base:
                     color = dict_colors[key]

--- a/scripts/scil_tractogram_commit.py
+++ b/scripts/scil_tractogram_commit.py
@@ -85,8 +85,8 @@ import numpy as np
 import nibabel as nib
 
 from scilpy.io.gradients import fsl2mrtrix
-from scilpy.io.streamlines import (reconstruct_streamlines,
-                                   reconstruct_streamlines_from_hdf5)
+from scilpy.io.hdf5 import reconstruct_streamlines_from_hdf5
+from scilpy.io.streamlines import reconstruct_streamlines
 from scilpy.io.utils import (add_overwrite_arg,
                              add_processes_arg,
                              add_verbose_arg,
@@ -365,8 +365,7 @@ def main():
         hdf5_keys = list(hdf5_file.keys())
         streamlines = []
         for key in hdf5_keys:
-            tmp_streamlines = reconstruct_streamlines_from_hdf5(hdf5_file,
-                                                                key)
+            tmp_streamlines = reconstruct_streamlines_from_hdf5(hdf5_file[key])
             streamlines.extend(tmp_streamlines)
             bundle_groups_len.append(len(tmp_streamlines))
 

--- a/scripts/scil_tractogram_convert_hdf5_to_trk.py
+++ b/scripts/scil_tractogram_convert_hdf5_to_trk.py
@@ -33,7 +33,7 @@ import h5py
 import itertools
 import numpy as np
 
-from scilpy.io.streamlines import reconstruct_streamlines_from_hdf5
+from scilpy.io.hdf5 import reconstruct_streamlines_from_hdf5
 from scilpy.io.utils import (add_overwrite_arg,
                              add_verbose_arg,
                              assert_inputs_exist,
@@ -109,7 +109,7 @@ def main():
         voxel_sizes = hdf5_file.attrs['voxel_sizes']
         header = create_nifti_header(affine, dimensions, voxel_sizes)
         for key in selected_keys:
-            streamlines = reconstruct_streamlines_from_hdf5(hdf5_file, key)
+            streamlines = reconstruct_streamlines_from_hdf5(hdf5_file[key])
 
             if len(streamlines) == 0 and not args.save_empty:
                 continue

--- a/scripts/scil_tractogram_cut_streamlines.py
+++ b/scripts/scil_tractogram_cut_streamlines.py
@@ -80,11 +80,16 @@ def main():
 
     # Loading
     sft = load_tractogram_with_reference(parser, args, args.in_tractogram)
-    if args.step_size is not None:
-        sft = resample_streamlines_step_size(sft, args.step_size)
-
     mask_img = nib.load(args.in_mask)
     binary_mask = get_data_as_mask(mask_img)
+
+    # Streamlines must be in voxel space to deal correctly with bounding box.
+    sft.to_vox()
+    sft.to_corner()
+
+    # Processing
+    if args.step_size is not None:
+        sft = resample_streamlines_step_size(sft, args.step_size)
 
     # Segment into blobs, count each.
     bundle_disjoint, _ = ndi.label(binary_mask)

--- a/scripts/scil_tractogram_cut_streamlines.py
+++ b/scripts/scil_tractogram_cut_streamlines.py
@@ -2,9 +2,9 @@
 # -*- coding: utf-8 -*-
 
 """
-Filters streamlines and only keeps the parts of streamlines within or
-between the ROIs. The script accepts a single input mask, the mask has either
-1 entity/blob or 2 entities/blobs (does not support disconnected voxels).
+Filters streamlines and only keeps the parts of streamlines within or between
+the ROIs. The script accepts a single input mask, the mask has either 1
+entity/blob or 2 entities/blobs (does not support disconnected voxels).
 The option --biggest_blob can help if you have such a scenario.
 
 The 1 entity scenario will 'trim' the streamlines so their longest segment is
@@ -22,7 +22,6 @@ import argparse
 import logging
 
 from dipy.io.streamline import save_tractogram
-from dipy.io.utils import is_header_compatible
 from dipy.io.stateful_tractogram import StatefulTractogram
 from dipy.tracking.streamlinespeed import compress_streamlines
 import nibabel as nib
@@ -49,12 +48,13 @@ def _build_arg_parser():
     p.add_argument('in_mask',
                    help='Binary mask containing either 1 or 2 blobs.')
     p.add_argument('out_tractogram',
-                   help='Output tractogram file.')
+                   help='Output tractogram file. Note: data_per_point will be '
+                        'discarded, if any!')
 
-    p.add_argument('--resample', dest='step_size', type=float, default=None,
+    p.add_argument('--resample', dest='step_size', type=float,
                    help='Resample streamlines to a specific step-size in mm '
                         '[%(default)s].')
-    p.add_argument('--compress', dest='error_rate', type=float, default=None,
+    p.add_argument('--compress', dest='error_rate', type=float,
                    help='Maximum compression distance in mm [%(default)s].')
     p.add_argument('--biggest_blob', action='store_true',
                    help='Use the biggest entity and force the 1 ROI scenario.')
@@ -71,12 +71,14 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
+    # Verifications
     assert_inputs_exist(parser, [args.in_tractogram, args.in_mask],
                         args.reference)
     assert_outputs_exist(parser, args, args.out_tractogram)
     assert_headers_compatible(parser, [args.in_tractogram, args.in_mask],
                               reference=args.reference)
 
+    # Loading
     sft = load_tractogram_with_reference(parser, args, args.in_tractogram)
     if args.step_size is not None:
         sft = resample_streamlines_step_size(sft, args.step_size)
@@ -84,39 +86,42 @@ def main():
     mask_img = nib.load(args.in_mask)
     binary_mask = get_data_as_mask(mask_img)
 
-    if not is_header_compatible(sft, mask_img):
-        parser.error('Incompatible header between the tractogram and mask.')
-
+    # Segment into blobs, count each.
     bundle_disjoint, _ = ndi.label(binary_mask)
     unique, count = np.unique(bundle_disjoint, return_counts=True)
+
+    # Cut streamlines based on user options
     if args.biggest_blob:
+        logging.info("Biggest blob found: {} voxels.".format(np.max(count)))
         val = unique[np.argmax(count[1:])+1]
         binary_mask[bundle_disjoint != val] = 0
         unique = [0, val]
     if len(unique) == 2:
-        logging.info('The provided mask has 1 entity '
+        logging.info('Found only one blob in the provided mask. '
                      'cut_outside_of_mask_streamlines function selected.')
         new_sft = cut_outside_of_mask_streamlines(sft, binary_mask)
     elif len(unique) == 3:
-        logging.info('The provided mask has 2 entity '
+        logging.info('Found only two blobs in the provided mask. '
                      'cut_between_mask_two_blobs_streamlines '
                      'function selected.')
         new_sft = cut_between_mask_two_blobs_streamlines(sft, binary_mask)
 
     else:
-        logging.warning('The provided mask has MORE THAN 2 entity '
+        logging.warning('The provided mask has MORE THAN 2 blobs. '
                         'cut_between_mask_two_blobs_streamlines function '
                         'selected. This may cause problems with the outputed '
                         'streamlines. Please inspect the output carefully.')
         new_sft = cut_between_mask_two_blobs_streamlines(sft, binary_mask)
 
+    # Saving
     if len(new_sft) == 0:
         logging.warning('No streamline intersected the provided mask. '
                         'Saving empty tractogram.')
     elif args.error_rate is not None:
         compressed_strs = [compress_streamlines(
             s, args.error_rate) for s in new_sft.streamlines]
-        new_sft = StatefulTractogram.from_sft(compressed_strs, sft)
+        new_sft = StatefulTractogram.from_sft(
+            compressed_strs, sft, data_per_streamline=sft.data_per_streamline)
 
     save_tractogram(new_sft, args.out_tractogram)
 

--- a/scripts/tests/test_tractogram_apply_transform.py
+++ b/scripts/tests/test_tractogram_apply_transform.py
@@ -11,22 +11,19 @@ from scilpy.io.fetcher import fetch_data, get_testing_files_dict
 fetch_data(get_testing_files_dict(), keys=['bst.zip'])
 tmp_dir = tempfile.TemporaryDirectory()
 
+in_model = os.path.join(SCILPY_HOME, 'bst', 'template', 'rpt_m.trk')
+in_fa = os.path.join(SCILPY_HOME, 'bst', 'fa.nii.gz')
+in_aff = os.path.join(SCILPY_HOME, 'bst', 'output0GenericAffine.mat')
+in_warp = os.path.join(SCILPY_HOME, 'bst', 'output1InverseWarp.nii.gz')
+
 
 def test_help_option(script_runner):
     ret = script_runner.run('scil_tractogram_apply_transform.py', '--help')
     assert ret.success
 
 
-def test_execution_bst(script_runner):
+def test_execution_inverse(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
-    in_model = os.path.join(SCILPY_HOME, 'bst', 'template',
-                            'rpt_m.trk')
-    in_fa = os.path.join(SCILPY_HOME, 'bst',
-                         'fa.nii.gz')
-    in_aff = os.path.join(SCILPY_HOME, 'bst',
-                          'output0GenericAffine.mat')
-    in_warp = os.path.join(SCILPY_HOME, 'bst',
-                           'output1InverseWarp.nii.gz')
     ret = script_runner.run('scil_tractogram_apply_transform.py',
                             in_model, in_fa, in_aff, 'rpt_m_warp.trk',
                             '--inverse', '--in_deformation', in_warp,

--- a/scripts/tests/test_tractogram_apply_transform.py
+++ b/scripts/tests/test_tractogram_apply_transform.py
@@ -11,11 +11,6 @@ from scilpy.io.fetcher import fetch_data, get_testing_files_dict
 fetch_data(get_testing_files_dict(), keys=['bst.zip'])
 tmp_dir = tempfile.TemporaryDirectory()
 
-in_model = os.path.join(SCILPY_HOME, 'bst', 'template', 'rpt_m.trk')
-in_fa = os.path.join(SCILPY_HOME, 'bst', 'fa.nii.gz')
-in_aff = os.path.join(SCILPY_HOME, 'bst', 'output0GenericAffine.mat')
-in_warp = os.path.join(SCILPY_HOME, 'bst', 'output1InverseWarp.nii.gz')
-
 
 def test_help_option(script_runner):
     ret = script_runner.run('scil_tractogram_apply_transform.py', '--help')
@@ -24,6 +19,11 @@ def test_help_option(script_runner):
 
 def test_execution_inverse(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
+    in_model = os.path.join(SCILPY_HOME, 'bst', 'template', 'rpt_m.trk')
+    in_fa = os.path.join(SCILPY_HOME, 'bst', 'fa.nii.gz')
+    in_aff = os.path.join(SCILPY_HOME, 'bst', 'output0GenericAffine.mat')
+    in_warp = os.path.join(SCILPY_HOME, 'bst', 'output1InverseWarp.nii.gz')
+
     ret = script_runner.run('scil_tractogram_apply_transform.py',
                             in_model, in_fa, in_aff, 'rpt_m_warp.trk',
                             '--inverse', '--in_deformation', in_warp,

--- a/scripts/tests/test_tractogram_apply_transform_to_hdf5.py
+++ b/scripts/tests/test_tractogram_apply_transform_to_hdf5.py
@@ -24,6 +24,10 @@ def test_execution_connectivity(script_runner):
     in_target = os.path.join(SCILPY_HOME, 'connectivity',
                              'endpoints_atlas.nii.gz')
     in_transfo = os.path.join(SCILPY_HOME, 'connectivity', 'affine.txt')
+
+    # toDo. Add a --in_deformation file in our test data, fitting with hdf5.
+    #  (See test_tractogram_apply_transform)
+    # toDo. Add some dps in the hdf5's data for more line coverage.
     ret = script_runner.run('scil_tractogram_apply_transform_to_hdf5.py',
                             in_h5, in_target, in_transfo, 'decompose_lin.h5')
     assert ret.success

--- a/scripts/tests/test_tractogram_assign_uniform_color.py
+++ b/scripts/tests/test_tractogram_assign_uniform_color.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-
+import json
 import os
 import tempfile
 
@@ -11,6 +11,8 @@ from scilpy.io.fetcher import fetch_data, get_testing_files_dict
 fetch_data(get_testing_files_dict(), keys=['tractometry.zip'])
 tmp_dir = tempfile.TemporaryDirectory()
 
+in_bundle = os.path.join(SCILPY_HOME, 'tractometry', 'IFGWM.trk')
+
 
 def test_help_option(script_runner):
     ret = script_runner.run('scil_tractogram_assign_uniform_color.py',
@@ -18,11 +20,25 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_tractometry(script_runner):
+def test_execution_fill(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
-    in_bundle = os.path.join(SCILPY_HOME, 'tractometry',
-                             'IFGWM.trk')
+
     ret = script_runner.run('scil_tractogram_assign_uniform_color.py',
                             in_bundle, '--fill_color', '0x000000',
                             '--out_tractogram', 'colored.trk')
+    assert ret.success
+
+
+def test_execution_dict(script_runner):
+    os.chdir(os.path.expanduser(tmp_dir.name))
+
+    # Create a fake dictionary. Using the other hexadecimal format.
+    my_dict = {'IFGWM': '#000000'}
+    json_file = 'my_json_dict.json'
+    with open(json_file, "w+") as f:
+        json.dump(my_dict, f)
+
+    ret = script_runner.run('scil_tractogram_assign_uniform_color.py',
+                            in_bundle, '--dict_colors', json_file,
+                            '--out_suffix', 'colored')
     assert ret.success

--- a/scripts/tests/test_tractogram_cut_streamlines.py
+++ b/scripts/tests/test_tractogram_cut_streamlines.py
@@ -18,13 +18,24 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_filtering(script_runner):
+def test_execution_two_roi(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
     in_tractogram = os.path.join(SCILPY_HOME, 'filtering',
                                  'bundle_all_1mm.trk')
-    in_mask = os.path.join(SCILPY_HOME, 'filtering',
-                           'mask.nii.gz')
+    in_mask = os.path.join(SCILPY_HOME, 'filtering', 'mask.nii.gz')
     ret = script_runner.run('scil_tractogram_cut_streamlines.py',
                             in_tractogram, in_mask, 'out_tractogram_cut.trk',
                             '--resample', '0.2', '--compress', '0.1')
+    assert ret.success
+
+
+def test_execution_biggest(script_runner):
+    os.chdir(os.path.expanduser(tmp_dir.name))
+    in_tractogram = os.path.join(SCILPY_HOME, 'filtering',
+                                 'bundle_all_1mm.trk')
+    in_mask = os.path.join(SCILPY_HOME, 'filtering', 'mask.nii.gz')
+    ret = script_runner.run('scil_tractogram_cut_streamlines.py',
+                            in_tractogram, in_mask, 'out_tractogram_cut2.trk',
+                            '--resample', '0.2', '--compress', '0.1',
+                            '--biggest')
     assert ret.success


### PR DESCRIPTION
# Quick description

Verified the four first tractogram scripts.
1. `scil_tractogram_apply_transform`: 
    - Fixed difference between the doc's explanation and the script's management of option --remove_invalid.
2. `scil_tractogram_apply_transform_to_hdf5`:
   - Made the same choices of management of invalid as in script 1.
   - ENCAPSULATED HDF5 MANAGEMENT IN SCILPY.IO.HDF5.  (Many of these methods are not used here but will be in the next PR. I just wanted to make sure right now that everything fitted correctly).
3. `scil_tractogram_assign_uniform_color`:
   - Moved loading of the json file out of the loop.
   - Better explanation in parser
   - Better verifications in main
   - Encapsulated hexadecimal_to_RGB in viz.utils.
4. `scil_tractogram_cut_streamlines`:
   - Now the data_per_streamline is kept.

## Type of change

Check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [ ] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
