### PR TITLE
Tractogram scripts parts2

### DIFF
--- a/scilpy/io/hdf5.py
+++ b/scilpy/io/hdf5.py
@@ -158,7 +158,7 @@ def assert_header_compatible_hdf5(hdf5_handle, ref):
         # Expecting nibabel reference
         ref_affine = ref.affine
         ref_dimension = ref.shape
-        name = ref.filename
+        name = ref.get_filename()
 
     affine = hdf5_handle.attrs['affine']
     dimensions = hdf5_handle.attrs['dimensions']
@@ -212,7 +212,7 @@ def construct_hdf5_from_sft(hdf5_handle, sfts, groups_keys='streamlines',
     """
     if isinstance(sfts, StatefulTractogram):
         sfts = [sfts]
-    if isinstance(groups_keys, list):
+    if isinstance(groups_keys, str):
         groups_keys = [groups_keys]
 
     assert len(sfts) == len(groups_keys)

--- a/scilpy/io/hdf5.py
+++ b/scilpy/io/hdf5.py
@@ -42,8 +42,8 @@ def reconstruct_sft_from_hdf5(hdf5_handle, group_keys, space=Space.VOX,
         all bundles into one SFT. Else, returns one SFT per group.
     allow_empty: bool
         If true, if no streamlines are found, an empty tractogram will be
-        returned. If one or more group_keys does not exist, will NOT raise an
-        error anymore.
+        returned. If one or more group_keys do not exist, no error will be
+        raised.
 
     Returns
     -------
@@ -122,9 +122,8 @@ def reconstruct_sft_from_hdf5(hdf5_handle, group_keys, space=Space.VOX,
     # 3) Format as SFT
     if merge_groups:
         if len(streamlines) == 0 and not allow_empty:
-            raise ValueError("Empty SFT cannot reconstructed from hdf5. "
-                             "Set allow_empty to true to allow loading an "
-                             "empty tractogram.")
+            raise ValueError("Cannot load an empty tractogram from HDF5. Set "
+                             "`allow_empty` to True if you want to force it.")
         sft = StatefulTractogram(streamlines, header, space=space,
                                  origin=origin, data_per_streamline=dps[0])
         return sft, groups_len
@@ -132,9 +131,9 @@ def reconstruct_sft_from_hdf5(hdf5_handle, group_keys, space=Space.VOX,
         sfts = []
         for (sub_streamlines, sub_dps) in zip(streamlines, dps):
             if len(streamlines) == 0 and not allow_empty:
-                raise ValueError("Empty SFT cannot reconstructed from hdf5. "
-                                 "Set allow_empty to true to allow loading an "
-                                 "empty tractogram.")
+                raise ValueError("Cannot load an empty tractogram from HDF5. "
+                                 "Set `allow_empty` to True if you want to "
+                                 "force it.")
             else:
                 sfts.append(
                     StatefulTractogram(sub_streamlines, header, space=space,

--- a/scilpy/io/hdf5.py
+++ b/scilpy/io/hdf5.py
@@ -122,9 +122,9 @@ def reconstruct_sft_from_hdf5(hdf5_handle, group_keys, space=Space.VOX,
     # 3) Format as SFT
     if merge_groups:
         if len(streamlines) == 0 and not allow_empty:
-            # Could raise an Error? Todo. Check all scripts first.
-            logging.info("Empty SFT not reconstructed from hdf5.")
-            return None
+            raise ValueError("Empty SFT cannot reconstructed from hdf5. "
+                             "Set allow_empty to true to allow loading an "
+                             "empty tractogram.")
         sft = StatefulTractogram(streamlines, header, space=space,
                                  origin=origin, data_per_streamline=dps[0])
         return sft, groups_len
@@ -132,9 +132,9 @@ def reconstruct_sft_from_hdf5(hdf5_handle, group_keys, space=Space.VOX,
         sfts = []
         for (sub_streamlines, sub_dps) in zip(streamlines, dps):
             if len(streamlines) == 0 and not allow_empty:
-                # Could raise an Error? Todo. Check all scripts first.
-                logging.info("Empty SFT not reconstructed from hdf5.")
-                sfts.append([])
+                raise ValueError("Empty SFT cannot reconstructed from hdf5. "
+                                 "Set allow_empty to true to allow loading an "
+                                 "empty tractogram.")
             else:
                 sfts.append(
                     StatefulTractogram(sub_streamlines, header, space=space,

--- a/scilpy/io/utils.py
+++ b/scilpy/io/utils.py
@@ -522,7 +522,7 @@ def verify_compression_th(compress_th):
     -----------
     compress_th: float, the compression threshold.
     """
-    if compress_th:
+    if compress_th is not None:
         if compress_th < 0.001 or compress_th > 1:
             logging.warning(
                 'You are using an error rate of {}.\nWe recommend setting it '

--- a/scilpy/io/utils.py
+++ b/scilpy/io/utils.py
@@ -209,10 +209,15 @@ def add_sphere_arg(parser, symmetric_only=False, default='repulsion724'):
                              'Default: [%(default)s]')
 
 
-def add_overwrite_arg(parser):
+def add_overwrite_arg(parser, will_delete_dirs=False):
+    if will_delete_dirs:
+        _help = ('Force overwriting of the output files.\n'
+                 'CAREFUL. The whole output directory will be deleted if it '
+                 'exists.')
+    else:
+        _help = 'Force overwriting of the output files.'
     parser.add_argument(
-        '-f', dest='overwrite', action='store_true',
-        help='Force overwriting of the output files.')
+        '-f', dest='overwrite', action='store_true', help=_help)
 
 
 def add_tolerance_arg(parser):

--- a/scripts/scil_connectivity_compute_matrices.py
+++ b/scripts/scil_connectivity_compute_matrices.py
@@ -57,7 +57,8 @@ import numpy as np
 import scipy.ndimage as ndi
 
 from scilpy.image.labels import get_data_as_labels
-from scilpy.io.hdf5 import reconstruct_streamlines_from_hdf5
+from scilpy.io.hdf5 import (assert_header_compatible_hdf5,
+                            reconstruct_streamlines_from_hdf5)
 from scilpy.io.image import get_data_as_mask
 from scilpy.io.utils import (add_overwrite_arg, add_processes_arg,
                              add_verbose_arg,
@@ -103,10 +104,7 @@ def _processing_wrapper(args):
 
     affine, dimensions, voxel_sizes, _ = get_reference_info(labels_img)
     measures_to_return = {}
-
-    if not (np.allclose(hdf5_file.attrs['affine'], affine, atol=1e-03)
-            and np.array_equal(hdf5_file.attrs['dimensions'], dimensions)):
-        raise ValueError('Provided hdf5 have incompatible headers.')
+    assert_header_compatible_hdf5(hdf5_file, (affine, dimensions))
 
     # Precompute to save one transformation, insert later
     if 'length' in measures_to_compute:

--- a/scripts/scil_tractogram_apply_transform_to_hdf5.py
+++ b/scripts/scil_tractogram_apply_transform_to_hdf5.py
@@ -25,11 +25,13 @@ import nibabel as nib
 import numpy as np
 
 from scilpy.io.hdf5 import (reconstruct_sft_from_hdf5,
-                            construct_hdf5_from_sft, construct_hdf5_header,
-                            construct_hdf5_group_from_streamlines)
-from scilpy.io.utils import (add_overwrite_arg, add_reference_arg,
-                             add_verbose_arg, assert_inputs_exist,
-                             assert_outputs_exist, load_matrix_in_any_format)
+                            construct_hdf5_from_sft)
+from scilpy.io.utils import (add_overwrite_arg,
+                             add_reference_arg,
+                             add_verbose_arg,
+                             assert_inputs_exist,
+                             assert_outputs_exist,
+                             load_matrix_in_any_format)
 from scilpy.tractograms.tractogram_operations import transform_warp_sft
 
 
@@ -104,11 +106,10 @@ def main():
             target_img = nib.load(args.in_target_file)
 
             # For each bundle / tractogram in the hdf5:
-            for i, key in enumerate(in_hdf5_file.keys()):
+            for key in in_hdf5_file.keys():
                 # Get the bundle as sft
                 moving_sft, _ = reconstruct_sft_from_hdf5(
                     in_hdf5_file, key, load_dps=True, load_dpp=False)
-
                 if moving_sft is None:
                     continue
 
@@ -120,9 +121,6 @@ def main():
                     reverse_op=args.reverse_operation,
                     remove_invalid=args.remove_invalid,
                     cut_invalid=args.cut_invalid)
-
-                if i == 0:
-                    construct_hdf5_header(out_hdf5_file, new_sft)
 
                 # Default is to crash if invalid.
                 if args.keep_invalid:
@@ -139,10 +137,8 @@ def main():
                             "--remove_invalid.")
 
                 # Save result to the hdf5
-                group = out_hdf5_file.create_group(key)
-                construct_hdf5_group_from_streamlines(
-                    group, new_sft.streamlines,
-                    dps=new_sft.data_per_streamline)
+                construct_hdf5_from_sft(out_hdf5_file, new_sft, key,
+                                        save_dps=True, save_dpp=False)
 
 
 if __name__ == "__main__":

--- a/scripts/scil_tractogram_commit.py
+++ b/scripts/scil_tractogram_commit.py
@@ -22,34 +22,44 @@ The output from COMMIT is:
     fiting error (Root Mean Square Error)
 - results.pickle
     Dictionary containing the experiment parameters and final weights
-- compartment_EC.nii.gz (est. Extra-Cellular signal fraction)
-- compartment_IC.nii.gz (est. Intra-Cellular signal fraction)
-- compartment_ISO.nii.gz (est. isotropic signal fraction
-  (freewater comportment))
+- compartment_EC.nii.gz
+    (est. Extra-Cellular signal fraction)
+- compartment_IC.nii.gz
+    (est. Intra-Cellular signal fraction)
+- compartment_ISO.nii.gz
+    (est. isotropic signal fraction (freewater comportment)):
     Each of COMMIT compartments
 - streamline_weights.txt
     Text file containing the commit weights for each streamline of the
     input tractogram.
 - streamlines_length.txt
-    Text file containing the length (mm) of each streamline
+    Text file containing the length (mm) of each streamline.
+- streamline_weights_by_length.txt
+    Text file containing the commit weights for each streamline of the
+    input tractogram, ordered by their length.
 - tot_streamline_weights
     Text file containing the total commit weights of each streamline.
     Equal to commit_weights * streamlines_length (W_i * L_i)
 - essential.trk / non_essential.trk
     Tractograms containing the streamlines below or equal (essential) and
     above (non_essential) a threshold_weights of 0.
+- decompose_commit.h5
+    In the case where the input is a hdf5 file only, we will save an output
+    hdf5 with the following information separated into each bundle's dps:
+    - streamlines_weights
+    - streamline_weights_by_length
+    For each bundle, only the essential streamlines are kept.
 
 This script can divide the input tractogram in two using a threshold to apply
-on the streamlines' weight. The threshold used is 0.0, keeping only
-streamlines that have non-zero weight and that contribute to explain the DWI
-signal. Streamlines with 0 weight are essentially not necessary according to
-COMMIT.
+on the streamlines' weight. The threshold used is 0.0, keeping only streamlines
+that have non-zero weight and that contribute to explain the DWI signal.
+Streamlines with 0 weight are essentially not necessary according to COMMIT.
 
 COMMIT2 is available only for HDF5 data from
 scil_tractogram_segment_bundles_for_connectivity.py and
 with the --ball_stick option. Use the --commit2 option to activite it, slightly
 longer computation time. This wrapper offers a simplify way to call COMMIT,
-but does not allow to use (or fine-tune) every parameters. If you want to use
+but does not allow to use (or fine-tune) every parameter. If you want to use
 COMMIT with full access to all parameters,
 visit: https://github.com/daducci/COMMIT
 
@@ -74,10 +84,8 @@ import tempfile
 
 import commit
 from commit import trk2dictionary
-from dipy.io.stateful_tractogram import (Origin, Space,
-                                         StatefulTractogram)
+
 from dipy.io.streamline import save_tractogram, load_tractogram
-from dipy.io.utils import is_header_compatible
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.tracking.streamlinespeed import length
 import h5py
@@ -85,16 +93,19 @@ import numpy as np
 import nibabel as nib
 
 from scilpy.io.gradients import fsl2mrtrix
-from scilpy.io.hdf5 import reconstruct_streamlines_from_hdf5
+from scilpy.io.hdf5 import (reconstruct_sft_from_hdf5,
+                            construct_hdf5_group_from_streamlines,
+                            construct_hdf5_header)
 from scilpy.io.streamlines import reconstruct_streamlines
 from scilpy.io.utils import (add_overwrite_arg,
                              add_processes_arg,
                              add_verbose_arg,
                              assert_inputs_exist,
                              assert_output_dirs_exist_and_empty,
-                             redirect_stdout_c)
-from scilpy.gradients.bvec_bval_tools import identify_shells
-
+                             redirect_stdout_c, add_tolerance_arg,
+                             add_skip_b0_check_arg, assert_headers_compatible)
+from scilpy.gradients.bvec_bval_tools import identify_shells, \
+    check_b0_threshold
 
 EPILOG = """
 References:
@@ -114,7 +125,7 @@ def _build_arg_parser():
     p.add_argument('in_tractogram',
                    help='Input tractogram (.trk or .tck or .h5).')
     p.add_argument('in_dwi',
-                   help='Diffusion-weighted images used by COMMIT (.nii.gz).')
+                   help='Diffusion-weighted image used by COMMIT (.nii.gz).')
     p.add_argument('in_bval',
                    help='b-values in the FSL format (.bval).')
     p.add_argument('in_bvec',
@@ -122,10 +133,6 @@ def _build_arg_parser():
     p.add_argument('out_dir',
                    help='Output directory for the COMMIT maps.')
 
-    p.add_argument('--b_thr', type=int, default=40,
-                   help='Limit value to consider that a b-value is on an '
-                        'existing shell.\nAbove this limit, the b-value is '
-                        'placed on a new shell. This includes b0s values.')
     p.add_argument('--nbr_dir', type=int, default=500,
                    help='Number of directions, on the half of the sphere,\n'
                         'representing the possible orientations of the '
@@ -134,8 +141,8 @@ def _build_arg_parser():
                    help='Maximum number of iterations [%(default)s].')
     p.add_argument('--in_peaks',
                    help='Peaks file representing principal direction(s) '
-                        'locally,\n typically coming from fODFs. This file is '
-                        'mandatory for the default\n stick-zeppelin-ball '
+                        'locally,\ntypically coming from fODFs. This file is '
+                        'mandatory for the default \nstick-zeppelin-ball '
                         'model.')
     p.add_argument('--in_tracking_mask',
                    help='Binary mask where tratography was allowed.\n'
@@ -148,17 +155,17 @@ def _build_arg_parser():
                          'ball&stick model.')
     g0.add_argument('--lambda_commit_2', type=float, default=1e-3,
                     help='Specify the clustering prior strength '
-                    '[%(default)s].')
+                         '[%(default)s].')
 
     g1 = p.add_argument_group(title='Model options')
     g1.add_argument('--ball_stick', action='store_true',
                     help='Use the ball&Stick model, disable the zeppelin '
                          'compartment.\nOnly model suitable for single-shell '
                          'data.')
-    g1.add_argument('--para_diff', type=float,
+    g1.add_argument('--para_diff', type=float, default=1.7E-3,
                     help='Parallel diffusivity in mm^2/s.\n'
-                         'Default for ball_stick: 1.7E-3\n'
-                         'Default for stick_zeppelin_ball: 1.7E-3')
+                         'Default for both ball_stick and '
+                         'stick_zeppelin_ball: 1.7E-3.')
     g1.add_argument('--perp_diff', nargs='+', type=float,
                     help='Perpendicular diffusivity in mm^2/s.\n'
                          'Default for ball_stick: None\n'
@@ -183,6 +190,8 @@ def _build_arg_parser():
     g2.add_argument('--compute_only', action='store_true',
                     help='Compute kernels only, --save_kernels must be used.')
 
+    add_tolerance_arg(p)
+    add_skip_b0_check_arg(p, will_overwrite_with_min=True)
     add_processes_arg(p)
     add_verbose_arg(p)
     add_overwrite_arg(p)
@@ -190,107 +199,137 @@ def _build_arg_parser():
     return p
 
 
-def _save_results_wrapper(args, tmp_dir, ext, hdf5_file, offsets_list,
-                          sub_dir, is_commit_2):
-    out_dir = os.path.join(args.out_dir, sub_dir)
-    os.mkdir(out_dir)
-    # Simplifying output for streamlines and cleaning output directory
+def _save_tmp_tractogram_from_hdf5(tmp_dir, args, dwi_img):
+    logging.info('Reconstructing {} into a tractogram for COMMIT.'
+                 .format(args.in_tractogram))
+
+    # Keep track of the order of connections/streamlines in relation to the
+    # tractogram as well as the number of streamlines for each connection.
+    with h5py.File(args.in_tractogram, 'r') as hdf5_file:
+        sft, bundle_groups_len = reconstruct_sft_from_hdf5(
+            hdf5_file, group_keys=None, ref_img=dwi_img, merge_groups=True)
+
+    offsets_list = np.cumsum([0] + bundle_groups_len)
+    tmp_tractogram_filename = os.path.join(tmp_dir.name, 'tractogram.trk')
+
+    # Keeping the input variable, saving trk file for COMMIT internal use
+    save_tractogram(sft, tmp_tractogram_filename)
+    args.in_tractogram = tmp_tractogram_filename
+
+    return hdf5_file, offsets_list, bundle_groups_len
+
+
+def _save_results(args, tmp_dir, ext, in_hdf5_file, offsets_list, sub_dir,
+                  is_commit_2):
+    # Will convert results saved by commit in:
     commit_results_dir = os.path.join(tmp_dir.name,
                                       'Results_StickZeppelinBall')
+
+    # Create the output dir. Will contain:
+    # - fit_NRMSE.nii.gz
+    # - fit_RMSE.nii.gz
+    # - results.pickle
+    # - compartment_EC.nii.gz
+    # - compartment_IC.nii.gz
+    # - compartment_ISO.nii.gz
+    # - streamline_weights.txt -- ok
+    # - streamlines_length.txt -- ok
+    # - streamline_weights_by_length.txt -- ok
+    # - tot_streamline_weights
+    # - essential.trk / non_essential.trk
+    out_dir = os.path.join(args.out_dir, sub_dir)
+    os.mkdir(out_dir)
+
+    # Simplifying output for streamlines and cleaning output directory
     streamline_weights = np.loadtxt(os.path.join(commit_results_dir,
                                                  'streamline_weights.txt'))
 
+    # Loading the tractogram (we never did yet! Only sent the filename to
+    # commit). Reminder. If input was a hdf5, we have changed
+    # args.in_tractogram to our tmp_tractogram saved in tmp_dir.
     sft = load_tractogram(args.in_tractogram, 'same')
     length_list = length(sft.streamlines)
     np.savetxt(os.path.join(commit_results_dir, 'streamlines_length.txt'),
                length_list)
     np.savetxt(os.path.join(commit_results_dir,
                             'streamline_weights_by_length.txt'),
-               streamline_weights*length_list)
-
-    if ext == '.h5':
-        new_filename = os.path.join(commit_results_dir,
-                                    'decompose_commit.h5')
-        with h5py.File(new_filename, 'w') as new_hdf5_file:
-            new_hdf5_file.attrs['affine'] = sft.affine
-            new_hdf5_file.attrs['dimensions'] = sft.dimensions
-            new_hdf5_file.attrs['voxel_sizes'] = sft.voxel_sizes
-            new_hdf5_file.attrs['voxel_order'] = sft.voxel_order
-            # Assign the weights into the hdf5, while respecting
-            # the ordering of connections/streamlines
-            logging.info('Adding commit weights to {}.'.format(new_filename))
-            for i, key in enumerate(list(hdf5_file.keys())):
-                new_group = new_hdf5_file.create_group(key)
-                old_group = hdf5_file[key]
-                tmp_streamline_weights = \
-                    streamline_weights[offsets_list[i]:offsets_list[i+1]]
-
-                essential_ind = np.where(tmp_streamline_weights > 0)[0]
-                tmp_streamline_weights = tmp_streamline_weights[essential_ind]
-
-                tmp_streamlines = reconstruct_streamlines(
-                    old_group['data'],
-                    old_group['offsets'],
-                    old_group['lengths'],
-                    indices=essential_ind)
-                tmp_length_list = length(tmp_streamlines)
-                # Replacing the data with the one above the threshold
-                # Safe since this hdf5 was a copy in the first place
-                new_group.create_dataset('data',
-                                         data=tmp_streamlines.get_data(),
-                                         dtype=np.float32)
-                new_group.create_dataset('offsets',
-                                         data=tmp_streamlines._offsets,
-                                         dtype=np.int64)
-                new_group.create_dataset('lengths',
-                                         data=tmp_streamlines._lengths,
-                                         dtype=np.int32)
-
-                for dps_key in hdf5_file[key].keys():
-                    if dps_key not in ['data', 'offsets', 'lengths']:
-                        new_group.create_dataset(
-                            key, data=hdf5_file[key][dps_key][essential_ind])
-
-                dps_key = 'commit2_weights' if is_commit_2 else \
-                    'commit1_weights'
-                dps_key_tot = 'tot_commit2_weights' if is_commit_2 else \
-                    'tot_commit1_weights'
-                new_group.create_dataset(dps_key,
-                                         data=tmp_streamline_weights)
-                new_group.create_dataset(
-                    dps_key_tot,
-                    data=tmp_streamline_weights*tmp_length_list)
+               streamline_weights * length_list)
 
     files = os.listdir(commit_results_dir)
     for f in files:
         shutil.copy(os.path.join(commit_results_dir, f), out_dir)
 
-    dps_key = 'commit2_weights' if is_commit_2 else \
-        'commit1_weights'
+    dps_key = 'commit2_weights' if is_commit_2 else 'commit1_weights'
     dps_key_tot = 'tot_commit2_weights' if is_commit_2 else \
         'tot_commit1_weights'
     # Reload is needed because of COMMIT handling its file by itself
     sft.data_per_streamline[dps_key] = streamline_weights
-    sft.data_per_streamline[dps_key_tot] = streamline_weights*length_list
+    sft.data_per_streamline[dps_key_tot] = streamline_weights * length_list
 
-    essential_ind = np.where(streamline_weights > 0)[0]
-    nonessential_ind = np.where(streamline_weights <= 0)[0]
-    logging.info('{} essential streamlines were kept at'.format(
-        len(essential_ind)))
-    logging.info('{} nonessential streamlines were kept'.format(
-        len(nonessential_ind)))
-
-    save_tractogram(sft[essential_ind],
-                    os.path.join(out_dir,
-                    'essential_tractogram.trk'))
-    save_tractogram(sft[nonessential_ind],
-                    os.path.join(out_dir,
-                    'nonessential_tractogram.trk'))
     if args.keep_whole_tractogram:
         output_filename = os.path.join(out_dir, 'tractogram.trk')
         logging.info('Saving tractogram with weights as {}'.format(
             output_filename))
         save_tractogram(sft, output_filename)
+
+    essential_ind = np.where(streamline_weights > 0)[0]
+    nonessential_ind = np.where(streamline_weights <= 0)[0]
+    logging.info('Tractogram separated into {} essential streamlines and '
+                 '{} nonessential streamlines'
+                 .format(len(essential_ind), len(nonessential_ind)))
+    save_tractogram(sft[essential_ind],
+                    os.path.join(out_dir, 'essential_tractogram.trk'))
+    save_tractogram(sft[nonessential_ind],
+                    os.path.join(out_dir, 'nonessential_tractogram.trk'))
+
+    if ext == '.h5':
+        _save_out_hdf5(commit_results_dir, sft, in_hdf5_file,
+                       streamline_weights, offsets_list, is_commit_2)
+
+
+def _save_out_hdf5(commit_results_dir, sft, in_hdf5_file,
+                   streamline_weights, offsets_list, is_commit_2):
+    new_filename = os.path.join(commit_results_dir, 'decompose_commit.h5')
+    with h5py.File(new_filename, 'w') as out_hdf5_file:
+        construct_hdf5_header(out_hdf5_file, sft)
+
+        # Assign the weights into the hdf5, while respecting
+        # the ordering of connections/streamlines
+        logging.info('Adding commit weights to {}.'.format(new_filename))
+        for i, key in enumerate(list(in_hdf5_file.keys())):
+            new_group = out_hdf5_file.create_group(key)
+            old_group = in_hdf5_file[key]
+
+            # Recomputing again essential streamlines, but only for this
+            # bundle.
+            tmp_streamline_weights = \
+                streamline_weights[offsets_list[i]:offsets_list[i + 1]]
+            essential_ind = np.where(tmp_streamline_weights > 0)[0]
+            tmp_streamline_weights = tmp_streamline_weights[essential_ind]
+
+            # toDo. Could we use bundle_groups_len to recreate from sft?
+            #  Would not need to keep in_hdf5_file in memory.
+            #  Would not need to reset again the DPS
+            tmp_streamlines = reconstruct_streamlines(
+                old_group['data'], old_group['offsets'],
+                old_group['lengths'], indices=essential_ind)
+            tmp_length_list = length(tmp_streamlines)
+            dps = {key: value[essential_ind]
+                   for key, value in in_hdf5_file[key].items()
+                   if key not in ['data', 'offsets', 'lengths']}
+
+            # Adding commit values as dps
+            dps_commit_key = 'commit2_weights' if is_commit_2 else \
+                'commit1_weights'
+            dps[dps_commit_key] = tmp_streamline_weights
+            dps_key_tot = 'tot_commit2_weights' if is_commit_2 else \
+                'tot_commit1_weights'
+            dps[dps_key_tot] = tmp_streamline_weights * tmp_length_list
+
+            # Replacing the data with the one above the threshold
+            # Safe since this hdf5 was a copy in the first place
+            construct_hdf5_group_from_streamlines(
+                new_group, tmp_streamlines, dps=dps, dpp=None)
 
 
 def main():
@@ -301,16 +340,20 @@ def main():
     if args.verbose == "WARNING":
         f = io.StringIO()
         redirected_stdout = redirect_stdout(f)
-        redirect_stdout_c() 
+        redirect_stdout_c()
     else:
         logging.getLogger().setLevel(logging.getLevelName(args.verbose))
         redirected_stdout = redirect_stdout(sys.stdout)
 
+    # === Verifications ===
     assert_inputs_exist(parser, [args.in_tractogram, args.in_dwi,
                                  args.in_bval, args.in_bvec],
                         [args.in_peaks, args.in_tracking_mask])
     assert_output_dirs_exist_and_empty(parser, args, args.out_dir,
                                        optional=args.save_kernels)
+    _, ext = os.path.splitext(args.in_tractogram)
+    if ext == '.trk':
+        assert_headers_compatible(parser, [args.in_tractogram, args.in_dwi])
 
     if args.commit2:
         if os.path.splitext(args.in_tractogram)[1] != '.h5':
@@ -323,9 +366,6 @@ def main():
     if args.compute_only and not args.save_kernels:
         parser.error('--compute_only must be used with --save_kernels.')
 
-    if args.load_kernels and args.save_kernels:
-        parser.error('Cannot load and save kernels at the same time.')
-
     if args.ball_stick and args.perp_diff:
         parser.error('Cannot use --perp_diff with ball&stick.')
 
@@ -336,65 +376,53 @@ def main():
         parser.error('Cannot use more than one --iso_diff with '
                      'ball&stick.')
 
-    # If it is a trk, check compatibility of header since COMMIT does not do it
-    dwi_img = nib.load(args.in_dwi)
-    _, ext = os.path.splitext(args.in_tractogram)
-    if ext == '.trk' and not is_header_compatible(args.in_tractogram,
-                                                  dwi_img):
-        parser.error('{} does not have a compatible header with {}'.format(
-            args.in_tractogram, args.in_dwi))
+    # Case-dependant defaults:
+    tol_fun = 1e-2 if args.commit2 else 1e-3
+    if args.ball_stick:
+        logging.info('Disabled zeppelin, using the Ball & Stick model.')
+        perp_diff = []
+        isotropc_diff = args.iso_diff or [2.0E-3]
+    else:
+        logging.info('Using the Stick Zeppelin Ball model.')
+        perp_diff = args.perp_diff or [0.85E-3, 0.51E-3]
+        isotropc_diff = args.iso_diff or [1.7E-3, 3.0E-3]
 
+    # Prepare tmp dir for all our intermediate files
     tmp_dir = tempfile.TemporaryDirectory()
-    hdf5_file = None
-    offsets_list = None
-    if ext == '.h5':
-        logging.info('Reconstructing {} into a tractogram for COMMIT.'.format(
-            args.in_tractogram))
 
-        hdf5_file = h5py.File(args.in_tractogram, 'r')
-        if not (np.allclose(hdf5_file.attrs['affine'], dwi_img.affine,
-                            atol=1e-03)
-                and np.array_equal(hdf5_file.attrs['dimensions'],
-                                   dwi_img.shape[0:3])):
-            parser.error('{} does not have a compatible header with {}'.format(
-                args.in_tractogram, args.in_dwi))
+    # === Loading ===
+    dwi_img = nib.load(args.in_dwi)
 
-        # Keep track of the order of connections/streamlines in relation to the
-        # tractogram as well as the number of streamlines for each connection.
-        bundle_groups_len = []
-        hdf5_keys = list(hdf5_file.keys())
-        streamlines = []
-        for key in hdf5_keys:
-            tmp_streamlines = reconstruct_streamlines_from_hdf5(hdf5_file[key])
-            streamlines.extend(tmp_streamlines)
-            bundle_groups_len.append(len(tmp_streamlines))
-
-        offsets_list = np.cumsum([0]+bundle_groups_len)
-        sft = StatefulTractogram(streamlines, args.in_dwi,
-                                 Space.VOX, origin=Origin.TRACKVIS)
-        tmp_tractogram_filename = os.path.join(tmp_dir.name, 'tractogram.trk')
-
-        # Keeping the input variable, saving trk file for COMMIT internal use
-        save_tractogram(sft, tmp_tractogram_filename)
-        args.in_tractogram = tmp_tractogram_filename
-
-    # Writing the scheme file with proper shells
-    tmp_scheme_filename = os.path.join(tmp_dir.name, 'gradients.b')
-    tmp_bval_filename = os.path.join(tmp_dir.name, 'bval')
+    # Load bvals
     bvals, _ = read_bvals_bvecs(args.in_bval, args.in_bvec)
-    shells_centroids, indices_shells = identify_shells(bvals, args.b_thr,
+    _ = check_b0_threshold(bvals.min(), b0_thr=args.tolerance,
+                           skip_b0_check=args.skip_b0_check)
+    shells_centroids, indices_shells = identify_shells(bvals, args.tolerance,
                                                        round_centroids=True)
-    np.savetxt(tmp_bval_filename, shells_centroids[indices_shells],
-               newline=' ', fmt='%i')
-    fsl2mrtrix(tmp_bval_filename, args.in_bvec, tmp_scheme_filename)
-    logging.info('Lauching COMMIT on {} shells at found at {}.'.format(
-        len(shells_centroids),
-        shells_centroids))
-
     if len(shells_centroids) == 2 and not args.ball_stick:
         parser.error('The DWI data appears to be single-shell.\n'
                      'Use --ball_stick for single-shell.')
 
+    # If hdf5: reconstruct and save to a temporary trk file on disk
+    bundle_groups_len = []
+    hdf5_file = None
+    offsets_list = None
+    if ext == '.h5':
+        hdf5_file, offsets_list, bundle_groups_len = \
+            _save_tmp_tractogram_from_hdf5(tmp_dir, args, dwi_img)
+
+    # Writing the scheme file with proper shells
+    tmp_scheme_filename = os.path.join(tmp_dir.name, 'gradients.b')
+    tmp_bval_filename = os.path.join(tmp_dir.name, 'bval')
+    np.savetxt(tmp_bval_filename, shells_centroids[indices_shells],
+               newline=' ', fmt='%i')
+    fsl2mrtrix(tmp_bval_filename, args.in_bvec, tmp_scheme_filename)
+
+    # === Main processing ===
+
+    logging.info('Lauching COMMIT on {} shells at found at {}.'.format(
+        len(shells_centroids),
+        shells_centroids))
     with redirected_stdout:
         # Setting up the tractogram and nifti files
         trk2dictionary.run(filename_tractogram=args.in_tractogram,
@@ -410,29 +438,16 @@ def main():
 
         # FIX for very small values during HCP processing
         # (based on order of magnitude of signal)
-        img = nib.load(args.in_dwi)
-        data = img.get_fdata(dtype=np.float32)
+        data = dwi_img.get_fdata(dtype=np.float32)
         data[data <
-             (0.001*10**np.floor(np.log10(np.mean(data[data > 0]))))] = 0
-        nib.save(nib.Nifti1Image(data, img.affine),
+             (0.001 * 10 ** np.floor(np.log10(np.mean(data[data > 0]))))] = 0
+        nib.save(nib.Nifti1Image(data, dwi_img.affine),
                  os.path.join(tmp_dir.name, 'dwi_zero_fix.nii.gz'))
 
         mit.load_data(os.path.join(tmp_dir.name, 'dwi_zero_fix.nii.gz'),
                       tmp_scheme_filename)
         mit.set_model('StickZeppelinBall')
-
-        if args.ball_stick:
-            logging.info('Disabled zeppelin, using the Ball & Stick model.')
-            para_diff = args.para_diff or 1.7E-3
-            perp_diff = []
-            isotropc_diff = args.iso_diff or [2.0E-3]
-            mit.model.set(para_diff, perp_diff, isotropc_diff)
-        else:
-            logging.info('Using the Stick Zeppelin Ball model.')
-            para_diff = args.para_diff or 1.7E-3
-            perp_diff = args.perp_diff or [0.85E-3, 0.51E-3]
-            isotropc_diff = args.iso_diff or [1.7E-3, 3.0E-3]
-            mit.model.set(para_diff, perp_diff, isotropc_diff)
+        mit.model.set(args.para_diff, perp_diff, isotropc_diff)
 
         # The kernels are, by default, set to be in the current directory
         # Depending on the choice, manually change the saving location
@@ -452,25 +467,23 @@ def main():
             return
         mit.load_kernels()
         use_mask = args.in_tracking_mask is not None
-        mit.load_dictionary(tmp_dir.name,
-                            use_all_voxels_in_mask=use_mask)
+        mit.load_dictionary(tmp_dir.name, use_all_voxels_in_mask=use_mask)
         mit.set_threads(args.nbr_processes)
 
         mit.build_operator(build_dir=os.path.join(tmp_dir.name, 'build/'))
-        tol_fun = 1e-2 if args.commit2 else 1e-3
         mit.fit(tol_fun=tol_fun, max_iter=args.nbr_iter, verbose=False)
         mit.save_results()
-        _save_results_wrapper(args, tmp_dir, ext, hdf5_file, offsets_list,
-                              'commit_1/', False)
+        _save_results(args, tmp_dir, ext, hdf5_file, offsets_list,
+                      'commit_1/', False)
 
         if args.commit2:
             tmp = np.insert(np.cumsum(bundle_groups_len), 0, 0)
-            group_idx = np.array([np.arange(tmp[i], tmp[i+1])
-                                  for i in range(len(tmp)-1)])
+            group_idx = np.array([np.arange(tmp[i], tmp[i + 1])
+                                  for i in range(len(tmp) - 1)])
             group_w = np.empty_like(bundle_groups_len, dtype=np.float64)
             for k in range(len(bundle_groups_len)):
                 group_w[k] = np.sqrt(bundle_groups_len[k]) / \
-                    (np.linalg.norm(mit.x[group_idx[k]]) + 1e-12)
+                             (np.linalg.norm(mit.x[group_idx[k]]) + 1e-12)
             prior_on_bundles = commit.solvers.init_regularisation(
                 mit, structureIC=group_idx, weightsIC=group_w,
                 regnorms=[commit.solvers.group_sparsity,
@@ -480,8 +493,8 @@ def main():
             mit.fit(tol_fun=1e-3, max_iter=args.nbr_iter,
                     regularisation=prior_on_bundles, verbose=False)
             mit.save_results()
-            _save_results_wrapper(args, tmp_dir, ext, hdf5_file, offsets_list,
-                                  'commit_2/', True)
+            _save_results(args, tmp_dir, ext, hdf5_file, offsets_list,
+                          'commit_2/', True)
 
     tmp_dir.cleanup()
 

--- a/scripts/scil_tractogram_commit.py
+++ b/scripts/scil_tractogram_commit.py
@@ -225,18 +225,7 @@ def _save_results(args, tmp_dir, ext, in_hdf5_file, offsets_list, sub_dir,
     commit_results_dir = os.path.join(tmp_dir.name,
                                       'Results_StickZeppelinBall')
 
-    # Create the output dir. Will contain:
-    # - fit_NRMSE.nii.gz
-    # - fit_RMSE.nii.gz
-    # - results.pickle
-    # - compartment_EC.nii.gz
-    # - compartment_IC.nii.gz
-    # - compartment_ISO.nii.gz
-    # - streamline_weights.txt -- ok
-    # - streamlines_length.txt -- ok
-    # - streamline_weights_by_length.txt -- ok
-    # - tot_streamline_weights
-    # - essential.trk / non_essential.trk
+    # Create the output dir.
     out_dir = os.path.join(args.out_dir, sub_dir)
     os.mkdir(out_dir)
 

--- a/scripts/scil_tractogram_compress.py
+++ b/scripts/scil_tractogram_compress.py
@@ -18,11 +18,11 @@ from nibabel.streamlines import LazyTractogram
 import numpy as np
 
 from scilpy.io.streamlines import check_tracts_same_format
-from scilpy.tractograms.tractogram_operations import compress_streamlines_wrapper
-from scilpy.io.utils import (add_overwrite_arg,
-                             add_verbose_arg,
-                             assert_inputs_exist,
-                             assert_outputs_exist)
+from scilpy.tractograms.tractogram_operations import \
+    compress_streamlines_wrapper
+from scilpy.io.utils import (add_overwrite_arg, add_verbose_arg,
+                             assert_inputs_exist, assert_outputs_exist,
+                             verify_compression_th)
 
 
 def _build_arg_parser():
@@ -50,14 +50,7 @@ def main():
     assert_inputs_exist(parser, args.in_tractogram)
     assert_outputs_exist(parser, args, args.out_tractogram)
     check_tracts_same_format(parser, args.in_tractogram, args.out_tractogram)
-
-    if args.error_rate < 0.001 or args.error_rate > 1:
-        logging.warning(
-            'You are using an error rate of {}.\n'
-            'We recommend setting it between 0.001 and 1.\n'
-            '0.001 will do almost nothing to the streamlines\n'
-            'while 1 will highly compress/linearize the streamlines'
-            .format(args.error_rate))
+    verify_compression_th(args.error_rate)
 
     in_tractogram = nib.streamlines.load(args.in_tractogram, lazy_load=True)
     compressed_streamlines = compress_streamlines_wrapper(in_tractogram,

--- a/scripts/scil_tractogram_compute_TODI.py
+++ b/scripts/scil_tractogram_compute_TODI.py
@@ -95,8 +95,7 @@ def main():
     assert_outputs_exist(parser, args, [], outputs)
 
     if np.all([f is None for f in outputs]):
-        parser.error('No output to be done. Choose at least one output '
-                     'option.')
+        parser.error('No output selected. Choose at least one output option.')
 
     if args.normalize_per_voxel and not (args.out_todi_sh or args.out_todi_sf):
         logging.warning("Option --normalize_per_voxel is only useful when "

--- a/scripts/scil_tractogram_compute_TODI.py
+++ b/scripts/scil_tractogram_compute_TODI.py
@@ -91,12 +91,10 @@ def main():
                         [args.mask, args.reference])
     assert_headers_compatible(parser, args.in_tractogram, args.mask,
                               reference=args.reference)
-    assert_outputs_exist(parser, args, [],
-                         [args.out_mask, args.out_tdi, args.out_todi_sf,
-                          args.out_todi_sh])
+    outputs = [args.out_mask, args.out_tdi, args.out_todi_sf, args.out_todi_sh]
+    assert_outputs_exist(parser, args, [], outputs)
 
-    if not (args.out_mask or args.out_tdi or args.out_todi_sf or
-            args.out_todi_sh):
+    if np.all([f is None for f in outputs]):
         parser.error('No output to be done. Choose at least one output '
                      'option.')
 
@@ -111,7 +109,7 @@ def main():
 
     sft.to_vox()
     # Because compute_todi expects streamline points (in voxel coordinates)
-    # to be in the range (0..size) rather than (-0.5..size - 0.5), we shift
+    # to be in the range [0, size] rather than [-0.5, size - 0.5], we shift
     # the voxel origin to corner.
     sft.to_corner()
 
@@ -131,7 +129,8 @@ def main():
         todi_obj.mask_todi(mask)
 
     if args.normalize_per_voxel:
-        # Normalizes mainly the SH, but, indirectly, changes the SF values.
+        # Normalization is done on the SH, but, indirectly, it may change the
+        # SF values. So, applying even if we don't have --out_todi_sh.
         todi_obj.normalize_todi_per_voxel()
 
     # Saving

--- a/scripts/scil_tractogram_compute_TODI.py
+++ b/scripts/scil_tractogram_compute_TODI.py
@@ -91,12 +91,12 @@ def main():
                         [args.mask, args.reference])
     assert_headers_compatible(parser, args.in_tractogram, args.mask,
                               reference=args.reference)
+    assert_outputs_exist(parser, args, [],
+                         [args.out_mask, args.out_tdi, args.out_todi_sf,
+                          args.out_todi_sh])
 
-    out_files = [args.out_mask, args.out_tdi, args.out_todi_sf,
-                 args.out_todi_sh]
-    assert_outputs_exist(parser, args, [], out_files)
-
-    if not np.any(out_files):
+    if not (args.out_mask or args.out_tdi or args.out_todi_sf or
+            args.out_todi_sh):
         parser.error('No output to be done. Choose at least one output '
                      'option.')
 

--- a/scripts/scil_tractogram_compute_density_map.py
+++ b/scripts/scil_tractogram_compute_density_map.py
@@ -2,9 +2,7 @@
 # -*- coding: utf-8 -*-
 
 """
-Compute a density map from a streamlines file.
-
-A specific value can be assigned instead of using the tract count.
+Compute a density map from a streamlines file. Can be binary.
 
 This script correctly handles compressed streamlines.
 
@@ -49,6 +47,7 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
+    # Verifications
     assert_inputs_exist(parser, args.in_bundle, optional=args.reference)
     assert_outputs_exist(parser, args, args.out_img)
 
@@ -58,14 +57,16 @@ def main():
                      'must be greater than 0 and smaller or equal to {}'
                      .format(args.binary, max_))
 
+    # Loading
     sft = load_tractogram_with_reference(parser, args, args.in_bundle)
     sft.to_vox()
     sft.to_corner()
-    streamlines = sft.streamlines
     transformation, dimensions, _, _ = sft.space_attributes
 
-    streamline_count = compute_tract_counts_map(streamlines, dimensions)
+    # Processing
+    streamline_count = compute_tract_counts_map(sft.streamlines, dimensions)
 
+    # Saving
     dtype_to_use = np.int32
     if args.binary is not None:
         if args.binary == 1:

--- a/scripts/scil_tractogram_compute_density_map.py
+++ b/scripts/scil_tractogram_compute_density_map.py
@@ -32,9 +32,9 @@ def _build_arg_parser():
     p.add_argument('--binary', metavar='FIXED_VALUE', type=int,
                    nargs='?', const=1,
                    help='If set, will store the same value for all '
-                        'intersected voxels, creating a binary map.\n'
-                        'When set without a value, 1 is used (and dtype '
-                        'uint8). \nIf a value is given, will be used as the '
+                        'intersected voxels, \ncreating a binary map.'
+                        'When set without a value, 1 is used (and dtype \n'
+                        'uint8). If a value is given, will be used as the '
                         'stored value.')
     add_reference_arg(p)
     add_verbose_arg(p)

--- a/scripts/scil_tractogram_convert.py
+++ b/scripts/scil_tractogram_convert.py
@@ -24,11 +24,11 @@ def _build_arg_parser():
     p = argparse.ArgumentParser(description=__doc__,
                                 formatter_class=argparse.RawTextHelpFormatter)
 
-    p.add_argument('in_tractogram', metavar='IN_TRACTOGRAM',
+    p.add_argument('in_tractogram',
                    help='Tractogram filename. Format must be one of \n'
                         'trk, tck, vtk, fib, dpy')
 
-    p.add_argument('output_name', metavar='OUTPUT_NAME',
+    p.add_argument('output_name',
                    help='Output filename. Format must be one of \n'
                         'trk, tck, vtk, fib, dpy')
 

--- a/scripts/scil_tractogram_convert_hdf5_to_trk.py
+++ b/scripts/scil_tractogram_convert_hdf5_to_trk.py
@@ -2,14 +2,15 @@
 # -*- coding: utf-8 -*-
 
 """
-Save individual connection of an hd5f from
-scil_tractogram_segment_bundles_for_connectivity.py.
+Save individual connections of an hdf5 from
+>> scil_tractogram_segment_bundles_for_connectivity.py.
+
 Useful for quality control and visual inspections.
 
-It can either save all connections, individual connections specified with
-edge_keys or connections from specific nodes with node_keys.
+It can either save all connections (default), individual connections specified
+with --edge_keys or connections from specific nodes specified with --node_keys.
 
-With the option save_empty, a label_lists, as a txt file, must be provided.
+With the option --save_empty, a label_lists, as a txt file, must be provided.
 This option saves existing connections and empty connections.
 
 The output is a directory containing the thousands of connections:
@@ -32,8 +33,7 @@ import itertools
 import numpy as np
 
 from scilpy.io.hdf5 import reconstruct_sft_from_hdf5
-from scilpy.io.utils import (add_overwrite_arg,
-                             add_verbose_arg,
+from scilpy.io.utils import (add_overwrite_arg, add_verbose_arg,
                              assert_inputs_exist,
                              assert_output_dirs_exist_and_empty)
 
@@ -51,22 +51,24 @@ def _build_arg_parser():
                    help='Include the data_per_streamline the metadata.')
 
     group = p.add_mutually_exclusive_group()
-    group.add_argument('--edge_keys', nargs='+',
-                       help='Keys to identify the edges of '
-                            'interest (LABEL1_LABEL2).')
+    group.add_argument('--edge_keys', nargs='+', metavar='LABEL1_LABEL2',
+                       help='Keys to identify the edges (connections) of '
+                            'interest.')
+    group.add_argument('--node_keys', nargs='+', metavar='NODE',
+                       help='Node keys to identify the sub-networks of '
+                            'interest.\nEquivalent to adding any --edge_keys '
+                            'node_LABEL2 or LABEL2_node.')
 
-    group.add_argument('--node_keys', nargs='+',
-                       help='Node keys to identify the '
-                            'sub-network of interest.')
-
-    p.add_argument('--save_empty', action='store_true',
-                   help='Save empty connections.')
-    p.add_argument('--labels_list',
-                   help='A txt file containing a list '
-                        'saved by the decomposition script.')
+    p.add_argument('--save_empty', metavar='labels_list', dest='labels_list',
+                   help='Save empty connections. Then, the list of possible '
+                        'connections is \nnot found from the hdf5 but from '
+                        'labels_list, a txt file containing \na list saved by '
+                        'the decomposition script.\n'
+                        '*If used together with edge_keys or node_keys, the '
+                        'provided labels must \nexist in labels_list.')
 
     add_verbose_arg(p)
-    add_overwrite_arg(p)
+    add_overwrite_arg(p, will_delete_dirs=True)
 
     return p
 
@@ -76,31 +78,43 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
-    assert_inputs_exist(parser, args.in_hdf5)
+    # Verifications
+    assert_inputs_exist(parser, args.in_hdf5, args.labels_list)
     assert_output_dirs_exist_and_empty(parser, args, args.out_dir,
                                        create_dir=True)
-    if args.save_empty and args.labels_list is None:
-        parser.error("The option --save_empty requires --labels_list.")
 
+    # Processing
     with h5py.File(args.in_hdf5, 'r') as hdf5_file:
-        if args.save_empty:
+        if args.labels_list:
             all_labels = np.loadtxt(args.labels_list, dtype='str')
             comb_list = list(itertools.combinations(all_labels, r=2))
             comb_list.extend(zip(all_labels, all_labels))
-            keys = [i[0]+'_'+i[1] for i in comb_list]
+            all_keys = [i[0]+'_'+i[1] for i in comb_list]
+            keys_origin = "the labels_list file's labels combination"
         else:
-            keys = hdf5_file.keys()
+            all_keys = hdf5_file.keys()
+            keys_origin = "the hdf5 stored keys"
 
         if args.edge_keys is not None:
-            selected_keys = [key for key in keys if key in args.edge_keys]
+            selected_keys = args.edge_keys
+
+            # Check that all selected_keys exist.
+            impossible_keys = np.setdiff1d(selected_keys, all_keys)
+            if len(impossible_keys) > 0:
+                parser.error("The following key(s) to not exist in {}: {}\n"
+                             "Please verify your --edge_keys."
+                             .format(keys_origin, impossible_keys))
+
         elif args.node_keys is not None:
             selected_keys = []
             for node in args.node_keys:
-                selected_keys.extend([key for key in keys
+                selected_keys.extend([key for key in all_keys
                                       if key.startswith(node + '_')
                                       or key.endswith('_' + node)])
+            logging.debug("All keys found for provided nodes are: {}"
+                          .format(selected_keys))
         else:
-            selected_keys = keys
+            selected_keys = all_keys
 
         for key in selected_keys:
             sft, _ = reconstruct_sft_from_hdf5(hdf5_file, key, load_dps=True)

--- a/scripts/scil_tractogram_convert_hdf5_to_trk.py
+++ b/scripts/scil_tractogram_convert_hdf5_to_trk.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 """
-Save individual connections of an hdf5 from
+Save connections of a hdf5 created with
 >> scil_tractogram_segment_bundles_for_connectivity.py.
 
 Useful for quality control and visual inspections.

--- a/scripts/scil_tractogram_segment_bundles_for_connectivity.py
+++ b/scripts/scil_tractogram_segment_bundles_for_connectivity.py
@@ -47,13 +47,12 @@ from nibabel.streamlines.array_sequence import ArraySequence
 import numpy as np
 
 from scilpy.image.labels import get_data_as_labels
+from scilpy.io.hdf5 import (construct_hdf5_header,
+                            construct_hdf5_group_from_streamlines)
 from scilpy.io.streamlines import load_tractogram_with_reference
-from scilpy.io.utils import (add_bbox_arg,
-                             add_overwrite_arg,
-                             add_processes_arg,
-                             add_verbose_arg,
-                             add_reference_arg,
-                             assert_inputs_exist,
+from scilpy.io.utils import (add_bbox_arg, add_overwrite_arg,
+                             add_processes_arg, add_verbose_arg,
+                             add_reference_arg, assert_inputs_exist,
                              assert_outputs_exist,
                              assert_output_dirs_exist_and_empty,
                              validate_nbr_processes)
@@ -128,15 +127,8 @@ def _save_if_needed(sft, hdf5_file, args,
         sft = sft[indices]
 
         group = hdf5_file.create_group('{}_{}'.format(in_label, out_label))
-        group.create_dataset('data', data=sft.streamlines._data,
-                             dtype=np.float32)
-        group.create_dataset('offsets', data=sft.streamlines._offsets,
-                             dtype=np.int64)
-        group.create_dataset('lengths', data=sft.streamlines._lengths,
-                             dtype=np.int32)
-        for key in sft.data_per_streamline.keys():
-            group.create_dataset(key, data=sft.data_per_streamline[key],
-                                 dtype=np.float32)
+        construct_hdf5_group_from_streamlines(group, sft.streamlines,
+                                              dps=sft.data_per_streamline)
 
     if args.out_dir:
         saving_options = _get_saving_options(args)
@@ -327,11 +319,7 @@ def main():
 
     iteration_counter = 0
     with h5py.File(args.out_hdf5, 'w') as hdf5_file:
-        affine, dimensions, voxel_sizes, voxel_order = get_reference_info(sft)
-        hdf5_file.attrs['affine'] = affine
-        hdf5_file.attrs['dimensions'] = dimensions
-        hdf5_file.attrs['voxel_sizes'] = voxel_sizes
-        hdf5_file.attrs['voxel_order'] = voxel_order
+        construct_hdf5_header(hdf5_file, sft)
 
         # Each connection is processed independently. Multiprocessing would be
         # a burden on the I/O of most SSD/HD

--- a/scripts/scil_tractogram_segment_bundles_for_connectivity.py
+++ b/scripts/scil_tractogram_segment_bundles_for_connectivity.py
@@ -11,7 +11,8 @@ robust to compressed streamlines.
 
 The output file is a hdf5 (.h5) where the keys are 'LABEL1_LABEL2' and each
 group is composed of 'data', 'offsets' and 'lengths' from the array_sequence.
-The 'data' is stored in VOX/CORNER for simplicity and efficiency.
+The 'data' is stored in VOX/CORNER for simplicity and efficiency. See script
+scil_tractogram_convert_hdf5_to_trk.py to convert to a list of .trk bundles.
 
 For the --outlier_threshold option the default is a recommended good trade-off
 for a freesurfer parcellation. With smaller parcels (brainnetome, glasser) the

--- a/scripts/tests/test_tractogram_commit.py
+++ b/scripts/tests/test_tractogram_commit.py
@@ -7,8 +7,6 @@ import tempfile
 from scilpy import SCILPY_HOME
 from scilpy.io.fetcher import fetch_data, get_testing_files_dict
 
-# Due to commit limitations we cannot run mutliple test of this script
-
 # If they already exist, this only takes 5 seconds (check md5sum)
 fetch_data(get_testing_files_dict(), keys=['commit_amico.zip'])
 
@@ -45,7 +43,7 @@ def test_execution_commit2(script_runner, monkeypatch):
     tmp_dir = tempfile.TemporaryDirectory()
     monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
 
-    # TODO Modify to use with hdf5. Currently impossible.
+    # TODO Add a HDF5 in our test data that could be used here.
     ret = script_runner.run(
         'scil_tractogram_commit.py', in_tracking, in_dwi, in_bval, in_bvec,
         'results_bzs/', '--tol', '30', '--nbr_dir', '500',

--- a/scripts/tests/test_tractogram_commit.py
+++ b/scripts/tests/test_tractogram_commit.py
@@ -11,7 +11,14 @@ from scilpy.io.fetcher import fetch_data, get_testing_files_dict
 
 # If they already exist, this only takes 5 seconds (check md5sum)
 fetch_data(get_testing_files_dict(), keys=['commit_amico.zip'])
-tmp_dir = tempfile.TemporaryDirectory()
+
+# ToDo: For more coverage, add test using a hdf5 as input.
+in_tracking = os.path.join(SCILPY_HOME, 'commit_amico', 'tracking.trk')
+in_dwi = os.path.join(SCILPY_HOME, 'commit_amico', 'dwi.nii.gz')
+in_bval = os.path.join(SCILPY_HOME, 'commit_amico', 'dwi.bval')
+in_bvec = os.path.join(SCILPY_HOME, 'commit_amico', 'dwi.bvec')
+in_mask = os.path.join(SCILPY_HOME, 'commit_amico', 'mask.nii.gz')
+in_peaks = os.path.join(SCILPY_HOME, 'commit_amico', 'peaks.nii.gz')
 
 
 def test_help_option(script_runner):
@@ -20,27 +27,31 @@ def test_help_option(script_runner):
 
 
 def test_execution_commit_amico(script_runner, monkeypatch):
+    tmp_dir = tempfile.TemporaryDirectory()
     monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
-    in_tracking = os.path.join(SCILPY_HOME, 'commit_amico',
-                               'tracking.trk')
-    in_dwi = os.path.join(SCILPY_HOME, 'commit_amico',
-                          'dwi.nii.gz')
-    in_bval = os.path.join(SCILPY_HOME, 'commit_amico',
-                           'dwi.bval')
-    in_bvec = os.path.join(SCILPY_HOME, 'commit_amico',
-                           'dwi.bvec')
-    in_mask = os.path.join(SCILPY_HOME, 'commit_amico',
-                           'mask.nii.gz')
-    in_peaks = os.path.join(SCILPY_HOME, 'commit_amico',
-                            'peaks.nii.gz')
-    ret = script_runner.run('scil_tractogram_commit.py', in_tracking, in_dwi,
-                            in_bval, in_bvec, 'results_bzs/',
-                            '--b_thr', '30', '--nbr_dir', '500',
-                            '--nbr_iter', '500', '--in_peaks', in_peaks,
-                            '--in_tracking_mask', in_mask,
-                            '--para_diff', '1.7E-3',
-                            '--perp_diff',
-                            '1.19E-3', '0.85E-3', '0.51E-3', '0.17E-3',
-                            '--iso_diff', '1.7E-3', '3.0E-3',
-                            '--processes', '1')
+
+    ret = script_runner.run(
+        'scil_tractogram_commit.py', in_tracking, in_dwi, in_bval, in_bvec,
+        'results_bzs/', '--tol', '30', '--nbr_dir', '500',
+        '--nbr_iter', '500', '--in_peaks', in_peaks,
+        '--in_tracking_mask', in_mask,
+        '--perp_diff', '1.19E-3', '0.85E-3', '0.51E-3', '0.17E-3',
+        '--iso_diff', '1.7E-3', '3.0E-3',
+        '--processes', '1', '--keep_whole_tractogram')
     assert ret.success
+
+
+def test_execution_commit2(script_runner, monkeypatch):
+    tmp_dir = tempfile.TemporaryDirectory()
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+
+    # TODO Modify to use with hdf5. Currently impossible.
+    ret = script_runner.run(
+        'scil_tractogram_commit.py', in_tracking, in_dwi, in_bval, in_bvec,
+        'results_bzs/', '--tol', '30', '--nbr_dir', '500',
+        '--nbr_iter', '500', '--in_peaks', in_peaks,
+        '--in_tracking_mask', in_mask,
+        '--perp_diff', '1.19E-3', '0.85E-3', '0.51E-3', '0.17E-3',
+        '--iso_diff', '1.7E-3', '3.0E-3',
+        '--processes', '1', '--commit2')
+    assert not ret.success

--- a/scripts/tests/test_tractogram_compute_TODI.py
+++ b/scripts/tests/test_tractogram_compute_TODI.py
@@ -22,12 +22,12 @@ def test_execution_bst(script_runner, monkeypatch):
     in_bundle = os.path.join(SCILPY_HOME, 'bst', 'rpt_m_warp.trk')
     in_mask = os.path.join(SCILPY_HOME, 'bst', 'mask.nii.gz')
 
-    # Note. For more coverage, could use option --out_todi_sf, but slower.
     ret = script_runner.run('scil_tractogram_compute_TODI.py', in_bundle,
                             '--mask', in_mask,
                             '--out_mask', 'todi_mask.nii.gz',
                             '--out_tdi', 'tdi.nii.gz',
                             '--out_todi_sh', 'todi_sh.nii.gz',
+                            '--out_todi_sf', 'todi_sf.nii.gz',
                             '--sh_order', '6',
                             '--normalize_per_voxel', '--smooth_todi',
                             '--sh_basis', 'descoteaux07')

--- a/scripts/tests/test_tractogram_compute_TODI.py
+++ b/scripts/tests/test_tractogram_compute_TODI.py
@@ -21,6 +21,8 @@ def test_execution_bst(script_runner, monkeypatch):
     monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_bundle = os.path.join(SCILPY_HOME, 'bst', 'rpt_m_warp.trk')
     in_mask = os.path.join(SCILPY_HOME, 'bst', 'mask.nii.gz')
+
+    # Note. For more coverage, could use option --out_todi_sf, but slower.
     ret = script_runner.run('scil_tractogram_compute_TODI.py', in_bundle,
                             '--mask', in_mask,
                             '--out_mask', 'todi_mask.nii.gz',

--- a/scripts/tests/test_tractogram_convert_hdf5_to_trk.py
+++ b/scripts/tests/test_tractogram_convert_hdf5_to_trk.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-
+import glob
 import os
 import tempfile
 
@@ -10,6 +10,7 @@ from scilpy.io.fetcher import fetch_data, get_testing_files_dict
 # If they already exist, this only takes 5 seconds (check md5sum)
 fetch_data(get_testing_files_dict(), keys=['connectivity.zip'])
 tmp_dir = tempfile.TemporaryDirectory()
+in_h5 = os.path.join(SCILPY_HOME, 'connectivity', 'decompose.h5')
 
 
 def test_help_option(script_runner):
@@ -17,9 +18,53 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_connectivity(script_runner, monkeypatch):
+def test_execution_all_keys(script_runner, monkeypatch):
     monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
-    in_h5 = os.path.join(SCILPY_HOME, 'connectivity', 'decompose.h5')
     ret = script_runner.run('scil_tractogram_convert_hdf5_to_trk.py',
                             in_h5, 'save_trk/')
     assert ret.success
+
+    # With current test data, out directory should have 7 files
+    out_files = glob.glob('save_trk/*')
+    assert len(out_files) == 7
+
+
+def test_execution_edge_keys(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+    ret = script_runner.run('scil_tractogram_convert_hdf5_to_trk.py',
+                            in_h5, 'save_trk2/', '--edge_keys', '1_10', '1_7')
+    assert ret.success
+
+    # Out directory should have 2 files
+    out_files = glob.glob('save_trk2/*')
+    assert len(out_files) == 2
+
+
+def test_execution_node_keys(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+    ret = script_runner.run('scil_tractogram_convert_hdf5_to_trk.py',
+                            in_h5, 'save_trk3/', '--node_keys', '7')
+    assert ret.success
+
+    # With current test data, out directory should have 3 files
+    out_files = glob.glob('save_trk3/*')
+    assert len(out_files) == 3
+
+
+def test_execution_save_empty(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+
+    # Saving a txt file with more connections than really exist, to save empty
+    # connections.
+    with open('labels_list.txt', 'w') as f:
+        f.write('1\n10\n100')
+    ret = script_runner.run('scil_tractogram_convert_hdf5_to_trk.py',
+                            in_h5, 'save_trk4/',
+                            '--save_empty', 'labels_list.txt',
+                            '--edge_keys', '1_10', '1_100',
+                            '-v', 'DEBUG')
+    assert ret.success
+
+    # Out directory should have 2 files
+    out_files = glob.glob('save_trk4/*')
+    assert len(out_files) == 2


### PR DESCRIPTION
# Quick description


- Using the hdf5 methods from part 1 in scripts where I found hdf5 usage.
- scil_tractogram_commit: clarifying. Adding test coverage.
- scil_tractogram_compress: ok!
- scil_tractogram_compute_density_map: ok!
- scil_tractogram_compute_TODI: clarifying. After discussion with @frheault , moving option --normalize out of the if.
- scil_tractogram_convert: ok!
- scil_tractogram_convert_hdf5_to_trk: Clarifying help. More checks. --labels_list and --save_empty were both needed OR both not used. Merged the two args.

## Type of change

Check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist

- [x] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [x] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
