### PR TITLE
Tractogram scripts parts3

### DIFF
--- a/scilpy/io/streamlines.py
+++ b/scilpy/io/streamlines.py
@@ -5,7 +5,8 @@ import logging
 import os
 import tempfile
 
-from dipy.io.streamline import load_tractogram, save_tractogram
+from dipy.io.streamline import load_tractogram
+from dipy.io.streamline import save_tractogram as _save_tractogram
 from dipy.io.utils import is_header_compatible
 import nibabel as nib
 from nibabel.streamlines.array_sequence import ArraySequence
@@ -118,8 +119,7 @@ def load_tractogram_with_reference(parser, args, filepath, arg_name=None):
     return sft
 
 
-def check_empty_option_save_tractogram(sft, filename, no_empty,
-                                       bbox_valid_check=True):
+def save_tractogram(sft, filename, no_empty, bbox_valid_check=True):
     if len(sft.streamlines) == 0 and no_empty:
         logging.info("The file {} won't be written (0 streamlines)"
                      .format(filename))
@@ -127,7 +127,7 @@ def check_empty_option_save_tractogram(sft, filename, no_empty,
         if len(sft.streamlines) == 0:
             logging.info("Writing an empty file (0 streamlines): {} "
                          .format(filename))
-        save_tractogram(sft, filename, bbox_valid_check=bbox_valid_check)
+        _save_tractogram(sft, filename, bbox_valid_check=bbox_valid_check)
 
 
 def verify_compatibility_with_reference_sft(ref_sft, files_to_verify,

--- a/scilpy/io/streamlines.py
+++ b/scilpy/io/streamlines.py
@@ -5,7 +5,7 @@ import logging
 import os
 import tempfile
 
-from dipy.io.streamline import load_tractogram
+from dipy.io.streamline import load_tractogram, save_tractogram
 from dipy.io.utils import is_header_compatible
 import nibabel as nib
 from nibabel.streamlines.array_sequence import ArraySequence
@@ -116,6 +116,18 @@ def load_tractogram_with_reference(parser, args, filepath, arg_name=None):
         parser.error('{} is an unsupported file format'.format(filepath))
 
     return sft
+
+
+def check_empty_option_save_tractogram(sft, filename, no_empty,
+                                       bbox_valid_check=True):
+    if len(sft.streamlines) == 0 and no_empty:
+        logging.info("The file {} won't be written (0 streamlines)"
+                     .format(filename))
+    else:
+        if len(sft.streamlines) == 0:
+            logging.info("Writing an empty file (0 streamlines): {} "
+                         .format(filename))
+        save_tractogram(sft, filename, bbox_valid_check=bbox_valid_check)
 
 
 def verify_compatibility_with_reference_sft(ref_sft, files_to_verify,

--- a/scilpy/io/utils.py
+++ b/scilpy/io/utils.py
@@ -514,7 +514,7 @@ def validate_sh_basis_choice(sh_basis):
 
 
 def add_compression_arg(p, additional_msg=''):
-    p.add_argument('--compress', dest='compress_th', const=0.1,
+    p.add_argument('--compress', dest='compress_th', nargs='?', const=0.1,
                    type=ranged_type(float, 0, None),
                    help='If set, compress the resulting streamline. Value is '
                         'the maximum \ncompression distance in mm.'

--- a/scilpy/io/utils.py
+++ b/scilpy/io/utils.py
@@ -513,6 +513,14 @@ def validate_sh_basis_choice(sh_basis):
                          "'tournier07'.")
 
 
+def add_compression_arg(p, additional_msg=''):
+    p.add_argument('--compress', dest='compress_th', const=0.1,
+                   type=ranged_type(float, 0, None),
+                   help='If set, compress the resulting streamline. Value is '
+                        'the maximum \ncompression distance in mm.'
+                        + additional_msg + '[%(const)s]')
+
+
 def verify_compression_th(compress_th):
     """
     Verify that the compression threshold is between 0.001 and 1. Else,

--- a/scilpy/io/utils.py
+++ b/scilpy/io/utils.py
@@ -896,7 +896,7 @@ def snapshot(scene, filename, **kwargs):
     image.save(filename)
 
 
-def ranged_type(value_type, min_value, max_value):
+def ranged_type(value_type, min_value=None, max_value=None):
     """Return a function handle of an argument type function for ArgumentParser
     checking a range: `min_value` <= arg <= `max_value`.
 
@@ -923,9 +923,16 @@ def ranged_type(value_type, min_value, max_value):
             f = value_type(arg)
         except ValueError:
             raise argparse.ArgumentTypeError(f"must be a valid {value_type}")
-        if f < min_value or f > max_value:
-            raise argparse.ArgumentTypeError(
-                f"must be within [{min_value}, {max_value}]")
+        if min_value is not None and max_value is not None:
+            if f < min_value or f > max_value:
+                raise argparse.ArgumentTypeError(
+                    f"must be within [{min_value}, {max_value}]")
+        elif min_value is not None:
+            if f < min_value:
+                raise argparse.ArgumentTypeError(f"must be >= {min_value}")
+        elif max_value is not None:
+            if f > max_value:
+                raise argparse.ArgumentTypeError(f"must be <= {max_value}")
         return f
 
     # Return handle to checking function

--- a/scilpy/io/utils.py
+++ b/scilpy/io/utils.py
@@ -519,6 +519,15 @@ def validate_sh_basis_choice(sh_basis):
 
 
 def add_compression_arg(p, additional_msg=''):
+    """
+    Parameters
+    ----------
+    p: ArgumentParser
+        Paser
+    additional_msg: str
+        Any additional message to be displayed after explanation on the
+        compress arg.
+    """
     p.add_argument('--compress', dest='compress_th', nargs='?', const=0.1,
                    type=ranged_type(float, 0, None),
                    help='If set, compress the resulting streamline. Value is '

--- a/scilpy/tracking/utils.py
+++ b/scilpy/tracking/utils.py
@@ -20,7 +20,8 @@ from scilpy.reconst.utils import find_order_from_nb_coeff, get_maximas
 from nibabel.streamlines import TrkFile
 from nibabel.streamlines.tractogram import LazyTractogram, TractogramItem
 
-from scilpy.io.utils import add_sh_basis_args, add_overwrite_arg
+from scilpy.io.utils import add_sh_basis_args, add_overwrite_arg, \
+    add_compression_arg
 
 
 class TrackingDirection(list):
@@ -138,12 +139,11 @@ def add_out_options(p):
     scil_tracking_local_dev scripts.
     """
     out_g = p.add_argument_group('Output options')
-    out_g.add_argument('--compress', type=float, metavar='thresh',
-                       help='If set, will compress streamlines. The parameter '
-                            'value is the \ndistance threshold. A rule of '
-                            'thumb is to set it to 0.1mm for \ndeterministic '
-                            'streamlines and 0.2mm for probabilitic '
-                            'streamlines.')
+    add_compression_arg(out_g, additional_msg=
+                        "\nA rule of thumb is to set it to 0.1mm for "
+                        "deterministic \nstreamlines and to 0.2mm for "
+                        "probabilitic streamlines.")
+
     add_overwrite_arg(out_g)
     out_g.add_argument('--save_seeds', action='store_true',
                        help='If set, save the seeds used for the tracking \n '
@@ -178,8 +178,8 @@ def tqdm_if_verbose(generator: Iterable, verbose: bool, *args, **kwargs):
 
 
 def save_tractogram(
-    streamlines_generator, tracts_format, ref_img, total_nb_seeds,
-    out_tractogram, min_length, max_length, compress, save_seeds, verbose
+        streamlines_generator, tracts_format, ref_img, total_nb_seeds,
+        out_tractogram, min_length, max_length, compress, save_seeds, verbose
 ):
     """ Save the streamlines on-the-fly using a generator. Tracts are
     filtered according to their length and compressed if requested. Seeds
@@ -248,8 +248,8 @@ def save_tractogram(
                 else:
                     # Streamlines are dumped in true world space with
                     # origin center as expected by .tck files.
-                    strl = np.dot(strl, ref_img.affine[:3, :3]) +\
-                        ref_img.affine[:3, 3]
+                    strl = np.dot(strl, ref_img.affine[:3, :3]) + \
+                           ref_img.affine[:3, 3]
 
                 yield TractogramItem(strl, dps, {})
 
@@ -346,17 +346,17 @@ def get_direction_getter(in_img, algo, sphere, sub_sphere, theta, sh_basis,
             # find the closest direction on the sphere.
             logging.info('Input detected as peaks.')
             nb_peaks = img_data.shape[-1] // 3
-            slices = np.arange(0, 15+1, 3)
-            peak_values = np.zeros(img_shape_3d+(nb_peaks,))
-            peak_indices = np.zeros(img_shape_3d+(nb_peaks,))
+            slices = np.arange(0, 15 + 1, 3)
+            peak_values = np.zeros(img_shape_3d + (nb_peaks,))
+            peak_indices = np.zeros(img_shape_3d + (nb_peaks,))
 
             for idx in np.argwhere(np.sum(img_data, axis=-1)):
                 idx = tuple(idx)
                 for i in range(nb_peaks):
                     peak_values[idx][i] = np.linalg.norm(
-                        img_data[idx][slices[i]:slices[i+1]], axis=-1)
+                        img_data[idx][slices[i]:slices[i + 1]], axis=-1)
                     peak_indices[idx][i] = sphere.find_closest(
-                        img_data[idx][slices[i]:slices[i+1]])
+                        img_data[idx][slices[i]:slices[i + 1]])
 
             dg.peak_dirs = img_data
         else:
@@ -365,8 +365,8 @@ def get_direction_getter(in_img, algo, sphere, sub_sphere, theta, sh_basis,
             logging.info('Input detected as fodf.')
             npeaks = 5
             peak_dirs = np.zeros((img_shape_3d + (npeaks, 3)))
-            peak_values = np.zeros((img_shape_3d + (npeaks, )))
-            peak_indices = np.full((img_shape_3d + (npeaks, )), -1,
+            peak_values = np.zeros((img_shape_3d + (npeaks,)))
+            peak_indices = np.full((img_shape_3d + (npeaks,)), -1,
                                    dtype='int')
             b_matrix, _ = sh_to_sf_matrix(sphere,
                                           find_order_from_nb_coeff(img_data),

--- a/scilpy/tracking/utils.py
+++ b/scilpy/tracking/utils.py
@@ -139,10 +139,9 @@ def add_out_options(p):
     scil_tracking_local_dev scripts.
     """
     out_g = p.add_argument_group('Output options')
-    add_compression_arg(out_g, additional_msg=
-                        "\nA rule of thumb is to set it to 0.1mm for "
-                        "deterministic \nstreamlines and to 0.2mm for "
-                        "probabilitic streamlines.")
+    msg = ("\nA rule of thumb is to set it to 0.1mm for deterministic \n"
+           "streamlines and to 0.2mm for probabilitic streamlines.")
+    add_compression_arg(out_g, additional_msg=msg)
 
     add_overwrite_arg(out_g)
     out_g.add_argument('--save_seeds', action='store_true',

--- a/scilpy/tractanalysis/bundle_operations.py
+++ b/scilpy/tractanalysis/bundle_operations.py
@@ -176,7 +176,7 @@ def detect_ushape(sft, minU, maxU):
 
     Returns
     -------
-    list: the ids of clean streamlines
+    list: the ids of u-shaped streamlines
         Only the ids are returned so proper filtering can be done afterwards.
     """
     ids = []

--- a/scilpy/tractograms/streamline_operations.py
+++ b/scilpy/tractograms/streamline_operations.py
@@ -766,12 +766,8 @@ def parallel_transport_streamline(streamline, nb_streamlines, radius,
     return new_streamlines
 
 
-def remove_loops_and_sharp_turns(streamlines,
-                                 max_angle,
-                                 use_qb=False,
-                                 qb_threshold=15.,
-                                 qb_seed=0,
-                                 num_processes=1):
+def remove_loops_and_sharp_turns(streamlines, max_angle, qb_threshold=None,
+                                 qb_seed=0, num_processes=1):
     """
     Remove loops and sharp turns from a list of streamlines.
 
@@ -782,12 +778,11 @@ def remove_loops_and_sharp_turns(streamlines,
     max_angle: float
         Maximal winding angle a streamline can have before
         being classified as a loop.
-    use_qb: bool
-        Set to True if the additional QuickBundles pass is done.
-        This will help remove sharp turns. Should only be used on
-        bundled streamlines, not on whole-brain tractograms.
-    qb_threshold: float
-        Quickbundles distance threshold, only used if use_qb is True.
+    qb_threshold: float, optional
+        If not None, do the additional QuickBundles pass. This will help remove
+        sharp turns. Should only be used on bundled streamlines, not on
+        whole-brain tractograms. If set, value is Quickbundles distance
+        threshold. Suggested default: 15.
     qb_seed: int
         Seed to initialize randomness in QuickBundles
     num_processes : int
@@ -798,17 +793,14 @@ def remove_loops_and_sharp_turns(streamlines,
     list: the ids of clean streamlines
         Only the ids are returned so proper filtering can be done afterwards
     """
-
-    streamlines_clean = []
-    ids = []
     pool = Pool(num_processes)
-
     windings = pool.map(tm.winding, streamlines)
     pool.close()
+
     streamlines_clean = streamlines[np.array(windings) < max_angle]
     ids = list(np.where(np.array(windings) < max_angle)[0])
 
-    if use_qb:
+    if qb_threshold is not None:
         ids = []
         if len(streamlines_clean) > 1:
             curvature = []

--- a/scilpy/tractograms/streamline_operations.py
+++ b/scilpy/tractograms/streamline_operations.py
@@ -566,7 +566,9 @@ def _warn_and_save(new_streamlines, sft):
 
 
 def smooth_line_gaussian(streamline, sigma):
-    """ Smooth a streamline using a gaussian filter.
+    """
+    Smooths a streamline using a gaussian filter. Enforces the endpoints to
+    remain the same.
 
     Parameters
     ----------
@@ -602,8 +604,11 @@ def smooth_line_gaussian(streamline, sigma):
 
 
 def smooth_line_spline(streamline, smoothing_parameter, nb_ctrl_points):
-    """ Smooth a streamline using a spline. The number of control points
-    can be specified, but must be at least 3.
+    """
+    Smooths a streamline using a spline. The number of control points can be
+    specified, but must be at least 3. The final streamline will have the same
+    number of points as the input streamline. Enforces the endpoints to remain
+    the same.
 
     Parameters
     ----------

--- a/scilpy/tractograms/tractogram_operations.py
+++ b/scilpy/tractograms/tractogram_operations.py
@@ -879,46 +879,6 @@ def split_sft_randomly_per_cluster(orig_sft, chunk_sizes, seed, thresholds):
     return final_sfts
 
 
-def filter_tractogram_data(sft, streamline_ids):
-    """
-    Filter a tractogram according to streamline ids and keep the data.
-
-    Parameters:
-    -----------
-    sft: StatefulTractogram
-        Tractogram containing the data to be filtered.
-    streamline_ids: array_like
-        List of streamline ids the data corresponds to.
-
-    Returns:
-    --------
-    new_tractogram: Tractogram or StatefulTractogram
-        Returns a new tractogram with only the selected streamlines and data.
-    """
-    if len(streamline_ids) > 0:
-        streamline_ids = np.asarray(streamline_ids, dtype=int)
-
-        assert np.all(
-            np.in1d(streamline_ids, np.arange(len(sft.streamlines)))
-        ), "Received ids outside of streamline range"
-
-        new_streamlines = sft.streamlines[streamline_ids]
-        new_data_per_streamline = sft.data_per_streamline[streamline_ids]
-        new_data_per_point = sft.data_per_point[streamline_ids]
-    else:
-        new_streamlines = []
-        new_data_per_point = {}
-        new_data_per_streamline = {}
-
-    # Could have been nice to deepcopy the tractogram modify the attributes in
-    # place instead of creating a new one, but tractograms cant be subsampled
-    # if they have data.
-    return StatefulTractogram.from_sft(
-        new_streamlines, sft,
-        data_per_point=new_data_per_point,
-        data_per_streamline=new_data_per_streamline)
-
-
 OPERATIONS = {
     'difference_robust': difference_robust,
     'intersection_robust': intersection_robust,

--- a/scilpy/tractograms/tractogram_operations.py
+++ b/scilpy/tractograms/tractogram_operations.py
@@ -879,13 +879,13 @@ def split_sft_randomly_per_cluster(orig_sft, chunk_sizes, seed, thresholds):
     return final_sfts
 
 
-def filter_tractogram_data(tractogram, streamline_ids):
+def filter_tractogram_data(sft, streamline_ids):
     """
     Filter a tractogram according to streamline ids and keep the data.
 
     Parameters:
     -----------
-    tractogram: StatefulTractogram
+    sft: StatefulTractogram
         Tractogram containing the data to be filtered.
     streamline_ids: array_like
         List of streamline ids the data corresponds to.
@@ -895,24 +895,26 @@ def filter_tractogram_data(tractogram, streamline_ids):
     new_tractogram: Tractogram or StatefulTractogram
         Returns a new tractogram with only the selected streamlines and data.
     """
+    if len(streamline_ids) > 0:
+        streamline_ids = np.asarray(streamline_ids, dtype=int)
 
-    streamline_ids = np.asarray(streamline_ids, dtype=int)
+        assert np.all(
+            np.in1d(streamline_ids, np.arange(len(sft.streamlines)))
+        ), "Received ids outside of streamline range"
 
-    assert np.all(
-        np.in1d(streamline_ids, np.arange(len(tractogram.streamlines)))
-    ), "Received ids outside of streamline range"
-
-    new_streamlines = tractogram.streamlines[streamline_ids]
-    new_data_per_streamline = tractogram.data_per_streamline[streamline_ids]
-    new_data_per_point = tractogram.data_per_point[streamline_ids]
+        new_streamlines = sft.streamlines[streamline_ids]
+        new_data_per_streamline = sft.data_per_streamline[streamline_ids]
+        new_data_per_point = sft.data_per_point[streamline_ids]
+    else:
+        new_streamlines = []
+        new_data_per_point = {}
+        new_data_per_streamline = {}
 
     # Could have been nice to deepcopy the tractogram modify the attributes in
     # place instead of creating a new one, but tractograms cant be subsampled
     # if they have data.
-
     return StatefulTractogram.from_sft(
-        new_streamlines,
-        tractogram,
+        new_streamlines, sft,
         data_per_point=new_data_per_point,
         data_per_streamline=new_data_per_streamline)
 

--- a/scripts/scil_tracking_local.py
+++ b/scripts/scil_tracking_local.py
@@ -175,7 +175,7 @@ def main():
                      'tck): {0}'.format(args.out_tractogram))
 
     verify_streamline_length_options(parser, args)
-    verify_compression_th(args.compress)
+    verify_compression_th(args.compress_th)
     verify_seed_options(parser, args)
 
     tracts_format = detect_format(args.out_tractogram)
@@ -279,7 +279,7 @@ def main():
     # save streamlines on-the-fly to file
     save_tractogram(streamlines_generator, tracts_format,
                     odf_sh_img, total_nb_seeds, args.out_tractogram,
-                    args.min_length, args.max_length, args.compress,
+                    args.min_length, args.max_length, args.compress_th,
                     args.save_seeds, args.verbose)
     # Final logging
     logging.info('Saved tractogram to {0}.'.format(args.out_tractogram))

--- a/scripts/scil_tracking_local_dev.py
+++ b/scripts/scil_tracking_local_dev.py
@@ -165,7 +165,7 @@ def main():
     assert_outputs_exist(parser, args, args.out_tractogram)
 
     verify_streamline_length_options(parser, args)
-    verify_compression_th(args.compress)
+    verify_compression_th(args.compress_th)
     verify_seed_options(parser, args)
 
     tracts_format = detect_format(args.out_tractogram)
@@ -245,7 +245,7 @@ def main():
     logging.info("Instantiating tracker.")
     tracker = Tracker(propagator, mask, seed_generator, nbr_seeds, min_nbr_pts,
                       max_nbr_pts, args.max_invalid_nb_points,
-                      compression_th=args.compress,
+                      compression_th=args.compress_th,
                       nbr_processes=args.nbr_processes,
                       save_seeds=args.save_seeds,
                       mmap_mode='r+', rng_seed=args.rng_seed,

--- a/scripts/scil_tractogram_apply_transform.py
+++ b/scripts/scil_tractogram_apply_transform.py
@@ -42,11 +42,11 @@ Formerly: scil_apply_transform_to_tractogram.py
 import argparse
 import logging
 
-from dipy.io.streamline import save_tractogram
 import nibabel as nib
 import numpy as np
 
-from scilpy.io.streamlines import load_tractogram_with_reference
+from scilpy.io.streamlines import load_tractogram_with_reference, \
+    check_empty_option_save_tractogram
 from scilpy.io.utils import (add_overwrite_arg,
                              add_reference_arg,
                              add_verbose_arg,
@@ -139,16 +139,15 @@ def main():
                                  cut_invalid=args.cut_invalid)
 
     # Saving
-    if len(new_sft.streamlines) == 0 and args.no_empty:
-        logging.info("The file {} won't be written "
-                     "(0 streamline).".format(args.out_tractogram))
-        return
 
     # Default is to crash if invalid.
     if args.keep_invalid:
         if not new_sft.is_bbox_in_vox_valid():
             logging.warning('Saving tractogram with invalid streamlines.')
-        save_tractogram(new_sft, args.out_tractogram, bbox_valid_check=False)
+
+        check_empty_option_save_tractogram(new_sft, args.out_tractogram,
+                                           args.no_empty,
+                                           bbox_valid_check=False)
     else:
         # Here, there should be no invalid streamlines left. Either option =
         # to crash, or remove/cut, already managed.
@@ -156,7 +155,9 @@ def main():
             raise ValueError("The result has invalid streamlines. Please "
                              "chose --keep_invalid, --cut_invalid or "
                              "--remove_invalid.")
-        save_tractogram(new_sft, args.out_tractogram)
+        check_empty_option_save_tractogram(new_sft, args.out_tractogram,
+                                           args.no_empty,
+                                           bbox_valid_check=True)
 
 
 if __name__ == "__main__":

--- a/scripts/scil_tractogram_apply_transform.py
+++ b/scripts/scil_tractogram_apply_transform.py
@@ -46,7 +46,7 @@ import nibabel as nib
 import numpy as np
 
 from scilpy.io.streamlines import load_tractogram_with_reference, \
-    check_empty_option_save_tractogram
+    save_tractogram
 from scilpy.io.utils import (add_overwrite_arg,
                              add_reference_arg,
                              add_verbose_arg,
@@ -145,9 +145,9 @@ def main():
         if not new_sft.is_bbox_in_vox_valid():
             logging.warning('Saving tractogram with invalid streamlines.')
 
-        check_empty_option_save_tractogram(new_sft, args.out_tractogram,
-                                           args.no_empty,
-                                           bbox_valid_check=False)
+        save_tractogram(new_sft, args.out_tractogram,
+                        args.no_empty,
+                        bbox_valid_check=False)
     else:
         # Here, there should be no invalid streamlines left. Either option =
         # to crash, or remove/cut, already managed.
@@ -155,9 +155,9 @@ def main():
             raise ValueError("The result has invalid streamlines. Please "
                              "chose --keep_invalid, --cut_invalid or "
                              "--remove_invalid.")
-        check_empty_option_save_tractogram(new_sft, args.out_tractogram,
-                                           args.no_empty,
-                                           bbox_valid_check=True)
+        save_tractogram(new_sft, args.out_tractogram,
+                        args.no_empty,
+                        bbox_valid_check=True)
 
 
 if __name__ == "__main__":

--- a/scripts/scil_tractogram_cut_streamlines.py
+++ b/scripts/scil_tractogram_cut_streamlines.py
@@ -32,7 +32,8 @@ from scilpy.io.image import get_data_as_mask
 from scilpy.io.streamlines import load_tractogram_with_reference
 from scilpy.io.utils import (add_overwrite_arg, add_reference_arg,
                              add_verbose_arg, assert_inputs_exist,
-                             assert_outputs_exist, assert_headers_compatible)
+                             assert_outputs_exist, assert_headers_compatible,
+                             add_compression_arg)
 from scilpy.tractograms.streamline_and_mask_operations import \
     cut_outside_of_mask_streamlines, cut_between_mask_two_blobs_streamlines
 from scilpy.tractograms.streamline_operations import \
@@ -54,11 +55,10 @@ def _build_arg_parser():
     p.add_argument('--resample', dest='step_size', type=float,
                    help='Resample streamlines to a specific step-size in mm '
                         '[%(default)s].')
-    p.add_argument('--compress', dest='error_rate', type=float,
-                   help='Maximum compression distance in mm [%(default)s].')
     p.add_argument('--biggest_blob', action='store_true',
                    help='Use the biggest entity and force the 1 ROI scenario.')
 
+    add_compression_arg(p)
     add_reference_arg(p)
     add_verbose_arg(p)
     add_overwrite_arg(p)
@@ -122,9 +122,9 @@ def main():
     if len(new_sft) == 0:
         logging.warning('No streamline intersected the provided mask. '
                         'Saving empty tractogram.')
-    elif args.error_rate is not None:
+    elif args.compress_th:
         compressed_strs = [compress_streamlines(
-            s, args.error_rate) for s in new_sft.streamlines]
+            s, args.compress_th) for s in new_sft.streamlines]
         new_sft = StatefulTractogram.from_sft(
             compressed_strs, sft, data_per_streamline=sft.data_per_streamline)
 

--- a/scripts/scil_tractogram_detect_loops.py
+++ b/scripts/scil_tractogram_detect_loops.py
@@ -6,19 +6,17 @@ This script can be used to remove loops in two types of streamline datasets:
 
   - Whole brain: For this type, the script removes streamlines if they
     make a loop with an angle of more than 360 degrees. It's possible to change
-    this angle with the -a option. Warning: Don't use --qb option for a
+    this angle with the --angle option. Warning: Don't use --qb option for a
     whole brain tractography.
 
   - Bundle dataset: For this type, it is possible to remove loops and
-    streamlines outside of the bundle. For the sharp angle turn, use --qb
-    option.
-
-----------------------------------------------------------------------------
-Reference:
-QuickBundles based on [Garyfallidis12] Frontiers in Neuroscience, 2012.
-----------------------------------------------------------------------------
+    streamlines outside the bundle. For the sharp angle turn, use --qb option.
 
 Formerly: scil_detect_streamlines_loops.py
+"""
+
+REFERENCE = """
+QuickBundles, based on [Garyfallidis12] Frontiers in Neuroscience, 2012.
 """
 
 import argparse
@@ -37,7 +35,7 @@ from scilpy.io.utils import (add_json_args,
                              assert_inputs_exist,
                              assert_outputs_exist,
                              check_tracts_same_format,
-                             validate_nbr_processes)
+                             validate_nbr_processes, ranged_type)
 from scilpy.tractograms.tractogram_operations import filter_tractogram_data
 from scilpy.tractograms.streamline_operations import \
     remove_loops_and_sharp_turns
@@ -45,27 +43,27 @@ from scilpy.tractograms.streamline_operations import \
 
 def _build_arg_parser():
     p = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
-                                description=__doc__)
+                                description=__doc__, epilog=REFERENCE)
     p.add_argument('in_tractogram',
                    help='Tractogram input file name.')
     p.add_argument('out_tractogram',
                    help='Output tractogram without loops.')
-    p.add_argument('--looping_tractogram',
+    p.add_argument('--looping_tractogram', metavar='out_filename',
                    help='If set, saves detected looping streamlines.')
-    p.add_argument('--qb', action='store_true',
-                   help='If set, uses QuickBundles to detect\n' +
-                        'outliers (loops, sharp angle turns).\n' +
-                        'Should mainly be used with bundles. '
-                        '[%(default)s]')
-    p.add_argument('--threshold', default=8., type=float,
-                   help='Maximal streamline to bundle distance\n' +
-                        'for a streamline to be considered as\n' +
-                        'a tracking error. [%(default)s]')
-    p.add_argument('-a', dest='angle', default=360, type=float,
+    p.add_argument('--qb', nargs='?', metavar='threshold', dest='qb_threshold',
+                   const=8., type=ranged_type(float, 0.0, None),
+                   help='If set, uses QuickBundles to detect outliers (loops, '
+                        'sharp angle \nturns). Given threshold is the maximal '
+                        'streamline to bundle \ndistance for a streamline to '
+                        'be considered as a tracking error.\nDefault if '
+                        'set: [%(const)s]')
+    p.add_argument('--angle', default=360, type=ranged_type(float, 0.0, 360.0),
                    help='Maximum looping (or turning) angle of\n' +
                         'a streamline in degrees. [%(default)s]')
     p.add_argument('--display_counts', action='store_true',
                    help='Print streamline count before and after filtering')
+    p.add_argument('--no_empty', action='store_true',
+                   help="If set, will not save outputs if they are empty.")
 
     add_json_args(p)
     add_processes_arg(p)
@@ -81,6 +79,7 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
+    # Verifications
     assert_inputs_exist(parser, args.in_tractogram, args.reference)
     assert_outputs_exist(parser, args, args.out_tractogram,
                          optional=args.looping_tractogram)
@@ -88,53 +87,50 @@ def main():
                                       args.looping_tractogram])
     nbr_cpu = validate_nbr_processes(parser, args)
 
-    if args.threshold <= 0:
-        parser.error('Threshold "{}" '.format(args.threshold) +
-                     'must be greater than 0')
+    # Loading
+    sft = load_tractogram_with_reference(parser, args, args.in_tractogram)
+    nb_streamlines = len(sft.streamlines)
 
-    if args.angle <= 0:
-        parser.error('Angle "{}" '.format(args.angle) +
-                     'must be greater than 0')
-
-    tractogram = load_tractogram_with_reference(
-        parser, args, args.in_tractogram)
-
-    streamlines = tractogram.streamlines
-
-    ids_c = []
-
-    ids_l = []
-
-    if len(streamlines) > 1:
-        ids_c = remove_loops_and_sharp_turns(
-            streamlines, args.angle, use_qb=args.qb,
-            qb_threshold=args.threshold,
-            num_processes=nbr_cpu)
-        ids_l = np.setdiff1d(np.arange(len(streamlines)), ids_c)
-    else:
+    if nb_streamlines < 1:
         parser.error(
-            'Zero or one streamline in {}'.format(args.in_tractogram) +
-            '. The file must have more than one streamline.')
+            'Zero or one streamline in {}. The file must have more than one '
+            'streamline.'.format(args.in_tractogram))
 
-    if len(ids_c) > 0:
-        sft_c = filter_tractogram_data(tractogram, ids_c)
-        save_tractogram(sft_c, args.out_tractogram)
-    else:
-        logging.warning(
-            'No clean streamlines in {}'.format(args.in_tractogram))
+    # Processing
+    ids_clean = remove_loops_and_sharp_turns(
+        sft.streamlines, args.angle, qb_threshold=args.qb_threshold,
+        num_processes=nbr_cpu)
+    ids_removed = np.setdiff1d(np.arange(nb_streamlines), ids_clean)
+    sft_clean = filter_tractogram_data(sft, ids_clean)
 
     if args.display_counts:
-        sc_bf = len(tractogram.streamlines)
-        sc_af = len(sft_c.streamlines)
-        print(json.dumps({'streamline_count_before_filtering': int(sc_bf),
+        sc_af = len(sft_clean.streamlines)
+        print(json.dumps({'streamline_count_before_filtering': nb_streamlines,
                          'streamline_count_after_filtering': int(sc_af)},
                          indent=args.indent))
 
-    if len(ids_l) == 0:
-        logging.warning('No loops in {}'.format(args.in_tractogram))
-    elif args.looping_tractogram:
-        sft_l = filter_tractogram_data(tractogram, ids_l)
-        save_tractogram(sft_l, args.looping_tractogram)
+    # Saving
+    if len(ids_clean) == 0:
+        msg = ('No clean streamlines in {}. They are all looping streamlines? '
+               'Check your parameters.'.format(args.in_tractogram))
+        if args.no_empty:
+            logging.warning(msg + " Not saving the tractogram.")
+        else:
+            logging.info(msg + " Saving empty tractogram.")
+
+    if not (len(ids_clean) == 0 and args.no_empty):
+        save_tractogram(sft_clean, args.out_tractogram)
+
+    if args.looping_tractogram:
+        if len(ids_removed) == 0:
+            if args.no_empty:
+                logging.warning('No loops found! Output {} not saved'
+                                .format(args.looping_tractogram))
+            else:
+                logging.info("No loops found! Saving empty tractogram")
+        if not (len(ids_removed) == 0 and args.no_empty):
+            sft_l = filter_tractogram_data(sft, ids_removed)
+            save_tractogram(sft_l, args.looping_tractogram)
 
 
 if __name__ == "__main__":

--- a/scripts/scil_tractogram_detect_loops.py
+++ b/scripts/scil_tractogram_detect_loops.py
@@ -22,7 +22,7 @@ import logging
 import numpy as np
 
 from scilpy.io.streamlines import load_tractogram_with_reference, \
-    check_empty_option_save_tractogram
+    save_tractogram
 from scilpy.io.utils import (add_json_args,
                              add_verbose_arg,
                              add_overwrite_arg,
@@ -114,13 +114,13 @@ def main():
                          indent=args.indent))
 
     # Saving
-    check_empty_option_save_tractogram(sft_clean, args.out_tractogram,
-                                       args.no_empty)
+    save_tractogram(sft_clean, args.out_tractogram,
+                    args.no_empty)
     if args.looping_tractogram:
         ids_removed = np.setdiff1d(np.arange(nb_streamlines), ids_clean)
         sft_l = sft[ids_removed]
-        check_empty_option_save_tractogram(sft_l, args.looping_tractogram,
-                                           args.no_empty)
+        save_tractogram(sft_l, args.looping_tractogram,
+                        args.no_empty)
 
 
 if __name__ == "__main__":

--- a/scripts/scil_tractogram_detect_loops.py
+++ b/scripts/scil_tractogram_detect_loops.py
@@ -126,11 +126,11 @@ def main():
             if args.no_empty:
                 logging.warning('No loops found! Output {} not saved'
                                 .format(args.looping_tractogram))
+                return
             else:
                 logging.info("No loops found! Saving empty tractogram")
-        if not (len(ids_removed) == 0 and args.no_empty):
-            sft_l = filter_tractogram_data(sft, ids_removed)
-            save_tractogram(sft_l, args.looping_tractogram)
+        sft_l = filter_tractogram_data(sft, ids_removed)
+        save_tractogram(sft_l, args.looping_tractogram)
 
 
 if __name__ == "__main__":

--- a/scripts/scil_tractogram_detect_loops.py
+++ b/scripts/scil_tractogram_detect_loops.py
@@ -15,10 +15,6 @@ This script can be used to remove loops in two types of streamline datasets:
 Formerly: scil_detect_streamlines_loops.py
 """
 
-REFERENCE = """
-QuickBundles, based on [Garyfallidis12] Frontiers in Neuroscience, 2012.
-"""
-
 import argparse
 import json
 import logging
@@ -40,9 +36,15 @@ from scilpy.tractograms.streamline_operations import \
     remove_loops_and_sharp_turns
 
 
+EPILOG = """
+References:
+    QuickBundles, based on [Garyfallidis12] Frontiers in Neuroscience, 2012.
+"""
+
+
 def _build_arg_parser():
     p = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
-                                description=__doc__, epilog=REFERENCE)
+                                description=__doc__, epilog=EPILOG)
     p.add_argument('in_tractogram',
                    help='Tractogram input file name.')
     p.add_argument('out_tractogram',

--- a/scripts/scil_tractogram_detect_loops.py
+++ b/scripts/scil_tractogram_detect_loops.py
@@ -36,7 +36,6 @@ from scilpy.io.utils import (add_json_args,
                              assert_outputs_exist,
                              check_tracts_same_format,
                              validate_nbr_processes, ranged_type)
-from scilpy.tractograms.tractogram_operations import filter_tractogram_data
 from scilpy.tractograms.streamline_operations import \
     remove_loops_and_sharp_turns
 
@@ -101,7 +100,7 @@ def main():
         sft.streamlines, args.angle, qb_threshold=args.qb_threshold,
         num_processes=nbr_cpu)
     ids_removed = np.setdiff1d(np.arange(nb_streamlines), ids_clean)
-    sft_clean = filter_tractogram_data(sft, ids_clean)
+    sft_clean = sft[ids_clean]
 
     if args.display_counts:
         sc_af = len(sft_clean.streamlines)

--- a/scripts/scil_tractogram_dpp_math.py
+++ b/scripts/scil_tractogram_dpp_math.py
@@ -50,13 +50,12 @@ def _build_arg_parser():
         description=__doc__)
 
     p.add_argument('operation', metavar='OPERATION',
-                   choices=['mean', 'sum', 'min',
-                            'max', 'correlation'],
+                   choices=['mean', 'sum', 'min', 'max', 'correlation'],
                    help='The type of operation to be performed on the \n'
-                        'streamlines. Must\nbe one of the following: \n'
-                        '%(choices)s.')
+                        'streamlines. Must be one of the following: \n'
+                        '[%(choices)s.]')
     p.add_argument('in_tractogram', metavar='INPUT_FILE',
-                   help='Input tractogram containing streamlines and \n'
+                   help='Input tractogram containing streamlines and '
                         'metadata.')
     p.add_argument('--mode', required=True, choices=['dpp', 'dps'],
                    help='Set to dps if the operation is to be performed \n'
@@ -69,11 +68,11 @@ def _build_arg_parser():
                         'operation to be performed on. If more than one dpp \n'
                         'is selected, the same operation will be applied \n'
                         'separately to each one.')
-    p.add_argument('--out_name', nargs='+', required=True, metavar='key',
+    p.add_argument('--out_keys', nargs='+', required=True, metavar='key',
                    help='Name of the resulting data_per_point or \n'
                    'data_per_streamline to be saved in the output \n'
                    'tractogram. If more than one --in_dpp_name was used, \n'
-                   'enter the same number of --out_name values.')
+                   'enter the same number of --out_keys values.')
     p.add_argument('out_tractogram', metavar='OUTPUT_FILE',
                    help='The file where the remaining streamlines \n'
                         'are saved.')
@@ -87,7 +86,7 @@ def _build_arg_parser():
                    'keys will be saved.')
     p.add_argument('--overwrite_dpp_dps', action='store_true',
                    help='If set, if --keep_all_dpp_dps is set and some \n'
-                   '--out_name keys already existed in your \n'
+                   '--out_keys keys already existed in your \n'
                    'data_per_point or data_per_streamline, allow \n'
                    'overwriting old data_per_point.')
 
@@ -102,27 +101,27 @@ def _build_arg_parser():
 def main():
     parser = _build_arg_parser()
     args = parser.parse_args()
-
     if args.verbose:
         logging.getLogger().setLevel(logging.INFO)
 
+    # Verifications
     assert_inputs_exist(parser, args.in_tractogram, args.reference)
     assert_outputs_exist(parser, args, args.out_tractogram)
 
-    # Load the input files.
+    if len(args.in_dpp_name) != len(args.out_keys):
+        parser.error('The number of in_dpp_names and out_keys must be '
+                     'the same.')
+
+    # Check to see if there are duplicates in the out_keys
+    if len(args.out_keys) != len(set(args.out_keys)):
+        parser.error('The output names (out_keys) must be unique.')
+
+    # Loading.
     logging.info("Loading file {}".format(args.in_tractogram))
     sft = load_tractogram_with_reference(parser, args, args.in_tractogram)
 
     if len(sft.streamlines) == 0:
         parser.error("Input tractogram contains no streamlines. Exiting.")
-
-    if len(args.in_dpp_name) != len(args.out_name):
-        parser.error('The number of in_dpp_names and out_names must be '
-                     'the same.')
-
-    # Check to see if there are duplicates in the out_names
-    if len(args.out_name) != len(set(args.out_name)):
-        parser.error('The output names (out_names) must be unique.')
 
     # Input name checks
     for in_dpp_name in args.in_dpp_name:
@@ -146,42 +145,41 @@ def main():
         if args.operation == 'correlation' and args.mode == 'dpp':
             parser.error('Correlation operation requires dps mode. Exiting.')
 
-        if not args.overwrite_dpp_dps:
-            if in_dpp_name in args.out_name:
-                parser.error('out_name {} already exists in input tractogram. '
-                             'Set overwrite_dpp_dps or choose a different '
-                             'out_name. Exiting.'.format(in_dpp_name))
+        if not args.overwrite_dpp_dps and in_dpp_name in args.out_keys:
+            parser.error('out_key {} already exists in input tractogram. '
+                         'Set overwrite_dpp_dps or choose a different '
+                         'out_key. Exiting.'.format(in_dpp_name))
 
+    # Processing
     data_per_point = {}
     data_per_streamline = {}
-    for in_dpp_name, out_name in zip(args.in_dpp_name,
-                                     args.out_name):
+    for in_dpp_name, out_keys in zip(args.in_dpp_name, args.out_keys):
         # Perform the requested operation.
         if args.operation == 'correlation':
             logging.info('Performing {} across endpoint data and saving as '
-                         'new dpp {}'.format(args.operation, out_name))
+                         'new dpp {}'.format(args.operation, out_keys))
             new_dps = perform_pairwise_streamline_operation_on_endpoints(
                 args.operation, sft, in_dpp_name)
 
-            data_per_streamline[out_name] = new_dps
+            data_per_streamline[out_keys] = new_dps
         elif args.mode == 'dpp':
             # Results in new data per point
             logging.info(
                 'Performing {} on data from each streamine point '
-                'and saving as new dpp {}'.format(
-                    args.operation, out_name))
+                'and saving as new dpp {}'.format(args.operation, out_keys))
             new_dpp = perform_operation_on_dpp(
                 args.operation, sft, in_dpp_name, args.endpoints_only)
-            data_per_point[out_name] = new_dpp
+            data_per_point[out_keys] = new_dpp
         elif args.mode == 'dps':
             # Results in new data per streamline
             logging.info(
                 'Performing {} across each streamline and saving resulting '
-                'data per streamline {}'.format(args.operation, out_name))
+                'data per streamline {}'.format(args.operation, out_keys))
             new_data_per_streamline = perform_operation_dpp_to_dps(
                 args.operation, sft, in_dpp_name, args.endpoints_only)
-            data_per_streamline[out_name] = new_data_per_streamline
+            data_per_streamline[out_keys] = new_data_per_streamline
 
+    # Saving
     if args.keep_all_dpp_dps:
         sft.data_per_streamline.update(data_per_streamline)
         sft.data_per_point.update(data_per_point)
@@ -195,14 +193,14 @@ def main():
     # Print DPP names
     if data_per_point not in [None, {}]:
         print("New data_per_point keys are: ")
-        for key in args.out_name:
+        for key in args.out_keys:
             print("  - {} with shape per point {}"
                   .format(key, new_sft.data_per_point[key][0].shape[1:]))
 
     # Print DPS names
     if data_per_streamline not in [None, {}]:
         print("New data_per_streamline keys are: ")
-        for key in args.out_name:
+        for key in args.out_keys:
             print("  - {} with shape per streamline {}"
                   .format(key, new_sft.data_per_streamline[key].shape[1:]))
 

--- a/scripts/scil_tractogram_extract_ushape.py
+++ b/scripts/scil_tractogram_extract_ushape.py
@@ -17,10 +17,10 @@ import argparse
 import json
 import logging
 
-from dipy.io.streamline import save_tractogram
 import numpy as np
 
-from scilpy.io.streamlines import load_tractogram_with_reference
+from scilpy.io.streamlines import load_tractogram_with_reference, \
+    check_empty_option_save_tractogram
 from scilpy.io.utils import (add_json_args,
                              add_verbose_arg,
                              add_overwrite_arg,
@@ -85,26 +85,13 @@ def main():
                          indent=args.indent))
 
     # Saving
-    if len(ids_ushaped) == 0:
-        if args.no_empty:
-            logging.warning("The file {} won't be written (0 streamline)."
-                            .format(args.out_tractogram))
-        else:
-            logging.info('The file {} contains 0 streamline.'
-                         .format(args.out_tractogram))
-    if not (len(ids_ushaped) == 0 and args.no_empty):
-        save_tractogram(sft[ids_ushaped], args.out_tractogram)
+    check_empty_option_save_tractogram(sft[ids_ushaped], args.out_tractogram,
+                                       args.no_empty)
 
     if args.remaining_tractogram:
-        if len(ids_others) == 0:
-            if args.no_empty:
-                logging.info("The file {} won't be written (0 streamline"
-                             ").".format(args.remaining_tractogram))
-                return
-            else:
-                logging.warning('No remaining streamlines. Saving an empty '
-                                'tractogram')
-        save_tractogram(sft[ids_others], args.remaining_tractogram)
+        check_empty_option_save_tractogram(sft[ids_others],
+                                           args.remaining_tractogram,
+                                           args.no_empty)
 
 
 if __name__ == "__main__":

--- a/scripts/scil_tractogram_extract_ushape.py
+++ b/scripts/scil_tractogram_extract_ushape.py
@@ -20,7 +20,7 @@ import logging
 import numpy as np
 
 from scilpy.io.streamlines import load_tractogram_with_reference, \
-    check_empty_option_save_tractogram
+    save_tractogram
 from scilpy.io.utils import (add_json_args,
                              add_verbose_arg,
                              add_overwrite_arg,
@@ -85,13 +85,13 @@ def main():
                          indent=args.indent))
 
     # Saving
-    check_empty_option_save_tractogram(sft[ids_ushaped], args.out_tractogram,
-                                       args.no_empty)
+    save_tractogram(sft[ids_ushaped], args.out_tractogram,
+                    args.no_empty)
 
     if args.remaining_tractogram:
-        check_empty_option_save_tractogram(sft[ids_others],
-                                           args.remaining_tractogram,
-                                           args.no_empty)
+        save_tractogram(sft[ids_others],
+                        args.remaining_tractogram,
+                        args.no_empty)
 
 
 if __name__ == "__main__":

--- a/scripts/scil_tractogram_extract_ushape.py
+++ b/scripts/scil_tractogram_extract_ushape.py
@@ -38,14 +38,12 @@ def _build_arg_parser():
                    help='Tractogram input file name.')
     p.add_argument('out_tractogram',
                    help='Output tractogram file name.')
-    p.add_argument('--minU',
-                   default=0.5, type=float,
+    p.add_argument('--minU', default=0.5, type=float,
                    help='Min ufactor value. [%(default)s]')
-    p.add_argument('--maxU',
-                   default=1.0, type=float,
+    p.add_argument('--maxU', default=1.0, type=float,
                    help='Max ufactor value. [%(default)s]')
 
-    p.add_argument('--remaining_tractogram',
+    p.add_argument('--remaining_tractogram', metavar='filename',
                    help='If set, saves remaining streamlines.')
     p.add_argument('--no_empty', action='store_true',
                    help='Do not write file if there is no streamline.')
@@ -65,6 +63,7 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
+    # Verifications
     assert_inputs_exist(parser, args.in_tractogram, args.reference)
     assert_outputs_exist(parser, args, args.out_tractogram,
                          optional=args.remaining_tractogram)

--- a/scripts/scil_tractogram_filter_by_anatomy.py
+++ b/scripts/scil_tractogram_filter_by_anatomy.py
@@ -71,7 +71,7 @@ from scilpy.segment.streamlines import filter_grid_roi
 from scilpy.tractograms.streamline_operations import \
     filter_streamlines_by_length, remove_loops_and_sharp_turns
 from scilpy.tractograms.tractogram_operations import \
-    perform_tractogram_operation_on_sft, filter_tractogram_data
+    perform_tractogram_operation_on_sft
 
 
 EPILOG = """
@@ -511,7 +511,7 @@ def main():
     if args.angle != np.inf:
         ids_c = remove_loops_and_sharp_turns(sft.streamlines, args.angle,
                                              num_processes=nbr_cpu)
-        new_sft = filter_tractogram_data(sft, ids_c)
+        new_sft = sft[ids_c]
     else:
         new_sft = deepcopy(sft)
 

--- a/scripts/scil_tractogram_filter_by_length.py
+++ b/scripts/scil_tractogram_filter_by_length.py
@@ -11,10 +11,10 @@ import argparse
 import json
 import logging
 
-from dipy.io.streamline import save_tractogram
 import numpy as np
 
-from scilpy.io.streamlines import load_tractogram_with_reference
+from scilpy.io.streamlines import load_tractogram_with_reference, \
+    check_empty_option_save_tractogram
 from scilpy.io.utils import (add_json_args,
                              add_overwrite_arg,
                              add_reference_arg,
@@ -74,17 +74,8 @@ def main():
                          'streamline_count_after_filtering': int(sc_af)},
                          indent=args.indent))
 
-    if len(new_sft.streamlines) == 0:
-        if args.no_empty:
-            logging.info("The file {} won't be written "
-                         "(0 streamline).".format(args.out_tractogram))
-
-            return
-
-        logging.info('The file {} contains 0 streamline'.format(
-                     args.out_tractogram))
-
-    save_tractogram(new_sft, args.out_tractogram)
+    check_empty_option_save_tractogram(new_sft, args.out_tractogram,
+                                       args.no_empty)
 
 
 if __name__ == "__main__":

--- a/scripts/scil_tractogram_filter_by_length.py
+++ b/scripts/scil_tractogram_filter_by_length.py
@@ -14,7 +14,7 @@ import logging
 import numpy as np
 
 from scilpy.io.streamlines import load_tractogram_with_reference, \
-    check_empty_option_save_tractogram
+    save_tractogram
 from scilpy.io.utils import (add_json_args,
                              add_overwrite_arg,
                              add_reference_arg,
@@ -74,8 +74,8 @@ def main():
                          'streamline_count_after_filtering': int(sc_af)},
                          indent=args.indent))
 
-    check_empty_option_save_tractogram(new_sft, args.out_tractogram,
-                                       args.no_empty)
+    save_tractogram(new_sft, args.out_tractogram,
+                    args.no_empty)
 
 
 if __name__ == "__main__":

--- a/scripts/scil_tractogram_filter_by_orientation.py
+++ b/scripts/scil_tractogram_filter_by_orientation.py
@@ -25,7 +25,7 @@ import logging
 import numpy as np
 
 from scilpy.io.streamlines import load_tractogram_with_reference, \
-    check_empty_option_save_tractogram
+    save_tractogram
 from scilpy.io.utils import (add_json_args,
                              add_overwrite_arg,
                              add_reference_arg,
@@ -111,12 +111,12 @@ def main():
                          'streamline_count_after_filtering': int(sc_af)},
                          indent=args.indent))
 
-    check_empty_option_save_tractogram(new_sft, args.out_tractogram,
-                                       args.no_empty)
+    save_tractogram(new_sft, args.out_tractogram,
+                    args.no_empty)
 
     if computed_rejected_sft:
-        check_empty_option_save_tractogram(rejected_sft, args.save_rejected,
-                                           args.no_empty)
+        save_tractogram(rejected_sft, args.save_rejected,
+                        args.no_empty)
 
 
 if __name__ == "__main__":

--- a/scripts/scil_tractogram_filter_by_orientation.py
+++ b/scripts/scil_tractogram_filter_by_orientation.py
@@ -22,10 +22,10 @@ import argparse
 import json
 import logging
 
-from dipy.io.streamline import save_tractogram
 import numpy as np
 
-from scilpy.io.streamlines import load_tractogram_with_reference
+from scilpy.io.streamlines import load_tractogram_with_reference, \
+    check_empty_option_save_tractogram
 from scilpy.io.utils import (add_json_args,
                              add_overwrite_arg,
                              add_reference_arg,
@@ -111,18 +111,12 @@ def main():
                          'streamline_count_after_filtering': int(sc_af)},
                          indent=args.indent))
 
-    if len(new_sft.streamlines) == 0:
-        if args.no_empty:
-            logging.info("The file {} won't be written "
-                         "(0 streamline).".format(args.out_tractogram))
-        else:
-            logging.info('The file {} contains 0 streamline'.format(
-                         args.out_tractogram))
-
-    save_tractogram(new_sft, args.out_tractogram)
+    check_empty_option_save_tractogram(new_sft, args.out_tractogram,
+                                       args.no_empty)
 
     if computed_rejected_sft:
-        save_tractogram(rejected_sft, args.save_rejected)
+        check_empty_option_save_tractogram(rejected_sft, args.save_rejected,
+                                           args.no_empty)
 
 
 if __name__ == "__main__":

--- a/scripts/scil_tractogram_filter_by_roi.py
+++ b/scripts/scil_tractogram_filter_by_roi.py
@@ -50,7 +50,7 @@ from scilpy.io.image import (get_data_as_mask,
                              merge_labels_into_mask)
 from scilpy.image.labels import get_data_as_labels
 from scilpy.io.streamlines import load_tractogram_with_reference, \
-    check_empty_option_save_tractogram
+    save_tractogram
 from scilpy.io.utils import (add_json_args,
                              add_overwrite_arg,
                              add_reference_arg,
@@ -381,16 +381,16 @@ def main():
     if args.display_counts:
         print(json.dumps(o_dict, indent=args.indent))
 
-    check_empty_option_save_tractogram(sft, args.out_tractogram,
-                                       args.no_empty)
+    save_tractogram(sft, args.out_tractogram,
+                    args.no_empty)
 
     if args.save_rejected:
         rejected_ids = np.setdiff1d(np.arange(len(initial_sft.streamlines)),
                                     total_kept_ids)
 
         sft = initial_sft[rejected_ids]
-        check_empty_option_save_tractogram(sft, args.save_rejected,
-                                           args.no_empty)
+        save_tractogram(sft, args.save_rejected,
+                        args.no_empty)
 
 
 if __name__ == "__main__":

--- a/scripts/scil_tractogram_filter_by_roi.py
+++ b/scripts/scil_tractogram_filter_by_roi.py
@@ -42,7 +42,6 @@ import logging
 import os
 from copy import deepcopy
 
-from dipy.io.streamline import save_tractogram
 from dipy.io.utils import is_header_compatible
 import nibabel as nib
 import numpy as np
@@ -50,7 +49,8 @@ import numpy as np
 from scilpy.io.image import (get_data_as_mask,
                              merge_labels_into_mask)
 from scilpy.image.labels import get_data_as_labels
-from scilpy.io.streamlines import load_tractogram_with_reference
+from scilpy.io.streamlines import load_tractogram_with_reference, \
+    check_empty_option_save_tractogram
 from scilpy.io.utils import (add_json_args,
                              add_overwrite_arg,
                              add_reference_arg,
@@ -381,29 +381,16 @@ def main():
     if args.display_counts:
         print(json.dumps(o_dict, indent=args.indent))
 
-    if not filtered_sft:
-        if args.no_empty:
-            logging.info("The file {} won't be written (0 streamline)".format(
-                args.out_tractogram))
-
-            return
-
-        logging.info('The file {} contains 0 streamline'.format(
-            args.out_tractogram))
-
-    save_tractogram(sft, args.out_tractogram)
+    check_empty_option_save_tractogram(sft, args.out_tractogram,
+                                       args.no_empty)
 
     if args.save_rejected:
         rejected_ids = np.setdiff1d(np.arange(len(initial_sft.streamlines)),
                                     total_kept_ids)
 
-        if len(rejected_ids) == 0 and args.no_empty:
-            logging.info("Rejected streamlines file won't be written (0 "
-                         "streamline).")
-            return
-
         sft = initial_sft[rejected_ids]
-        save_tractogram(sft, args.save_rejected)
+        check_empty_option_save_tractogram(sft, args.save_rejected,
+                                           args.no_empty)
 
 
 if __name__ == "__main__":

--- a/scripts/scil_tractogram_remove_invalid.py
+++ b/scripts/scil_tractogram_remove_invalid.py
@@ -16,7 +16,7 @@ import argparse
 import logging
 
 from scilpy.io.streamlines import load_tractogram_with_reference, \
-    check_empty_option_save_tractogram
+    save_tractogram
 from scilpy.io.utils import (add_overwrite_arg, add_verbose_arg,
                              add_reference_arg, assert_inputs_exist,
                              assert_outputs_exist)
@@ -94,7 +94,7 @@ def main():
     logging.warning('Removed {} invalid streamlines.'.format(
         ori_len - len(sft)))
 
-    check_empty_option_save_tractogram(sft, args.out_tractogram, args.no_empty)
+    save_tractogram(sft, args.out_tractogram, args.no_empty)
 
 
 if __name__ == "__main__":

--- a/scripts/scil_tractogram_remove_invalid.py
+++ b/scripts/scil_tractogram_remove_invalid.py
@@ -15,10 +15,8 @@ Formerly: scil_remove_invalid_streamlines.py
 import argparse
 import logging
 
-from dipy.io.streamline import save_tractogram
-import numpy as np
-
-from scilpy.io.streamlines import load_tractogram_with_reference
+from scilpy.io.streamlines import load_tractogram_with_reference, \
+    check_empty_option_save_tractogram
 from scilpy.io.utils import (add_overwrite_arg, add_verbose_arg,
                              add_reference_arg, assert_inputs_exist,
                              assert_outputs_exist)
@@ -96,10 +94,7 @@ def main():
     logging.warning('Removed {} invalid streamlines.'.format(
         ori_len - len(sft)))
 
-    if len(sft) > 0 or (not args.no_empty and len(sft) == 0):
-        save_tractogram(sft, args.out_tractogram)
-    else:
-        logging.warning('No valid streamline, not saving due to --no_empty.')
+    check_empty_option_save_tractogram(sft, args.out_tractogram, args.no_empty)
 
 
 if __name__ == "__main__":

--- a/scripts/scil_tractogram_segment_bundles_for_connectivity.py
+++ b/scripts/scil_tractogram_segment_bundles_for_connectivity.py
@@ -455,7 +455,6 @@ def main():
                 no_qb_curv_ids = remove_loops_and_sharp_turns(
                     inliers,
                     args.loop_max_angle,
-                    use_qb=True,
                     qb_threshold=args.curv_qb_distance,
                     num_processes=nbr_cpu)
                 qb_curv_ids = np.setdiff1d(np.arange(len(inliers)),

--- a/scripts/scil_tractogram_smooth.py
+++ b/scripts/scil_tractogram_smooth.py
@@ -12,8 +12,8 @@ array. The sigma will be indicative of the  number of points surrounding the
 center points to be used for blurring.
 - Spline will fit a spline curve to every streamline using a sigma and the
 number of control points. The sigma represents the allowed distance from the
-control points. The control points for the spline fit will be the resampled
-streamline.
+control points. The final streamlines are obtained by evaluating the spline at
+constant intervals so that it will have the same number of points as initially.
 
 This script enforces endpoints to remain the same.
 

--- a/scripts/scil_tractogram_smooth.py
+++ b/scripts/scil_tractogram_smooth.py
@@ -2,18 +2,18 @@
 # -*- coding: utf-8 -*-
 
 """
-This script will smooth the streamlines, usually to remove the
-'wiggles' in probabilistic tracking.
-Two choices of methods are available:
-- Gaussian will use the surrounding coordinates for smoothing.
-Streamlines are resampled to 1mm step-size and the smoothing is
-performed on the coordinate array. The sigma will be indicative of the
-number of points surrounding the center points to be used for blurring.
+This script will smooth the streamlines, usually to remove the 'wiggles' in
+probabilistic tracking.
 
-- Spline will fit a spline curve to every streamline using a sigma and
-the number of control points. The sigma represents the allowed distance
-from the control points. The control points for the spline fit will be
-the resampled streamline.
+Two choices of methods are available:
+- Gaussian will use the surrounding coordinates for smoothing. Streamlines are
+resampled to 1mm step-size and the smoothing is performed on the coordinate
+array. The sigma will be indicative of the  number of points surrounding the
+center points to be used for blurring.
+- Spline will fit a spline curve to every streamline using a sigma and the
+number of control points. The sigma represents the allowed distance from the
+control points. The control points for the spline fit will be the resampled
+streamline.
 
 This script enforces endpoints to remain the same.
 
@@ -36,7 +36,7 @@ from scilpy.io.streamlines import load_tractogram_with_reference
 from scilpy.io.utils import (add_overwrite_arg, add_reference_arg,
                              add_verbose_arg,
                              assert_inputs_exist,
-                             assert_outputs_exist)
+                             assert_outputs_exist, add_compression_arg)
 from scilpy.tractograms.streamline_operations import smooth_line_gaussian, \
     smooth_line_spline
 
@@ -54,8 +54,8 @@ def _build_arg_parser():
     sub_p = p.add_mutually_exclusive_group(required=True)
     sub_p.add_argument('--gaussian', metavar='SIGMA', type=int,
                        help='Sigma for smoothing. Use the value of surronding'
-                            '\nX,Y,Z points on the streamline to blur the'
-                            ' streamlines.\nA good sigma choice would be '
+                            '\nX,Y,Z points on the streamline to blur the '
+                            'streamlines.\nA good sigma choice would be '
                             'around 5.')
     sub_p.add_argument('--spline', nargs=2, metavar=('SIGMA', 'NB_CTRL_POINT'),
                        type=int,
@@ -63,10 +63,7 @@ def _build_arg_parser():
                             'spline.\nA good sigma choice would be around 5 '
                             'and control point around 10.')
 
-    p.add_argument('-e', dest='error_rate', type=float, default=0.1,
-                   help='Maximum compression distance in mm after smoothing. '
-                        '[%(default)s]')
-
+    add_compression_arg(p)
     add_reference_arg(p)
     add_verbose_arg(p)
     add_overwrite_arg(p)
@@ -91,9 +88,10 @@ def main():
             tmp_streamlines = smooth_line_spline(streamline, args.spline[0],
                                                  args.spline[1])
 
-        if args.error_rate:
-            smoothed_streamlines.append(compress_streamlines(tmp_streamlines,
-                                                             args.error_rate))
+        if args.compress_th:
+            tmp_streamlines = compress_streamlines(tmp_streamlines,
+                                                   args.compress_th)
+        smoothed_streamlines.append(tmp_streamlines)
 
     smoothed_sft = StatefulTractogram.from_sft(
                         smoothed_streamlines, sft,

--- a/scripts/tests/test_tractogram_detect_loops.py
+++ b/scripts/tests/test_tractogram_detect_loops.py
@@ -25,6 +25,6 @@ def test_execution_filtering(script_runner, monkeypatch):
                             in_bundle, 'bundle_4_filtered_no_loops.trk',
                             '--looping_tractogram',
                             'bundle_4_filtered_loops.trk',
-                            '-a', '270', '--qb', '--threshold', '4',
-                            '--processes', '1')
+                            '--angle', '270', '--qb', '4',
+                            '--processes', '1', '--display_counts')
     assert ret.success

--- a/scripts/tests/test_tractogram_dpp_math.py
+++ b/scripts/tests/test_tractogram_dpp_math.py
@@ -21,25 +21,29 @@ def test_help_option(script_runner):
 def test_execution_tractogram_point_math_mean_3D_defaults(script_runner,
                                                           monkeypatch):
     monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
-    in_bundle = os.path.join(SCILPY_HOME, 'tractometry',
-                             'IFGWM_uni.trk')
-    in_t1 = os.path.join(SCILPY_HOME, 'tractometry',
-                         'mni_masked.nii.gz')
-
+    in_bundle = os.path.join(SCILPY_HOME, 'tractometry', 'IFGWM_uni.trk')
+    in_t1 = os.path.join(SCILPY_HOME, 'tractometry', 'mni_masked.nii.gz')
     t1_on_bundle = 't1_on_streamlines.trk'
 
+    # Create some dpp. Could have test data with dpp instead.
     script_runner.run('scil_tractogram_project_map_to_streamlines.py',
-                      in_bundle, t1_on_bundle,
-                      '--in_maps', in_t1,
+                      in_bundle, t1_on_bundle, '--in_maps', in_t1,
                       '--out_dpp_name', 't1')
 
+    # Test dps mode
     ret = script_runner.run('scil_tractogram_dpp_math.py',
-                            'mean',
-                            t1_on_bundle,
-                            't1_mean_on_streamlines.trk',
-                            '--mode', 'dps',
-                            '--in_dpp_name', 't1',
-                            '--out_name', 't1_mean')
+                            'mean', t1_on_bundle, 't1_mean_on_streamlines.trk',
+                            '--mode', 'dps', '--in_dpp_name', 't1',
+                            '--out_keys', 't1_mean')
+
+    assert ret.success
+
+    # Test dpp mode
+    ret = script_runner.run('scil_tractogram_dpp_math.py',
+                            'mean', t1_on_bundle,
+                            't1_mean_on_streamlines2.trk',
+                            '--mode', 'dpp', '--in_dpp_name', 't1',
+                            '--out_keys', 't1_mean')
 
     assert ret.success
 
@@ -47,11 +51,8 @@ def test_execution_tractogram_point_math_mean_3D_defaults(script_runner,
 def test_execution_tractogram_point_math_mean_4D_correlation(script_runner,
                                                              monkeypatch):
     monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
-    in_bundle = os.path.join(SCILPY_HOME, 'tracking',
-                             'local_split_0.trk')
-
-    in_fodf = os.path.join(SCILPY_HOME, 'tracking',
-                           'fodf.nii.gz')
+    in_bundle = os.path.join(SCILPY_HOME, 'tracking', 'local_split_0.trk')
+    in_fodf = os.path.join(SCILPY_HOME, 'tracking', 'fodf.nii.gz')
     fodf_on_bundle = 'fodf_on_streamlines.trk'
 
     script_runner.run('scil_tractogram_project_map_to_streamlines.py',
@@ -60,11 +61,9 @@ def test_execution_tractogram_point_math_mean_4D_correlation(script_runner,
                       '--out_dpp_name', 'fodf', 'fodf2')
 
     ret = script_runner.run('scil_tractogram_dpp_math.py',
-                            'correlation',
-                            fodf_on_bundle,
+                            'correlation', fodf_on_bundle,
                             'fodf_correlation_on_streamlines.trk',
-                            '--mode', 'dps',
-                            '--in_dpp_name', 'fodf',
-                            '--out_name', 'fodf_correlation')
+                            '--mode', 'dps', '--in_dpp_name', 'fodf',
+                            '--out_keys', 'fodf_correlation')
 
     assert ret.success

--- a/scripts/tests/test_tractogram_project_streamlines_to_map.py
+++ b/scripts/tests/test_tractogram_project_streamlines_to_map.py
@@ -64,7 +64,7 @@ def test_execution_dps(script_runner, monkeypatch):
                       '--in_maps', in_mni, '--out_dpp_name', 'some_metric')
     script_runner.run('scil_tractogram_dpp_math.py', 'min', in_bundle_with_dpp,
                       in_bundle_with_dps, '--in_dpp_name', 'some_metric',
-                      '--out_name', 'some_metric_dps', '--mode', 'dps',
+                      '--out_keys', 'some_metric_dps', '--mode', 'dps',
                       '--keep_all')
 
     # Tests with dps.

--- a/scripts/tests/test_tractogram_smooth.py
+++ b/scripts/tests/test_tractogram_smooth.py
@@ -23,5 +23,5 @@ def test_execution_tracking(script_runner, monkeypatch):
                              'union_shuffle_sub.trk')
     ret = script_runner.run('scil_tractogram_smooth.py', in_tracto,
                             'union_shuffle_sub_smooth.trk', '--gaussian', '10',
-                            '-e', '0.05')
+                            '--compress', '0.05')
     assert ret.success


### PR DESCRIPTION
# Quick description

Next step of scripts verification.
- `scil_tractogram_detect_loops`: 
      - Clarified the argparser: arguments --qb and --threshold were either both required or both not used, so they were basically the same argument. Merged. 
      - Added a --no_empty option.
- `scil_tractogram_dpp_math`:
      -   argument --out_name was not really the output tractogram name, but the output dpp/dps name. Confusing. Changed to --out_key_name.
      - Moved some checks higher to do them before loading stuff.
      - Added more tests for better code coverage.
- `scil_tractogram_extract_ushape`: 
      - Using `ranged_type`; verifications not needed anymore.
      - Moving stuff a bit.
      - There was a return (old line 88) that could potentially prevent the rest of happening (print counts, save remaining_tractogram). Fixed.
- `scil_tractogram_smooth`: Just improving doc!

Other changes:

- New compression_arg in all script using compression.
- New method that saves an emtpy tractogram only if not --no_empty.
- Deleted the `filter_tractogram_data` method. Confirmed with François: All this is just the equivalent of sft[idx].

## Type of change

Check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [x] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [x] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
