### PR TITLE
switch to monkeypatch.chdir

### DIFF
--- a/scripts/tests/test_NODDI_maps.py
+++ b/scripts/tests/test_NODDI_maps.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_commit_amico(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_commit_amico(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi = os.path.join(SCILPY_HOME, 'commit_amico',
                           'dwi.nii.gz')
     in_bval = os.path.join(SCILPY_HOME, 'commit_amico',

--- a/scripts/tests/test_NODDI_priors.py
+++ b/scripts/tests/test_NODDI_priors.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_commit_amico(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_commit_amico(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_fa = os.path.join(SCILPY_HOME, 'processing',
                          'fa.nii.gz')
     in_ad = os.path.join(SCILPY_HOME, 'processing',

--- a/scripts/tests/test_aodf_metrics.py
+++ b/scripts/tests/test_aodf_metrics.py
@@ -16,10 +16,10 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution(script_runner):
+def test_execution(script_runner, monkeypatch):
 
     # toDo: Add --mask.
-    os.chdir(os.path.expanduser(tmp_dir.name))
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_fodf = os.path.join(
         f"{test_data_root}/fodf_descoteaux07_sub_unified_asym.nii.gz")
 
@@ -29,8 +29,8 @@ def test_execution(script_runner):
     assert ret.success
 
 
-def test_assert_not_all(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_assert_not_all(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_fodf = os.path.join(
         f"{test_data_root}/fodf_descoteaux07_sub_unified_asym.nii.gz")
 
@@ -39,8 +39,8 @@ def test_assert_not_all(script_runner):
     assert not ret.success
 
 
-def test_execution_not_all(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_not_all(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_fodf = os.path.join(
         f"{test_data_root}/fodf_descoteaux07_sub_unified_asym.nii.gz")
 
@@ -50,8 +50,8 @@ def test_execution_not_all(script_runner):
     assert ret.success
 
 
-def test_assert_symmetric_input(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_assert_symmetric_input(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_fodf = os.path.join(
         f"{test_data_root}/fodf_descoteaux07_sub.nii.gz")
 
@@ -61,8 +61,8 @@ def test_assert_symmetric_input(script_runner):
     assert not ret.success
 
 
-def test_execution_symmetric_input(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_symmetric_input(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_fodf = os.path.join(
         f"{test_data_root}/fodf_descoteaux07_sub.nii.gz")
 

--- a/scripts/tests/test_bingham_metrics.py
+++ b/scripts/tests/test_bingham_metrics.py
@@ -18,8 +18,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_processing(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_bingham = os.path.join(SCILPY_HOME, 'processing',
                               'fodf_bingham.nii.gz')
 
@@ -30,8 +30,8 @@ def test_execution_processing(script_runner):
     assert ret.success
 
 
-def test_execution_processing_mask(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing_mask(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_bingham = os.path.join(SCILPY_HOME, 'processing',
                               'fodf_bingham.nii.gz')
     in_mask = os.path.join(SCILPY_HOME, 'processing',
@@ -44,8 +44,8 @@ def test_execution_processing_mask(script_runner):
     assert ret.success
 
 
-def test_execution_processing_not_all(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing_not_all(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_bingham = os.path.join(SCILPY_HOME, 'processing',
                               'fodf_bingham.nii.gz')
 

--- a/scripts/tests/test_btensor_metrics.py
+++ b/scripts/tests/test_btensor_metrics.py
@@ -16,8 +16,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_nb_btensors_check(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_nb_btensors_check(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi_lin = os.path.join(SCILPY_HOME, 'btensor_testdata',
                               'dwi_linear.nii.gz')
     in_bval_lin = os.path.join(SCILPY_HOME, 'btensor_testdata',
@@ -51,8 +51,8 @@ def test_nb_btensors_check(script_runner):
     assert (not ret.success)
 
 
-def test_inputs_check(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_inputs_check(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi_lin = os.path.join(SCILPY_HOME, 'btensor_testdata',
                               'dwi_linear.nii.gz')
     in_bval_lin = os.path.join(SCILPY_HOME, 'btensor_testdata',
@@ -95,8 +95,8 @@ def test_inputs_check(script_runner):
     assert (not ret.success)
 
 
-def test_execution_processing(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi_lin = os.path.join(SCILPY_HOME, 'btensor_testdata',
                               'dwi_linear.nii.gz')
     in_bval_lin = os.path.join(SCILPY_HOME, 'btensor_testdata',

--- a/scripts/tests/test_bundle_compute_centroid.py
+++ b/scripts/tests/test_bundle_compute_centroid.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_tractometry(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_tractometry(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_bundle = os.path.join(SCILPY_HOME, 'tractometry', 'IFGWM_uni.trk')
     ret = script_runner.run('scil_bundle_compute_centroid.py',
                             in_bundle, 'IFGWM_uni_c.trk')

--- a/scripts/tests/test_bundle_compute_endpoints_map.py
+++ b/scripts/tests/test_bundle_compute_endpoints_map.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_tractometry(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_tractometry(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_bundle = os.path.join(SCILPY_HOME, 'tractometry', 'IFGWM_uni.trk')
     ret = script_runner.run('scil_bundle_compute_endpoints_map.py', in_bundle,
                             'head.nii.gz', 'tail.nii.gz', '--binary')

--- a/scripts/tests/test_bundle_diameter.py
+++ b/scripts/tests/test_bundle_diameter.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_tractometry(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_tractometry(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_bundle = os.path.join(SCILPY_HOME, 'tractometry', 'IFGWM.trk')
     in_labels = os.path.join(SCILPY_HOME, 'tractometry',
                              'IFGWM_labels_map.nii.gz')

--- a/scripts/tests/test_bundle_filter_by_occurence.py
+++ b/scripts/tests/test_bundle_filter_by_occurence.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_1 = os.path.join(SCILPY_HOME, 'filtering', 'bundle_4.trk')
     in_2 = os.path.join(SCILPY_HOME, 'filtering', 'bundle_4_filtered.trk')
     in_3 = os.path.join(SCILPY_HOME, 'filtering',

--- a/scripts/tests/test_bundle_generate_priors.py
+++ b/scripts/tests/test_bundle_generate_priors.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_bst(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_bst(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_bundle = os.path.join(SCILPY_HOME, 'bst', 'rpt_m_lin.trk')
     in_fodf = os.path.join(SCILPY_HOME, 'bst', 'fodf.nii.gz')
     in_mask = os.path.join(SCILPY_HOME, 'bst', 'mask.nii.gz')

--- a/scripts/tests/test_bundle_label_map.py
+++ b/scripts/tests/test_bundle_label_map.py
@@ -17,10 +17,11 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_tractometry(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_tractometry(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_bundle = os.path.join(SCILPY_HOME, 'tractometry', 'IFGWM.trk')
-    in_centroid = os.path.join(SCILPY_HOME, 'tractometry', 'IFGWM_uni_c_10.trk')
+    in_centroid = os.path.join(SCILPY_HOME, 'tractometry',
+                               'IFGWM_uni_c_10.trk')
     ret = script_runner.run('scil_bundle_label_map.py', in_bundle, in_centroid,
                             'results_dir/', '--colormap', 'viridis')
     assert ret.success

--- a/scripts/tests/test_bundle_mean_fixel_afd.py
+++ b/scripts/tests/test_bundle_mean_fixel_afd.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_processing(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_tracking = os.path.join(SCILPY_HOME, 'processing', 'tracking.trk')
     in_fodf = os.path.join(SCILPY_HOME, 'processing',
                            'fodf_descoteaux07.nii.gz')

--- a/scripts/tests/test_bundle_mean_fixel_afd_from_hdf5.py
+++ b/scripts/tests/test_bundle_mean_fixel_afd_from_hdf5.py
@@ -18,8 +18,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_connectivity(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_connectivity(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_h5 = os.path.join(SCILPY_HOME, 'connectivity', 'decompose.h5')
     in_fodf = os.path.join(SCILPY_HOME, 'connectivity', 'fodf.nii.gz')
     ret = script_runner.run('scil_bundle_mean_fixel_afd_from_hdf5.py',

--- a/scripts/tests/test_bundle_mean_fixel_bingham_metric.py
+++ b/scripts/tests/test_bundle_mean_fixel_bingham_metric.py
@@ -19,8 +19,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_processing(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_bingham = os.path.join(SCILPY_HOME, 'processing', 'fodf_bingham.nii.gz')
     in_metric = os.path.join(SCILPY_HOME, 'processing', 'fd.nii.gz')
     in_bundles = os.path.join(SCILPY_HOME, 'processing', 'tracking.trk')

--- a/scripts/tests/test_bundle_mean_std.py
+++ b/scripts/tests/test_bundle_mean_std.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_tractometry_whole(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_tractometry_whole(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_bundle = os.path.join(SCILPY_HOME, 'tractometry', 'IFGWM.trk')
     in_ref = os.path.join(SCILPY_HOME, 'tractometry', 'mni_masked.nii.gz')
     ret = script_runner.run('scil_bundle_mean_std.py', in_bundle, in_ref,
@@ -26,8 +26,8 @@ def test_execution_tractometry_whole(script_runner):
     assert ret.success
 
 
-def test_execution_tractometry_per_point(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_tractometry_per_point(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_bundle = os.path.join(SCILPY_HOME, 'tractometry', 'IFGWM.trk')
     in_label = os.path.join(SCILPY_HOME, 'tractometry',
                             'IFGWM_labels_map.nii.gz')

--- a/scripts/tests/test_bundle_pairwise_comparison.py
+++ b/scripts/tests/test_bundle_pairwise_comparison.py
@@ -18,8 +18,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_bundles(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_bundles(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_1 = os.path.join(SCILPY_HOME, 'bundles', 'bundle_0_reco.tck')
     in_2 = os.path.join(SCILPY_HOME, 'bundles', 'voting_results',
                         'bundle_0.trk')
@@ -32,8 +32,8 @@ def test_execution_bundles(script_runner):
     assert ret.success
 
 
-def test_single(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_single(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_1 = os.path.join(SCILPY_HOME, 'bundles', 'bundle_0_reco.tck')
     in_2 = os.path.join(SCILPY_HOME, 'bundles', 'voting_results',
                         'bundle_0.trk')
@@ -47,8 +47,8 @@ def test_single(script_runner):
     assert ret.success
 
 
-def test_no_overlap(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_no_overlap(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_1 = os.path.join(SCILPY_HOME, 'bundles', 'bundle_0_reco.tck')
     in_2 = os.path.join(SCILPY_HOME, 'bundles', 'voting_results',
                         'bundle_0.trk')
@@ -62,8 +62,8 @@ def test_no_overlap(script_runner):
     assert ret.success
 
 
-def test_ratio(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_ratio(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_1 = os.path.join(SCILPY_HOME, 'bundles', 'bundle_0_reco.tck')
     in_2 = os.path.join(SCILPY_HOME, 'bundles', 'voting_results',
                         'bundle_0.trk')
@@ -78,11 +78,11 @@ def test_ratio(script_runner):
     assert ret.success
 
 
-def test_ratio_fail(script_runner):
+def test_ratio_fail(script_runner, monkeypatch):
     """ Test ratio without single_compare argument.
     The test should fail.
     """
-    os.chdir(os.path.expanduser(tmp_dir.name))
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_1 = os.path.join(SCILPY_HOME, 'bundles',  'bundle_0_reco.tck')
     in_2 = os.path.join(SCILPY_HOME, 'bundles', 'voting_results',
                         'bundle_0.trk')

--- a/scripts/tests/test_bundle_score_many_bundles_one_tractogram.py
+++ b/scripts/tests/test_bundle_score_many_bundles_one_tractogram.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_score_bundles(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_score_bundles(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_tractogram = os.path.join(SCILPY_HOME, 'tracking', 'pft.trk')
 
     # Pretend we have our segmented bundles on disk

--- a/scripts/tests/test_bundle_score_same_bundle_many_segmentations.py
+++ b/scripts/tests/test_bundle_score_same_bundle_many_segmentations.py
@@ -18,8 +18,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_bundles(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_bundles(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_1 = os.path.join(SCILPY_HOME, 'bundles', 'bundle_0_reco.tck')
     in_2 = os.path.join(SCILPY_HOME, 'bundles', 'voting_results',
                         'bundle_0.trk')

--- a/scripts/tests/test_bundle_shape_measures.py
+++ b/scripts/tests/test_bundle_shape_measures.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_bundles(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_bundles(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_1 = os.path.join(SCILPY_HOME, 'bundles', 'bundle_0_reco.tck')
     in_2 = os.path.join(SCILPY_HOME, 'bundles', 'voting_results',
                         'bundle_0.trk')

--- a/scripts/tests/test_bundle_volume_per_label.py
+++ b/scripts/tests/test_bundle_volume_per_label.py
@@ -18,8 +18,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_tractometry(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_tractometry(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_label_map = os.path.join(SCILPY_HOME, 'tractometry',
                                 'IFGWM_labels_map.nii.gz')
     ret = script_runner.run('scil_bundle_volume_per_label.py',

--- a/scripts/tests/test_connectivity_compare_populations.py
+++ b/scripts/tests/test_connectivity_compare_populations.py
@@ -18,8 +18,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_connectivity(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_connectivity(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_1 = os.path.join(SCILPY_HOME, 'connectivity', 'sc.npy')
     in_2 = os.path.join(SCILPY_HOME, 'connectivity', 'sc_norm.npy')
     in_mask = os.path.join(SCILPY_HOME, 'connectivity', 'mask.npy')

--- a/scripts/tests/test_connectivity_compute_matrices.py
+++ b/scripts/tests/test_connectivity_compute_matrices.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_connectivity(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_connectivity(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_h5 = os.path.join(SCILPY_HOME, 'connectivity', 'decompose.h5')
     in_atlas = os.path.join(SCILPY_HOME, 'connectivity',
                             'endpoints_atlas.nii.gz')

--- a/scripts/tests/test_connectivity_compute_pca.py
+++ b/scripts/tests/test_connectivity_compute_pca.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_pca(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_pca(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     input_folder = os.path.join(SCILPY_HOME, 'stats/pca')
     output_folder = os.path.join(SCILPY_HOME, 'stats/pca_out')
     ids = os.path.join(SCILPY_HOME, 'stats/pca', 'list_id.txt')

--- a/scripts/tests/test_connectivity_filter.py
+++ b/scripts/tests/test_connectivity_filter.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_connectivity(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_connectivity(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_sc = os.path.join(SCILPY_HOME, 'connectivity',
                          'sc.npy')
     in_sim = os.path.join(SCILPY_HOME, 'connectivity',

--- a/scripts/tests/test_connectivity_graph_measures.py
+++ b/scripts/tests/test_connectivity_graph_measures.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_connectivity(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_connectivity(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_sc = os.path.join(SCILPY_HOME, 'connectivity', 'sc_norm.npy')
     in_len = os.path.join(SCILPY_HOME, 'connectivity', 'len.npy')
     ret = script_runner.run('scil_connectivity_graph_measures.py', in_sc,

--- a/scripts/tests/test_connectivity_hdf5_average_density_map.py
+++ b/scripts/tests/test_connectivity_hdf5_average_density_map.py
@@ -18,8 +18,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_connectivity(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_connectivity(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_h5 = os.path.join(SCILPY_HOME, 'connectivity', 'decompose.h5')
     ret = script_runner.run('scil_connectivity_hdf5_average_density_map.py',
                             in_h5, 'avg_density_maps/', '--binary',

--- a/scripts/tests/test_connectivity_math.py
+++ b/scripts/tests/test_connectivity_math.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_connectivity_div(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_connectivity_div(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_sc = os.path.join(SCILPY_HOME, 'connectivity',
                          'sc.npy')
     in_vol = os.path.join(SCILPY_HOME, 'connectivity',
@@ -28,8 +28,8 @@ def test_execution_connectivity_div(script_runner):
     assert ret.success
 
 
-def test_execution_connectivity_add(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_connectivity_add(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_sc = os.path.join(SCILPY_HOME, 'connectivity',
                          'sc.npy')
     ret = script_runner.run('scil_connectivity_math.py', 'addition',
@@ -37,8 +37,8 @@ def test_execution_connectivity_add(script_runner):
     assert ret.success
 
 
-def test_execution_connectivity_lower_threshold(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_connectivity_lower_threshold(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_sc = os.path.join(SCILPY_HOME, 'connectivity',
                          'sc.npy')
     ret = script_runner.run('scil_connectivity_math.py', 'lower_threshold',

--- a/scripts/tests/test_connectivity_normalize.py
+++ b/scripts/tests/test_connectivity_normalize.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_connectivity(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_connectivity(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_sc = os.path.join(SCILPY_HOME, 'connectivity', 'sc.npy')
     in_len = os.path.join(SCILPY_HOME, 'connectivity', 'len.npy')
     in_atlas = os.path.join(SCILPY_HOME, 'connectivity',

--- a/scripts/tests/test_connectivity_pairwise_agreement.py
+++ b/scripts/tests/test_connectivity_pairwise_agreement.py
@@ -18,8 +18,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_connectivity(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_connectivity(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_sc = os.path.join(SCILPY_HOME, 'connectivity', 'sc_norm.npy')
     in_len = os.path.join(SCILPY_HOME, 'connectivity', 'len.npy')
     ret = script_runner.run('scil_connectivity_pairwise_agreement.py', in_sc,

--- a/scripts/tests/test_connectivity_print_filenames.py
+++ b/scripts/tests/test_connectivity_print_filenames.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_connectivity(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_connectivity(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_sc = os.path.join(SCILPY_HOME, 'connectivity',
                          'sc_norm.npy')
     in_labels_list = os.path.join(SCILPY_HOME, 'connectivity',

--- a/scripts/tests/test_connectivity_reorder_rois.py
+++ b/scripts/tests/test_connectivity_reorder_rois.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_compute_OLO(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_compute_OLO(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_sc = os.path.join(SCILPY_HOME, 'connectivity',
                          'sc_norm.npy')
     in_labels_list = os.path.join(SCILPY_HOME, 'connectivity',
@@ -30,8 +30,8 @@ def test_execution_compute_OLO(script_runner):
     assert ret.success
 
 
-def test_execution_apply_ordering(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_apply_ordering(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_sc = os.path.join(SCILPY_HOME, 'connectivity', 'sc_norm.npy')
     in_txt = os.path.join(SCILPY_HOME, 'connectivity', 'reorder.txt')
     in_labels_list = os.path.join(SCILPY_HOME, 'connectivity',

--- a/scripts/tests/test_denoising_nlmeans.py
+++ b/scripts/tests/test_denoising_nlmeans.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_others(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_others(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_img = os.path.join(SCILPY_HOME, 'others', 't1_resample.nii.gz')
     ret = script_runner.run('scil_denoising_nlmeans.py', in_img,
                             't1_denoised.nii.gz',  '4', '--processes', '1')

--- a/scripts/tests/test_dki_metrics.py
+++ b/scripts/tests/test_dki_metrics.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_processing(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi = os.path.join(SCILPY_HOME, 'processing',
                           'dwi_crop.nii.gz')
     in_bval = os.path.join(SCILPY_HOME, 'processing',

--- a/scripts/tests/test_dti_convert_tensors.py
+++ b/scripts/tests/test_dti_convert_tensors.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_processing(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
 
     # No tensor in the current test data! I'm running the dti_metrics
     # to create one.

--- a/scripts/tests/test_dti_metrics.py
+++ b/scripts/tests/test_dti_metrics.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_processing(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi = os.path.join(SCILPY_HOME, 'processing', 'dwi_crop_1000.nii.gz')
     in_bval = os.path.join(SCILPY_HOME, 'processing', '1000.bval')
     in_bvec = os.path.join(SCILPY_HOME, 'processing', '1000.bvec')

--- a/scripts/tests/test_dwi_apply_bias_field.py
+++ b/scripts/tests/test_dwi_apply_bias_field.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_processing(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi = os.path.join(SCILPY_HOME, 'processing',
                           'dwi_crop.nii.gz')
     in_bias = os.path.join(SCILPY_HOME, 'processing',

--- a/scripts/tests/test_dwi_compute_snr.py
+++ b/scripts/tests/test_dwi_compute_snr.py
@@ -16,8 +16,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_snr(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_snr(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi = os.path.join(SCILPY_HOME, 'processing',
                           'dwi.nii.gz')
     in_bval = os.path.join(SCILPY_HOME, 'processing',

--- a/scripts/tests/test_dwi_concatenate.py
+++ b/scripts/tests/test_dwi_concatenate.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_processing_concatenate(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing_concatenate(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi = os.path.join(SCILPY_HOME, 'processing',
                           'dwi_crop.nii.gz')
     in_bval = os.path.join(SCILPY_HOME, 'processing',

--- a/scripts/tests/test_dwi_detect_volume_outliers.py
+++ b/scripts/tests/test_dwi_detect_volume_outliers.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi = os.path.join(SCILPY_HOME, 'processing',
                           'dwi_crop.nii.gz')
     in_bval = os.path.join(SCILPY_HOME, 'processing',

--- a/scripts/tests/test_dwi_extract_b0.py
+++ b/scripts/tests/test_dwi_extract_b0.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_processing(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi = os.path.join(SCILPY_HOME, 'processing',
                           'dwi_crop.nii.gz')
     in_bval = os.path.join(SCILPY_HOME, 'processing',

--- a/scripts/tests/test_dwi_extract_shell.py
+++ b/scripts/tests/test_dwi_extract_shell.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_processing_1000(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing_1000(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi = os.path.join(SCILPY_HOME, 'processing',
                           'dwi_crop.nii.gz')
     in_bval = os.path.join(SCILPY_HOME, 'processing',
@@ -32,8 +32,8 @@ def test_execution_processing_1000(script_runner):
     assert ret.success
 
 
-def test_execution_out_indices(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_out_indices(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi = os.path.join(SCILPY_HOME, 'processing',
                           'dwi_crop.nii.gz')
     in_bval = os.path.join(SCILPY_HOME, 'processing',
@@ -48,8 +48,8 @@ def test_execution_out_indices(script_runner):
     assert ret.success
 
 
-def test_execution_processing_3000(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing_3000(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi = os.path.join(SCILPY_HOME, 'processing',
                           'dwi_crop.nii.gz')
     in_bval = os.path.join(SCILPY_HOME, 'processing',

--- a/scripts/tests/test_dwi_powder_average.py
+++ b/scripts/tests/test_dwi_powder_average.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_processing(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
 
     in_dwi = os.path.join(SCILPY_HOME, 'processing',
                           'dwi_crop_1000.nii.gz')

--- a/scripts/tests/test_dwi_reorder_philips.py
+++ b/scripts/tests/test_dwi_reorder_philips.py
@@ -21,8 +21,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_reorder(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_reorder(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi = os.path.join(SCILPY_HOME, 'processing', 'dwi_crop.nii.gz')
     in_bval = os.path.join(SCILPY_HOME, 'processing', 'dwi.bval')
     in_bvec = os.path.join(SCILPY_HOME, 'processing', 'dwi.bvec')
@@ -40,8 +40,8 @@ def test_reorder(script_runner):
     assert ret.success
 
 
-def test_reorder_w_json_old_version(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_reorder_w_json_old_version(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi = os.path.join(SCILPY_HOME, 'processing', 'dwi_crop.nii.gz')
     in_bval = os.path.join(SCILPY_HOME, 'processing', 'dwi.bval')
     in_bvec = os.path.join(SCILPY_HOME, 'processing', 'dwi.bvec')
@@ -63,8 +63,8 @@ def test_reorder_w_json_old_version(script_runner):
     assert ret.success
 
 
-def test_reorder_w_json_new_version(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_reorder_w_json_new_version(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi = os.path.join(SCILPY_HOME, 'processing', 'dwi_crop.nii.gz')
     in_bval = os.path.join(SCILPY_HOME, 'processing', 'dwi.bval')
     in_bvec = os.path.join(SCILPY_HOME, 'processing', 'dwi.bvec')

--- a/scripts/tests/test_dwi_split_by_indices.py
+++ b/scripts/tests/test_dwi_split_by_indices.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_processing(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi = os.path.join(SCILPY_HOME, 'processing', 'dwi_crop.nii.gz')
     in_bval = os.path.join(SCILPY_HOME, 'processing', 'dwi.bval')
     in_bvec = os.path.join(SCILPY_HOME, 'processing', 'dwi.bvec')
@@ -27,8 +27,8 @@ def test_execution_processing(script_runner):
     assert ret.success
 
 
-def test_execution_processing_wrong_indices_given(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing_wrong_indices_given(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi = os.path.join(SCILPY_HOME, 'processing', 'dwi_crop.nii.gz')
     in_bval = os.path.join(SCILPY_HOME, 'processing', 'dwi.bval')
     in_bvec = os.path.join(SCILPY_HOME, 'processing', 'dwi.bvec')

--- a/scripts/tests/test_dwi_to_sh.py
+++ b/scripts/tests/test_dwi_to_sh.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_processing(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi = os.path.join(SCILPY_HOME, 'processing',
                           'dwi_crop_3000.nii.gz')
     in_bval = os.path.join(SCILPY_HOME, 'processing',

--- a/scripts/tests/test_fodf_max_in_ventricles.py
+++ b/scripts/tests/test_fodf_max_in_ventricles.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_processing(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_fodf = os.path.join(SCILPY_HOME, 'processing',
                            'fodf.nii.gz')
     in_fa = os.path.join(SCILPY_HOME, 'processing',

--- a/scripts/tests/test_fodf_memsmt.py
+++ b/scripts/tests/test_fodf_memsmt.py
@@ -16,8 +16,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_inputs_check(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_inputs_check(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi_lin = os.path.join(SCILPY_HOME, 'btensor_testdata',
                               'dwi_linear.nii.gz')
     in_bval_lin = os.path.join(SCILPY_HOME, 'btensor_testdata',
@@ -63,8 +63,8 @@ def test_inputs_check(script_runner):
     assert (not ret.success)
 
 
-def test_execution_processing(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi_lin = os.path.join(SCILPY_HOME, 'btensor_testdata',
                               'dwi_linear.nii.gz')
     in_bval_lin = os.path.join(SCILPY_HOME, 'btensor_testdata',

--- a/scripts/tests/test_fodf_metrics.py
+++ b/scripts/tests/test_fodf_metrics.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_processing(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_fodf = os.path.join(SCILPY_HOME, 'processing',
                            'fodf_descoteaux07.nii.gz')
     ret = script_runner.run('scil_fodf_metrics.py', in_fodf, '--not_al',

--- a/scripts/tests/test_fodf_msmt.py
+++ b/scripts/tests/test_fodf_msmt.py
@@ -16,8 +16,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_processing(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi = os.path.join(SCILPY_HOME, 'commit_amico', 'dwi.nii.gz')
     in_bval = os.path.join(SCILPY_HOME, 'commit_amico', 'dwi.bval')
     in_bvec = os.path.join(SCILPY_HOME, 'commit_amico', 'dwi.bvec')

--- a/scripts/tests/test_fodf_ssst.py
+++ b/scripts/tests/test_fodf_ssst.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_processing(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi = os.path.join(SCILPY_HOME, 'processing',
                           'dwi_crop_3000.nii.gz')
     in_bval = os.path.join(SCILPY_HOME, 'processing',

--- a/scripts/tests/test_fodf_to_bingham.py
+++ b/scripts/tests/test_fodf_to_bingham.py
@@ -18,8 +18,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_processing(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_fodf = os.path.join(SCILPY_HOME, 'processing',
                            'fodf_descoteaux07.nii.gz')
     ret = script_runner.run('scil_fodf_to_bingham.py',
@@ -33,8 +33,8 @@ def test_execution_processing(script_runner):
     assert ret.success
 
 
-def test_execution_processing_mask(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing_mask(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_fodf = os.path.join(SCILPY_HOME, 'processing',
                            'fodf_descoteaux07.nii.gz')
     in_mask = os.path.join(SCILPY_HOME, 'processing',

--- a/scripts/tests/test_freewater_maps.py
+++ b/scripts/tests/test_freewater_maps.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_commit_amico(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_commit_amico(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi = os.path.join(SCILPY_HOME, 'commit_amico',
                           'dwi.nii.gz')
     in_bval = os.path.join(SCILPY_HOME, 'commit_amico',

--- a/scripts/tests/test_frf_mean.py
+++ b/scripts/tests/test_frf_mean.py
@@ -18,22 +18,22 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_processing_ssst(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing_ssst(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_frf = os.path.join(SCILPY_HOME, 'processing', 'frf.txt')
     ret = script_runner.run('scil_frf_mean.py', in_frf, in_frf, 'mfrf1.txt')
     assert ret.success
 
 
-def test_execution_processing_msmt(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing_msmt(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_frf = os.path.join(SCILPY_HOME, 'commit_amico', 'wm_frf.txt')
     ret = script_runner.run('scil_frf_mean.py', in_frf, in_frf, 'mfrf2.txt')
     assert ret.success
 
 
-def test_execution_processing_bad_input(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing_bad_input(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_wm_frf = os.path.join(SCILPY_HOME, 'commit_amico', 'wm_frf.txt')
     in_frf = os.path.join(SCILPY_HOME, 'processing', 'frf.txt')
     ret = script_runner.run('scil_frf_mean.py', in_wm_frf, in_frf, 'mfrf3.txt')

--- a/scripts/tests/test_frf_memsmt.py
+++ b/scripts/tests/test_frf_memsmt.py
@@ -16,8 +16,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_roi_center_shape_parameter(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_roi_center_shape_parameter(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi_lin = os.path.join(SCILPY_HOME, 'btensor_testdata',
                               'dwi_linear.nii.gz')
     in_bval_lin = os.path.join(SCILPY_HOME, 'btensor_testdata',
@@ -48,8 +48,8 @@ def test_roi_center_shape_parameter(script_runner):
     assert (not ret.success)
 
 
-def test_roi_radii_shape_parameter(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_roi_radii_shape_parameter(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi_lin = os.path.join(SCILPY_HOME, 'btensor_testdata',
                               'dwi_linear.nii.gz')
     in_bval_lin = os.path.join(SCILPY_HOME, 'btensor_testdata',
@@ -99,8 +99,8 @@ def test_roi_radii_shape_parameter(script_runner):
     assert (not ret.success)
 
 
-def test_inputs_check(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_inputs_check(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi_lin = os.path.join(SCILPY_HOME, 'btensor_testdata',
                               'dwi_linear.nii.gz')
     in_bval_lin = os.path.join(SCILPY_HOME, 'btensor_testdata',
@@ -130,8 +130,8 @@ def test_inputs_check(script_runner):
     assert (not ret.success)
 
 
-def test_execution_processing(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi_lin = os.path.join(SCILPY_HOME, 'btensor_testdata',
                               'dwi_linear.nii.gz')
     in_bval_lin = os.path.join(SCILPY_HOME, 'btensor_testdata',

--- a/scripts/tests/test_frf_msmt.py
+++ b/scripts/tests/test_frf_msmt.py
@@ -16,8 +16,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_roi_radii_shape_parameter(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_roi_radii_shape_parameter(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi = os.path.join(SCILPY_HOME, 'commit_amico',
                           'dwi.nii.gz')
     in_bval = os.path.join(SCILPY_HOME, 'commit_amico',
@@ -46,8 +46,8 @@ def test_roi_radii_shape_parameter(script_runner):
     assert (not ret.success)
 
 
-def test_roi_radii_shape_parameter2(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_roi_radii_shape_parameter2(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi = os.path.join(SCILPY_HOME, 'commit_amico',
                           'dwi.nii.gz')
     in_bval = os.path.join(SCILPY_HOME, 'commit_amico',
@@ -75,8 +75,8 @@ def test_roi_radii_shape_parameter2(script_runner):
     assert (not ret.success)
 
 
-def test_execution_processing(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi = os.path.join(SCILPY_HOME, 'commit_amico',
                           'dwi.nii.gz')
     in_bval = os.path.join(SCILPY_HOME, 'commit_amico',

--- a/scripts/tests/test_frf_set_diffusivities.py
+++ b/scripts/tests/test_frf_set_diffusivities.py
@@ -18,8 +18,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_processing_ssst(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing_ssst(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_frf = os.path.join(SCILPY_HOME, 'processing',
                           'frf.txt')
     ret = script_runner.run('scil_frf_set_diffusivities.py', in_frf,
@@ -27,8 +27,8 @@ def test_execution_processing_ssst(script_runner):
     assert ret.success
 
 
-def test_execution_processing_msmt(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing_msmt(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_frf = os.path.join(SCILPY_HOME, 'commit_amico',
                           'wm_frf.txt')
     ret = script_runner.run('scil_frf_set_diffusivities.py', in_frf,
@@ -36,8 +36,8 @@ def test_execution_processing_msmt(script_runner):
     assert ret.success
 
 
-def test_execution_processing__wrong_input(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing__wrong_input(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_frf = os.path.join(SCILPY_HOME, 'commit_amico',
                           'wm_frf.txt')
     ret = script_runner.run('scil_frf_set_diffusivities.py', in_frf,

--- a/scripts/tests/test_frf_ssst.py
+++ b/scripts/tests/test_frf_ssst.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_roi_center_parameter(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_roi_center_parameter(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi = os.path.join(SCILPY_HOME, 'processing',
                           'dwi_crop.nii.gz')
     in_bval = os.path.join(SCILPY_HOME, 'processing',
@@ -44,8 +44,8 @@ def test_roi_center_parameter(script_runner):
     assert not ret.success
 
 
-def test_roi_radii_shape_parameter(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_roi_radii_shape_parameter(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi = os.path.join(SCILPY_HOME, 'processing',
                           'dwi_crop.nii.gz')
     in_bval = os.path.join(SCILPY_HOME, 'processing',
@@ -69,8 +69,8 @@ def test_roi_radii_shape_parameter(script_runner):
     assert (not ret.success)
 
 
-def test_execution_processing(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi = os.path.join(SCILPY_HOME, 'processing',
                           'dwi_crop.nii.gz')
     in_bval = os.path.join(SCILPY_HOME, 'processing',

--- a/scripts/tests/test_gradients_apply_transform.py
+++ b/scripts/tests/test_gradients_apply_transform.py
@@ -18,8 +18,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_bst(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_bst(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_bvecs = os.path.join(SCILPY_HOME, 'processing',
                             'dwi.bvec')
     in_aff = os.path.join(SCILPY_HOME, 'bst',

--- a/scripts/tests/test_gradients_convert.py
+++ b/scripts/tests/test_gradients_convert.py
@@ -18,8 +18,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_processing_fsl(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing_fsl(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_bval = os.path.join(SCILPY_HOME, 'processing',
                            '1000.bval')
     in_bvec = os.path.join(SCILPY_HOME, 'processing',
@@ -30,8 +30,8 @@ def test_execution_processing_fsl(script_runner):
     assert ret.success
 
 
-def test_execution_processing_mrtrix(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing_mrtrix(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_encoding = os.path.join(SCILPY_HOME, 'processing',
                                '1000.b')
     ret = script_runner.run('scil_gradients_convert.py',
@@ -40,8 +40,8 @@ def test_execution_processing_mrtrix(script_runner):
     assert ret.success
 
 
-def test_name_validation_mrtrix(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_name_validation_mrtrix(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_bval = os.path.join(SCILPY_HOME, 'processing',
                            '1000.bval')
     in_bvec = os.path.join(SCILPY_HOME, 'processing',
@@ -58,8 +58,8 @@ def test_name_validation_mrtrix(script_runner):
     assert os.path.isfile(right_path)
 
 
-def test_name_validation_fsl_bval(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_name_validation_fsl_bval(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_encoding = os.path.join(SCILPY_HOME, 'processing',
                                '1000.b')
     ret = script_runner.run('scil_gradients_convert.py',
@@ -78,8 +78,8 @@ def test_name_validation_fsl_bval(script_runner):
     assert os.path.isfile(right_path_bvec)
 
 
-def test_name_validation_fsl_bvec(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_name_validation_fsl_bvec(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_encoding = os.path.join(SCILPY_HOME, 'processing',
                                '1000.b')
     ret = script_runner.run('scil_gradients_convert.py',

--- a/scripts/tests/test_gradients_generate_sampling.py
+++ b/scripts/tests/test_gradients_generate_sampling.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_others(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_others(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     ret = script_runner.run('scil_gradients_generate_sampling.py',
                             '6', '6', 'encoding.b', '--mrtrix', '--eddy',
                             '--duty', '--b0_every', '25', '--b0_end',

--- a/scripts/tests/test_gradients_modify_axes.py
+++ b/scripts/tests/test_gradients_modify_axes.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_processing(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
 
     # mrtrix
     in_encoding = os.path.join(SCILPY_HOME, 'processing', '1000.b')

--- a/scripts/tests/test_gradients_round_bvals.py
+++ b/scripts/tests/test_gradients_round_bvals.py
@@ -18,8 +18,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_processing(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_bval = os.path.join(SCILPY_HOME, 'processing', '1000.bval')
     ret = script_runner.run('scil_gradients_round_bvals.py',
                             in_bval, '0', '1000', '1000_resample.b', "20",

--- a/scripts/tests/test_gradients_validate_correct.py
+++ b/scripts/tests/test_gradients_validate_correct.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_processing_dti_peaks(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing_dti_peaks(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi = os.path.join(SCILPY_HOME, 'processing',
                           'dwi_crop_1000.nii.gz')
     in_bval = os.path.join(SCILPY_HOME, 'processing',
@@ -36,8 +36,8 @@ def test_execution_processing_dti_peaks(script_runner):
     assert ret.success
 
 
-def test_execution_processing_fodf_peaks(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing_fodf_peaks(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_bvec = os.path.join(SCILPY_HOME, 'processing',
                            'dwi.bvec')
     in_peaks = os.path.join(SCILPY_HOME, 'processing',

--- a/scripts/tests/test_gradients_validate_correct_eddy.py
+++ b/scripts/tests/test_gradients_validate_correct_eddy.py
@@ -18,8 +18,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_extract_half(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_extract_half(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_bvec = os.path.join(SCILPY_HOME, 'processing', 'dwi.bvec')
     in_bval = os.path.join(SCILPY_HOME, 'processing', 'dwi.bval')
     ret = script_runner.run('scil_gradients_validate_correct_eddy.py',
@@ -29,8 +29,8 @@ def test_execution_extract_half(script_runner):
                             '-f')
     assert ret.success
 
-def test_execution_extract_total(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_extract_total(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_bvec = os.path.join(SCILPY_HOME, 'processing', 'dwi.bvec')
     in_bval = os.path.join(SCILPY_HOME, 'processing', 'dwi.bval')
     ret = script_runner.run('scil_gradients_validate_correct_eddy.py',

--- a/scripts/tests/test_header_print_info.py
+++ b/scripts/tests/test_header_print_info.py
@@ -17,15 +17,15 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_img(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_img(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_img = os.path.join(SCILPY_HOME, 'others', 'fa.nii.gz')
     ret = script_runner.run('scil_header_print_info.py', in_img)
     assert ret.success
 
 
-def test_execution_tractogram(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_tractogram(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_tracto = os.path.join(SCILPY_HOME, 'others', 'IFGWM.trk')
     ret = script_runner.run('scil_header_print_info.py', in_tracto)
     assert ret.success

--- a/scripts/tests/test_header_validate_compatibility.py
+++ b/scripts/tests/test_header_validate_compatibility.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_filtering(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_filtering(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_bundle = os.path.join(SCILPY_HOME, 'filtering', 'bundle_all_1mm.trk')
     in_roi = os.path.join(SCILPY_HOME, 'filtering', 'mask.nii.gz')
     ret = script_runner.run('scil_header_validate_compatibility.py',

--- a/scripts/tests/test_json_convert_entries_to_xlsx.py
+++ b/scripts/tests/test_json_convert_entries_to_xlsx.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_tractometry(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_tractometry(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_json = os.path.join(SCILPY_HOME, 'tractometry',
                            'length_stats_1.json')
     ret = script_runner.run('scil_json_convert_entries_to_xlsx.py', in_json,

--- a/scripts/tests/test_json_merge_entries.py
+++ b/scripts/tests/test_json_merge_entries.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_tractometry(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_tractometry(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_json_1 = os.path.join(SCILPY_HOME, 'tractometry',
                            'length_stats_1.json')
     in_json_2 = os.path.join(SCILPY_HOME, 'tractometry',

--- a/scripts/tests/test_labels_combine.py
+++ b/scripts/tests/test_labels_combine.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_atlas(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_atlas(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_atlas_1 = os.path.join(SCILPY_HOME, 'atlas',
                               'atlas_freesurfer_v2.nii.gz')
     in_brainstem = os.path.join(SCILPY_HOME, 'atlas', 'brainstem.nii.gz')
@@ -30,8 +30,8 @@ def test_execution_atlas(script_runner):
     assert ret.success
 
 
-def test_execution_atlas_merge(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_atlas_merge(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_atlas_1 = os.path.join(SCILPY_HOME, 'atlas',
                               'atlas_freesurfer_v2.nii.gz')
     in_brainstem = os.path.join(SCILPY_HOME, 'atlas', 'brainstem.nii.gz')

--- a/scripts/tests/test_labels_dilate.py
+++ b/scripts/tests/test_labels_dilate.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_atlas(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_atlas(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_atlas = os.path.join(SCILPY_HOME, 'atlas',
                             'atlas_freesurfer_v2_single_brainstem.nii.gz')
     ret = script_runner.run('scil_labels_dilate.py', in_atlas,

--- a/scripts/tests/test_labels_remove.py
+++ b/scripts/tests/test_labels_remove.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_atlas(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_atlas(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_atlas = os.path.join(SCILPY_HOME, 'atlas',
                             'atlas_freesurfer_v2.nii.gz')
     ret = script_runner.run('scil_labels_remove.py', in_atlas,

--- a/scripts/tests/test_labels_split_volume_by_ids.py
+++ b/scripts/tests/test_labels_split_volume_by_ids.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_atlas(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_atlas(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_atlas = os.path.join(SCILPY_HOME, 'atlas',
                             'atlas_freesurfer_v2.nii.gz')
     ret = script_runner.run('scil_labels_split_volume_by_ids.py', in_atlas,

--- a/scripts/tests/test_labels_split_volume_from_lut.py
+++ b/scripts/tests/test_labels_split_volume_from_lut.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_atlas(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_atlas(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_atlas = os.path.join(SCILPY_HOME, 'atlas',
                             'atlas_freesurfer_v2.nii.gz')
     in_json = os.path.join(SCILPY_HOME, 'atlas',

--- a/scripts/tests/test_mti_adjust_B1_header.py
+++ b/scripts/tests/test_mti_adjust_B1_header.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_ihMT_no_option(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_ihMT_no_option(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
 
     in_b1_map = os.path.join(SCILPY_HOME,
                              'MT', 'sub-001_run-01_B1map.nii.gz')

--- a/scripts/tests/test_mti_maps_MT.py
+++ b/scripts/tests/test_mti_maps_MT.py
@@ -62,8 +62,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_MT_no_option(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_MT_no_option(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
 
     # no option
     ret = script_runner.run('scil_mti_maps_MT.py', tmp_dir.name,
@@ -79,8 +79,8 @@ def test_execution_MT_no_option(script_runner):
     assert ret.success
 
 
-def test_execution_MT_prefix(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_MT_prefix(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
 
     # --out_prefix
     ret = script_runner.run('scil_mti_maps_MT.py', tmp_dir.name,
@@ -97,8 +97,8 @@ def test_execution_MT_prefix(script_runner):
     assert ret.success
 
 
-def test_execution_MT_extended(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_MT_extended(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
 
     # --extended
     ret = script_runner.run('scil_mti_maps_MT.py', tmp_dir.name,
@@ -115,8 +115,8 @@ def test_execution_MT_extended(script_runner):
     assert ret.success
 
 
-def test_execution_MT_filtering(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_MT_filtering(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
 
     # --filtering
     ret = script_runner.run('scil_mti_maps_MT.py', tmp_dir.name,
@@ -133,8 +133,8 @@ def test_execution_MT_filtering(script_runner):
     assert ret.success
 
 
-def test_execution_MT_B1_map(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_MT_B1_map(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
 
     out_b1_map = tmp_dir.name + '/B1map.nii.gz'
 
@@ -161,8 +161,8 @@ def test_execution_MT_B1_map(script_runner):
     assert ret.success
 
 
-def test_execution_MT_wrong_echoes(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_MT_wrong_echoes(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
 
     # Wrong number of echoes for negative
     ret = script_runner.run('scil_mti_maps_MT.py', tmp_dir.name,
@@ -180,8 +180,8 @@ def test_execution_MT_wrong_echoes(script_runner):
     assert (not ret.success)
 
 
-def test_execution_MT_single_echoe(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_MT_single_echoe(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
 
     # Single echoe
     ret = script_runner.run('scil_mti_maps_MT.py', tmp_dir.name,
@@ -195,8 +195,8 @@ def test_execution_MT_single_echoe(script_runner):
     assert ret.success
 
 
-def test_execution_MT_B1_not_T1(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_MT_B1_not_T1(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
 
     out_b1_map = tmp_dir.name + '/B1map.nii.gz'
 
@@ -217,8 +217,8 @@ def test_execution_MT_B1_not_T1(script_runner):
     assert ret.success
 
 
-def test_execution_MT_B1_no_fit(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_MT_B1_no_fit(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
 
     out_b1_map = tmp_dir.name + '/B1map.nii.gz'
 
@@ -240,8 +240,8 @@ def test_execution_MT_B1_no_fit(script_runner):
     assert (not ret.success)
 
 
-def test_execution_MT_acq_params(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_MT_acq_params(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
 
     # Acquisition parameters
     ret = script_runner.run('scil_mti_maps_MT.py', tmp_dir.name,

--- a/scripts/tests/test_mti_maps_ihMT.py
+++ b/scripts/tests/test_mti_maps_ihMT.py
@@ -71,8 +71,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_ihMT_no_option(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_ihMT_no_option(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
 
     # no option
     ret = script_runner.run('scil_mti_maps_ihMT.py', tmp_dir.name,
@@ -93,8 +93,8 @@ def test_execution_ihMT_no_option(script_runner):
     assert ret.success
 
 
-def test_execution_ihMT_prefix(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_ihMT_prefix(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
 
     # --out_prefix
     ret = script_runner.run('scil_mti_maps_ihMT.py', tmp_dir.name,
@@ -118,8 +118,8 @@ def test_execution_ihMT_prefix(script_runner):
     assert ret.success
 
 
-def test_execution_ihMT_extended(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_ihMT_extended(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
 
     # --extended
     ret = script_runner.run('scil_mti_maps_ihMT.py', tmp_dir.name,
@@ -143,8 +143,8 @@ def test_execution_ihMT_extended(script_runner):
     assert ret.success
 
 
-def test_execution_ihMT_filtering(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_ihMT_filtering(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
 
     # --filtering
     ret = script_runner.run('scil_mti_maps_ihMT.py', tmp_dir.name,
@@ -167,8 +167,8 @@ def test_execution_ihMT_filtering(script_runner):
     assert ret.success
 
 
-def test_execution_ihMT_B1_map(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_ihMT_B1_map(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
 
     out_b1_map = tmp_dir.name + '/B1map.nii.gz'
 
@@ -197,8 +197,8 @@ def test_execution_ihMT_B1_map(script_runner):
     assert ret.success
 
 
-def test_execution_ihMT_B1_no_T1(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_ihMT_B1_no_T1(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
 
     out_b1_map = tmp_dir.name + '/B1map.nii.gz'
 
@@ -224,8 +224,8 @@ def test_execution_ihMT_B1_no_T1(script_runner):
     assert ret.success
 
 
-def test_execution_ihMT_wrong_echoes(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_ihMT_wrong_echoes(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
 
     ret = script_runner.run('scil_mti_maps_ihMT.py', tmp_dir.name,
                             '--mask', in_mask,
@@ -244,8 +244,8 @@ def test_execution_ihMT_wrong_echoes(script_runner):
     assert (not ret.success)
 
 
-def test_execution_ihMT_B1_no_fit(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_ihMT_B1_no_fit(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
 
     out_b1_map = tmp_dir.name + '/B1map.nii.gz'
 
@@ -274,8 +274,8 @@ def test_execution_ihMT_B1_no_fit(script_runner):
     assert (not ret.success)
 
 
-def test_execution_ihMT_single_echo(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_ihMT_single_echo(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
 
     ret = script_runner.run('scil_mti_maps_ihMT.py', tmp_dir.name,
                             '--mask', in_mask,
@@ -291,8 +291,8 @@ def test_execution_ihMT_single_echo(script_runner):
     assert ret.success
 
 
-def test_execution_ihMT_acq_params(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_ihMT_acq_params(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
 
     ret = script_runner.run('scil_mti_maps_ihMT.py', tmp_dir.name,
                             '--mask', in_mask,

--- a/scripts/tests/test_outlier_rejection.py
+++ b/scripts/tests/test_outlier_rejection.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_filtering(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_filtering(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_bundle = os.path.join(SCILPY_HOME, 'filtering',
                              'bundle_all_1mm.trk')
     ret = script_runner.run('scil_outlier_rejection.py', in_bundle,

--- a/scripts/tests/test_plot_stats_per_point.py
+++ b/scripts/tests/test_plot_stats_per_point.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_tractometry(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_tractometry(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_json = os.path.join(SCILPY_HOME, 'tractometry',
                            'metric_label.json')
     ret = script_runner.run('scil_plot_stats_per_point.py', in_json,

--- a/scripts/tests/test_qball_metrics.py
+++ b/scripts/tests/test_qball_metrics.py
@@ -16,8 +16,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_processing(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi = os.path.join(SCILPY_HOME, 'processing',
                           'dwi_crop_1000.nii.gz')
     in_bval = os.path.join(SCILPY_HOME, 'processing',
@@ -29,8 +29,8 @@ def test_execution_processing(script_runner):
     assert ret.success
 
 
-def test_execution_not_all(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_not_all(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi = os.path.join(SCILPY_HOME, 'processing',
                           'dwi_crop_1000.nii.gz')
     in_bval = os.path.join(SCILPY_HOME, 'processing',

--- a/scripts/tests/test_rgb_convert.py
+++ b/scripts/tests/test_rgb_convert.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_others(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_others(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_img = os.path.join(SCILPY_HOME, 'others',
                           'rgb.nii.gz')
     ret = script_runner.run('scil_rgb_convert.py',

--- a/scripts/tests/test_sh_convert.py
+++ b/scripts/tests/test_sh_convert.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_processing(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_fodf = os.path.join(SCILPY_HOME, 'processing',
                            'fodf.nii.gz')
     ret = script_runner.run('scil_sh_convert.py', in_fodf,

--- a/scripts/tests/test_sh_fusion.py
+++ b/scripts/tests/test_sh_fusion.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_processing(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_sh_1 = os.path.join(SCILPY_HOME, 'processing',
                            'sh_1000.nii.gz')
     in_sh_2 = os.path.join(SCILPY_HOME, 'processing',

--- a/scripts/tests/test_sh_to_aodf.py
+++ b/scripts/tests/test_sh_to_aodf.py
@@ -25,8 +25,8 @@ def test_help_option(script_runner):
     [os.path.join(test_data_root, "fodf_descoteaux07_sub.nii.gz"),
      os.path.join(test_data_root,
                   "fodf_descoteaux07_sub_unified_asym.nii.gz")]])
-def test_asym_basis_output_gpu(script_runner, in_fodf, expected_fodf):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_asym_basis_output_gpu(script_runner, in_fodf, expected_fodf, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
 
     ret = script_runner.run('scil_sh_to_aodf.py',
                             in_fodf, 'out_fodf1.nii.gz',
@@ -61,8 +61,8 @@ def test_asym_basis_output_gpu(script_runner, in_fodf, expected_fodf):
     [os.path.join(test_data_root, "fodf_descoteaux07_sub.nii.gz"),
      os.path.join(test_data_root,
                   "fodf_descoteaux07_sub_unified_asym.nii.gz")]])
-def test_asym_basis_output(script_runner, in_fodf, expected_fodf):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_asym_basis_output(script_runner, in_fodf, expected_fodf, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
 
     ret = script_runner.run('scil_sh_to_aodf.py',
                             in_fodf, 'out_fodf1.nii.gz',
@@ -88,8 +88,8 @@ def test_asym_basis_output(script_runner, in_fodf, expected_fodf):
                   "fodf_descoteaux07_sub_unified_asym.nii.gz"),
      os.path.join(test_data_root,
                   "fodf_descoteaux07_sub_unified_asym_twice.nii.gz")]])
-def test_asym_input(script_runner, in_fodf, expected_fodf):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_asym_input(script_runner, in_fodf, expected_fodf, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
 
     ret = script_runner.run('scil_sh_to_aodf.py',
                             in_fodf, 'out_fodf1.nii.gz',
@@ -114,8 +114,8 @@ def test_asym_input(script_runner, in_fodf, expected_fodf):
     [os.path.join(test_data_root, 'fodf_descoteaux07_sub.nii.gz'),
      os.path.join(test_data_root,
                   'fodf_descoteaux07_sub_cosine_asym.nii.gz')]])
-def test_cosine_method(script_runner, in_fodf, out_fodf):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_cosine_method(script_runner, in_fodf, out_fodf, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
 
     ret = script_runner.run('scil_sh_to_aodf.py',
                             in_fodf, 'out_fodf1.nii.gz',

--- a/scripts/tests/test_sh_to_rish.py
+++ b/scripts/tests/test_sh_to_rish.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_processing(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_sh = os.path.join(SCILPY_HOME, 'processing',
                           'sh.nii.gz')
     ret = script_runner.run('scil_sh_to_rish.py', in_sh, 'rish.nii.gz')

--- a/scripts/tests/test_sh_to_sf.py
+++ b/scripts/tests/test_sh_to_sf.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_in_sphere(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_in_sphere(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_sh = os.path.join(SCILPY_HOME, 'processing', 'sh_1000.nii.gz')
     in_b0 = os.path.join(SCILPY_HOME, 'processing', 'fa.nii.gz')
     in_bval = os.path.join(SCILPY_HOME, 'processing', '1000.bval')
@@ -32,8 +32,8 @@ def test_execution_in_sphere(script_runner):
     assert ret.success
 
 
-def test_execution_in_bvec(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_in_bvec(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_sh = os.path.join(SCILPY_HOME, 'processing', 'sh_1000.nii.gz')
     in_bval = os.path.join(SCILPY_HOME, 'processing', '1000.bval')
     in_bvec = os.path.join(SCILPY_HOME, 'processing', '1000.bvec')
@@ -54,8 +54,8 @@ def test_execution_in_bvec(script_runner):
     assert not ret.success
 
 
-def test_execution_no_bval(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_no_bval(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_sh = os.path.join(SCILPY_HOME, 'processing', 'sh_1000.nii.gz')
     in_b0 = os.path.join(SCILPY_HOME, 'processing', 'fa.nii.gz')
 

--- a/scripts/tests/test_stats_group_comparison.py
+++ b/scripts/tests/test_stats_group_comparison.py
@@ -19,10 +19,11 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_bundles(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_bundles(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_json = os.path.join(SCILPY_HOME, 'stats/group', 'participants.tsv')
-    in_participants = os.path.join(SCILPY_HOME, 'stats/group', 'meanstd_all.json')
+    in_participants = os.path.join(SCILPY_HOME, 'stats/group',
+                                   'meanstd_all.json')
 
     ret = script_runner.run('scil_stats_group_comparison.py',
                             in_participants, in_json, 'Group',

--- a/scripts/tests/test_surface_apply_transform.py
+++ b/scripts/tests/test_surface_apply_transform.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_surface_vtk_fib(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_surface_vtk_fib(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_surf = os.path.join(SCILPY_HOME, 'surface_vtk_fib',
                            'lhpialt.vtk')
     in_aff = os.path.join(SCILPY_HOME, 'surface_vtk_fib',

--- a/scripts/tests/test_surface_convert.py
+++ b/scripts/tests/test_surface_convert.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_surface_vtk_fib(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_surface_vtk_fib(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_surf = os.path.join(SCILPY_HOME, 'surface_vtk_fib',
                            'lhpialt.vtk')
     ret = script_runner.run('scil_surface_convert.py', in_surf,
@@ -26,8 +26,8 @@ def test_execution_surface_vtk_fib(script_runner):
     assert ret.success
 
 
-def test_execution_surface_vtk_xfrom(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_surface_vtk_xfrom(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_surf = os.path.join(SCILPY_HOME, 'surface_vtk_fib',
                            'lh.pialt_xform')
     x_form = os.path.join(SCILPY_HOME, 'surface_vtk_fib',

--- a/scripts/tests/test_surface_flip.py
+++ b/scripts/tests/test_surface_flip.py
@@ -20,7 +20,7 @@ def test_help_option(script_runner):
 def test_execution_surface_vtk_fib(script_runner):
     # Weird behavior, flip around the origin in RASMM rather than the center of
     # the volume in VOX
-    os.chdir(os.path.expanduser(tmp_dir.name))
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_surf = os.path.join(SCILPY_HOME, 'surface_vtk_fib',
                            'lhpialt.vtk')
     ret = script_runner.run('scil_surface_flip.py', in_surf, 'rhpialt.vtk',

--- a/scripts/tests/test_surface_flip.py
+++ b/scripts/tests/test_surface_flip.py
@@ -17,7 +17,7 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_surface_vtk_fib(script_runner):
+def test_execution_surface_vtk_fib(script_runner, monkeypatch):
     # Weird behavior, flip around the origin in RASMM rather than the center of
     # the volume in VOX
     monkeypatch.chdir(os.path.expanduser(tmp_dir.name))

--- a/scripts/tests/test_surface_smooth.py
+++ b/scripts/tests/test_surface_smooth.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_surface_vtk_fib(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_surface_vtk_fib(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_surf = os.path.join(SCILPY_HOME, 'surface_vtk_fib',
                            'lhpialt.vtk')
     ret = script_runner.run('scil_surface_smooth.py', in_surf,

--- a/scripts/tests/test_tracking_local.py
+++ b/scripts/tests/test_tracking_local.py
@@ -21,7 +21,7 @@ def test_execution_tracking_fodf_prob(script_runner):
     # Our tests use -nt 100.
     # Our testing seeding mask has 125 286 voxels, this would be long.
     # Only testing option npv in our first gpu test, below
-    os.chdir(os.path.expanduser(tmp_dir.name))
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_fodf = os.path.join(SCILPY_HOME, 'tracking', 'fodf.nii.gz')
     in_mask = os.path.join(SCILPY_HOME, 'tracking', 'seeding_mask.nii.gz')
 
@@ -32,8 +32,8 @@ def test_execution_tracking_fodf_prob(script_runner):
     assert ret.success
 
 
-def test_execution_tracking_fodf_det(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_tracking_fodf_det(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_fodf = os.path.join(SCILPY_HOME, 'tracking', 'fodf.nii.gz')
     in_mask = os.path.join(SCILPY_HOME, 'tracking', 'seeding_mask.nii.gz')
 
@@ -45,8 +45,8 @@ def test_execution_tracking_fodf_det(script_runner):
     assert ret.success
 
 
-def test_execution_tracking_ptt(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_tracking_ptt(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_fodf = os.path.join(SCILPY_HOME, 'tracking', 'fodf.nii.gz')
     in_mask = os.path.join(SCILPY_HOME, 'tracking', 'seeding_mask.nii.gz')
 
@@ -58,8 +58,8 @@ def test_execution_tracking_ptt(script_runner):
     assert ret.success
 
 
-def test_execution_sphere_subdivide(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_sphere_subdivide(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_fodf = os.path.join(SCILPY_HOME, 'tracking', 'fodf.nii.gz')
     in_mask = os.path.join(SCILPY_HOME, 'tracking', 'seeding_mask.nii.gz')
 
@@ -72,8 +72,8 @@ def test_execution_sphere_subdivide(script_runner):
     assert ret.success
 
 
-def test_execution_sphere_gpu(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_sphere_gpu(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_fodf = os.path.join(SCILPY_HOME, 'tracking', 'fodf.nii.gz')
     in_mask = os.path.join(SCILPY_HOME, 'tracking', 'seeding_mask.nii.gz')
 
@@ -85,8 +85,8 @@ def test_execution_sphere_gpu(script_runner):
     assert not ret.success
 
 
-def test_sh_interp_without_gpu(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_sh_interp_without_gpu(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_fodf = os.path.join(SCILPY_HOME, 'tracking', 'fodf.nii.gz')
     in_mask = os.path.join(SCILPY_HOME, 'tracking', 'seeding_mask.nii.gz')
 
@@ -97,8 +97,8 @@ def test_sh_interp_without_gpu(script_runner):
     assert not ret.success
 
 
-def test_forward_without_gpu(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_forward_without_gpu(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_fodf = os.path.join(SCILPY_HOME, 'tracking', 'fodf.nii.gz')
     in_mask = os.path.join(SCILPY_HOME, 'tracking', 'seeding_mask.nii.gz')
 
@@ -109,8 +109,8 @@ def test_forward_without_gpu(script_runner):
     assert not ret.success
 
 
-def test_batch_size_without_gpu(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_batch_size_without_gpu(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_fodf = os.path.join(SCILPY_HOME, 'tracking', 'fodf.nii.gz')
     in_mask = os.path.join(SCILPY_HOME, 'tracking', 'seeding_mask.nii.gz')
 
@@ -121,8 +121,8 @@ def test_batch_size_without_gpu(script_runner):
     assert not ret.success
 
 
-def test_algo_with_gpu(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_algo_with_gpu(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_fodf = os.path.join(SCILPY_HOME, 'tracking', 'fodf.nii.gz')
     in_mask = os.path.join(SCILPY_HOME, 'tracking', 'seeding_mask.nii.gz')
 
@@ -133,8 +133,8 @@ def test_algo_with_gpu(script_runner):
     assert not ret.success
 
 
-def test_execution_tracking_fodf_no_compression(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_tracking_fodf_no_compression(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_fodf = os.path.join(SCILPY_HOME, 'tracking', 'fodf.nii.gz')
     in_mask = os.path.join(SCILPY_HOME, 'tracking', 'seeding_mask.nii.gz')
 
@@ -146,8 +146,8 @@ def test_execution_tracking_fodf_no_compression(script_runner):
     assert ret.success
 
 
-def test_execution_tracking_peaks(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_tracking_peaks(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_peaks = os.path.join(SCILPY_HOME, 'tracking', 'peaks.nii.gz')
     in_mask = os.path.join(SCILPY_HOME, 'tracking', 'seeding_mask.nii.gz')
     ret = script_runner.run('scil_tracking_local.py', in_peaks,
@@ -158,8 +158,8 @@ def test_execution_tracking_peaks(script_runner):
     assert ret.success
 
 
-def test_execution_tracking_fodf_prob_pmf_mapping(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_tracking_fodf_prob_pmf_mapping(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_fodf = os.path.join(SCILPY_HOME, 'tracking', 'fodf.nii.gz')
     in_mask = os.path.join(SCILPY_HOME, 'tracking', 'seeding_mask.nii.gz')
 

--- a/scripts/tests/test_tracking_local.py
+++ b/scripts/tests/test_tracking_local.py
@@ -17,7 +17,7 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_tracking_fodf_prob(script_runner):
+def test_execution_tracking_fodf_prob(script_runner, monkeypatch):
     # Our tests use -nt 100.
     # Our testing seeding mask has 125 286 voxels, this would be long.
     # Only testing option npv in our first gpu test, below

--- a/scripts/tests/test_tracking_local_dev.py
+++ b/scripts/tests/test_tracking_local_dev.py
@@ -18,8 +18,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_tracking_fodf(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_tracking_fodf(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_fodf = os.path.join(SCILPY_HOME, 'tracking',
                            'fodf.nii.gz')
     in_mask = os.path.join(SCILPY_HOME, 'tracking',

--- a/scripts/tests/test_tracking_pft.py
+++ b/scripts/tests/test_tracking_pft.py
@@ -18,8 +18,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_tracking(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_tracking(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_fodf = os.path.join(SCILPY_HOME, 'tracking',
                            'fodf.nii.gz')
     in_interface = os.path.join(SCILPY_HOME, 'tracking',

--- a/scripts/tests/test_tracking_pft_maps.py
+++ b/scripts/tests/test_tracking_pft_maps.py
@@ -18,8 +18,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_tracking(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_tracking(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_wm = os.path.join(SCILPY_HOME, 'tracking',
                          'map_wm.nii.gz')
     in_gm = os.path.join(SCILPY_HOME, 'tracking',

--- a/scripts/tests/test_tracking_pft_maps_edit.py
+++ b/scripts/tests/test_tracking_pft_maps_edit.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_tracking(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_tracking(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_include = os.path.join(SCILPY_HOME, 'tracking',
                               'map_include.nii.gz')
     in_exclude = os.path.join(SCILPY_HOME, 'tracking',

--- a/scripts/tests/test_tractogram_apply_transform.py
+++ b/scripts/tests/test_tractogram_apply_transform.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_inverse(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_inverse(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_model = os.path.join(SCILPY_HOME, 'bst', 'template', 'rpt_m.trk')
     in_fa = os.path.join(SCILPY_HOME, 'bst', 'fa.nii.gz')
     in_aff = os.path.join(SCILPY_HOME, 'bst', 'output0GenericAffine.mat')

--- a/scripts/tests/test_tractogram_apply_transform_to_hdf5.py
+++ b/scripts/tests/test_tractogram_apply_transform_to_hdf5.py
@@ -18,8 +18,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_connectivity(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_connectivity(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_h5 = os.path.join(SCILPY_HOME, 'connectivity', 'decompose.h5')
     in_target = os.path.join(SCILPY_HOME, 'connectivity',
                              'endpoints_atlas.nii.gz')

--- a/scripts/tests/test_tractogram_assign_custom_color.py
+++ b/scripts/tests/test_tractogram_assign_custom_color.py
@@ -23,8 +23,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_from_anat(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_from_anat(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_anat = os.path.join(SCILPY_HOME, 'tractometry',
                            'IFGWM_labels_map.nii.gz')
 
@@ -34,16 +34,16 @@ def test_execution_from_anat(script_runner):
     assert ret.success
 
 
-def test_execution_along_profile(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_along_profile(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
 
     ret = script_runner.run('scil_tractogram_assign_custom_color.py',
                             in_bundle, 'colored2.trk', '--along_profile')
     assert ret.success
 
 
-def test_execution_from_angle(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_from_angle(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
 
     ret = script_runner.run('scil_tractogram_assign_custom_color.py',
                             in_bundle, 'colored3.trk', '--local_angle')

--- a/scripts/tests/test_tractogram_assign_uniform_color.py
+++ b/scripts/tests/test_tractogram_assign_uniform_color.py
@@ -20,8 +20,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_fill(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_fill(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
 
     ret = script_runner.run('scil_tractogram_assign_uniform_color.py',
                             in_bundle, '--fill_color', '0x000000',
@@ -29,8 +29,8 @@ def test_execution_fill(script_runner):
     assert ret.success
 
 
-def test_execution_dict(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_dict(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
 
     # Create a fake dictionary. Using the other hexadecimal format.
     my_dict = {'IFGWM': '#000000'}

--- a/scripts/tests/test_tractogram_commit.py
+++ b/scripts/tests/test_tractogram_commit.py
@@ -19,8 +19,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_commit_amico(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_commit_amico(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_tracking = os.path.join(SCILPY_HOME, 'commit_amico',
                                'tracking.trk')
     in_dwi = os.path.join(SCILPY_HOME, 'commit_amico',
@@ -39,7 +39,8 @@ def test_execution_commit_amico(script_runner):
                             '--nbr_iter', '500', '--in_peaks', in_peaks,
                             '--in_tracking_mask', in_mask,
                             '--para_diff', '1.7E-3',
-                            '--perp_diff', '1.19E-3', '0.85E-3', '0.51E-3', '0.17E-3',
+                            '--perp_diff',
+                            '1.19E-3', '0.85E-3', '0.51E-3', '0.17E-3',
                             '--iso_diff', '1.7E-3', '3.0E-3',
                             '--processes', '1')
     assert ret.success

--- a/scripts/tests/test_tractogram_compress.py
+++ b/scripts/tests/test_tractogram_compress.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_surface_vtk_fib(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_surface_vtk_fib(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_fib = os.path.join(SCILPY_HOME, 'surface_vtk_fib',
                           'gyri_fanning.trk')
     ret = script_runner.run('scil_tractogram_compress.py', in_fib,

--- a/scripts/tests/test_tractogram_compute_TODI.py
+++ b/scripts/tests/test_tractogram_compute_TODI.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_bst(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_bst(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_bundle = os.path.join(SCILPY_HOME, 'bst', 'rpt_m_warp.trk')
     in_mask = os.path.join(SCILPY_HOME, 'bst', 'mask.nii.gz')
     ret = script_runner.run('scil_tractogram_compute_TODI.py', in_bundle,
@@ -32,8 +32,8 @@ def test_execution_bst(script_runner):
     assert ret.success
 
 
-def test_execution_asym(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_asym(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_bundle = os.path.join(SCILPY_HOME, 'bst', 'rpt_m_warp.trk')
     ret = script_runner.run('scil_tractogram_compute_TODI.py', in_bundle,
                             '--out_todi_sh', 'atodi_sh_8.nii.gz',

--- a/scripts/tests/test_tractogram_compute_density_map.py
+++ b/scripts/tests/test_tractogram_compute_density_map.py
@@ -18,16 +18,16 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_others(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_others(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_bundle = os.path.join(SCILPY_HOME, 'others', 'IFGWM.trk')
     ret = script_runner.run('scil_tractogram_compute_density_map.py',
                             in_bundle, 'binary.nii.gz', '--binary')
     assert ret.success
 
 
-def test_execution_tractometry(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_tractometry(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_bundle = os.path.join(SCILPY_HOME, 'tractometry', 'IFGWM.trk')
     ret = script_runner.run('scil_tractogram_compute_density_map.py',
                             in_bundle, 'IFGWM.nii.gz', '--binary')

--- a/scripts/tests/test_tractogram_convert.py
+++ b/scripts/tests/test_tractogram_convert.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_surface_vtk_fib(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_surface_vtk_fib(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_fib = os.path.join(SCILPY_HOME, 'surface_vtk_fib',
                           'gyri_fanning.fib')
     in_fa = os.path.join(SCILPY_HOME, 'surface_vtk_fib',

--- a/scripts/tests/test_tractogram_convert_hdf5_to_trk.py
+++ b/scripts/tests/test_tractogram_convert_hdf5_to_trk.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_connectivity(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_connectivity(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_h5 = os.path.join(SCILPY_HOME, 'connectivity', 'decompose.h5')
     ret = script_runner.run('scil_tractogram_convert_hdf5_to_trk.py',
                             in_h5, 'save_trk/')

--- a/scripts/tests/test_tractogram_count_streamlines.py
+++ b/scripts/tests/test_tractogram_count_streamlines.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_others(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_others(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_bundle = os.path.join(SCILPY_HOME, 'others',
                              'IFGWM_sub.trk')
     ret = script_runner.run('scil_tractogram_count_streamlines.py', in_bundle)

--- a/scripts/tests/test_tractogram_cut_streamlines.py
+++ b/scripts/tests/test_tractogram_cut_streamlines.py
@@ -18,8 +18,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_two_roi(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_two_roi(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_tractogram = os.path.join(SCILPY_HOME, 'filtering',
                                  'bundle_all_1mm.trk')
     in_mask = os.path.join(SCILPY_HOME, 'filtering', 'mask.nii.gz')
@@ -29,8 +29,8 @@ def test_execution_two_roi(script_runner):
     assert ret.success
 
 
-def test_execution_biggest(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_biggest(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_tractogram = os.path.join(SCILPY_HOME, 'filtering',
                                  'bundle_all_1mm.trk')
     in_mask = os.path.join(SCILPY_HOME, 'filtering', 'mask.nii.gz')

--- a/scripts/tests/test_tractogram_detect_loops.py
+++ b/scripts/tests/test_tractogram_detect_loops.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_filtering(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_filtering(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_bundle = os.path.join(SCILPY_HOME, 'filtering',
                              'bundle_4_filtered.trk')
     ret = script_runner.run('scil_tractogram_detect_loops.py',

--- a/scripts/tests/test_tractogram_dpp_math.py
+++ b/scripts/tests/test_tractogram_dpp_math.py
@@ -18,8 +18,9 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_tractogram_point_math_mean_3D_defaults(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_tractogram_point_math_mean_3D_defaults(script_runner,
+                                                          monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_bundle = os.path.join(SCILPY_HOME, 'tractometry',
                              'IFGWM_uni.trk')
     in_t1 = os.path.join(SCILPY_HOME, 'tractometry',
@@ -43,8 +44,9 @@ def test_execution_tractogram_point_math_mean_3D_defaults(script_runner):
     assert ret.success
 
 
-def test_execution_tractogram_point_math_mean_4D_correlation(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_tractogram_point_math_mean_4D_correlation(script_runner,
+                                                             monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_bundle = os.path.join(SCILPY_HOME, 'tracking',
                              'local_split_0.trk')
 

--- a/scripts/tests/test_tractogram_extract_ushape.py
+++ b/scripts/tests/test_tractogram_extract_ushape.py
@@ -18,12 +18,13 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_processing(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_trk = os.path.join(SCILPY_HOME, 'tracking', 'union.trk')
     out_trk = 'ushape.trk'
     remaining_trk = 'remaining.trk'
-    ret = script_runner.run('scil_tractogram_extract_ushape.py', in_trk, out_trk,
+    ret = script_runner.run('scil_tractogram_extract_ushape.py',
+                            in_trk, out_trk,
                             '--minU', '0.5',
                             '--maxU', '1',
                             '--remaining_tractogram', remaining_trk,

--- a/scripts/tests/test_tractogram_filter_by_anatomy.py
+++ b/scripts/tests/test_tractogram_filter_by_anatomy.py
@@ -18,8 +18,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_filtering_all_options(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_filtering_all_options(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_tractogram = os.path.join(SCILPY_HOME, 'anatomical_filtering',
                                  'tractogram_filter_ana.trk')
     in_wmparc = os.path.join(SCILPY_HOME, 'anatomical_filtering',
@@ -37,8 +37,8 @@ def test_execution_filtering_all_options(script_runner):
     assert ret.success
 
 
-def test_execution_filtering_rejected(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_filtering_rejected(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_tractogram = os.path.join(SCILPY_HOME, 'anatomical_filtering',
                                  'tractogram_filter_ana.trk')
     in_wmparc = os.path.join(SCILPY_HOME, 'anatomical_filtering',
@@ -55,8 +55,8 @@ def test_execution_filtering_rejected(script_runner):
     assert ret.success
 
 
-def test_execution_filtering_save_intermediate(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_filtering_save_intermediate(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_tractogram = os.path.join(SCILPY_HOME, 'anatomical_filtering',
                                  'tractogram_filter_ana.trk')
     in_wmparc = os.path.join(SCILPY_HOME, 'anatomical_filtering',

--- a/scripts/tests/test_tractogram_filter_by_length.py
+++ b/scripts/tests/test_tractogram_filter_by_length.py
@@ -18,8 +18,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_filtering(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_filtering(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_bundle = os.path.join(SCILPY_HOME, 'filtering',
                              'bundle_4.trk')
     ret = script_runner.run('scil_tractogram_filter_by_length.py',

--- a/scripts/tests/test_tractogram_filter_by_orientation.py
+++ b/scripts/tests/test_tractogram_filter_by_orientation.py
@@ -18,8 +18,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_filtering(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_filtering(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_bundle = os.path.join(SCILPY_HOME, 'filtering',
                              'bundle_4.trk')
     ret = script_runner.run('scil_tractogram_filter_by_orientation.py',

--- a/scripts/tests/test_tractogram_filter_by_roi.py
+++ b/scripts/tests/test_tractogram_filter_by_roi.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_filtering(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_filtering(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_tractogram = os.path.join(SCILPY_HOME, 'filtering',
                                  'bundle_all_1mm_inliers.trk')
     in_roi = os.path.join(SCILPY_HOME, 'filtering',
@@ -33,8 +33,8 @@ def test_execution_filtering(script_runner):
     assert ret.success
 
 
-def test_execution_filtering_distance(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_filtering_distance(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_tractogram = os.path.join(SCILPY_HOME, 'filtering',
                                  'bundle_all_1mm_inliers.trk')
     in_roi = os.path.join(SCILPY_HOME, 'filtering',

--- a/scripts/tests/test_tractogram_flip.py
+++ b/scripts/tests/test_tractogram_flip.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_surface_vtk_fib(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_surface_vtk_fib(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_fib = os.path.join(SCILPY_HOME, 'surface_vtk_fib',
                           'gyri_fanning.fib')
     in_fa = os.path.join(SCILPY_HOME, 'surface_vtk_fib',

--- a/scripts/tests/test_tractogram_math.py
+++ b/scripts/tests/test_tractogram_math.py
@@ -18,8 +18,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_lazy_concatenate_no_color(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_lazy_concatenate_no_color(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_tracto_1 = os.path.join(trk_path, 'fibercup_bundles.trk')
     in_tracto_2 = os.path.join(trk_path, 'fibercup_bundle_0.trk')
     ret = script_runner.run('scil_tractogram_math.py', 'lazy_concatenate',
@@ -28,8 +28,8 @@ def test_execution_lazy_concatenate_no_color(script_runner):
     assert ret.success
 
 
-def test_execution_lazy_concatenate_mix(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_lazy_concatenate_mix(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_tracto_1 = os.path.join(trk_path, 'fibercup_bundles_color.trk')
     in_tracto_2 = os.path.join(trk_path, 'fibercup_bundle_0.trk')
     ret = script_runner.run('scil_tractogram_math.py', 'lazy_concatenate',
@@ -38,8 +38,8 @@ def test_execution_lazy_concatenate_mix(script_runner):
     assert ret.success
 
 
-def test_execution_union_no_color(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_union_no_color(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_tracto_1 = os.path.join(trk_path, 'fibercup_bundles.trk')
     in_tracto_2 = os.path.join(trk_path, 'fibercup_bundle_0.trk')
     ret = script_runner.run('scil_tractogram_math.py', 'union',
@@ -47,8 +47,8 @@ def test_execution_union_no_color(script_runner):
     assert ret.success
 
 
-def test_execution_intersection_no_color(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_intersection_no_color(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_tracto_1 = os.path.join(trk_path, 'fibercup_bundles.trk')
     in_tracto_2 = os.path.join(trk_path, 'fibercup_bundle_0.trk')
     ret = script_runner.run('scil_tractogram_math.py', 'intersection',
@@ -56,8 +56,8 @@ def test_execution_intersection_no_color(script_runner):
     assert ret.success
 
 
-def test_execution_difference_no_color(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_difference_no_color(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_tracto_1 = os.path.join(trk_path, 'fibercup_bundles.trk')
     in_tracto_2 = os.path.join(trk_path, 'fibercup_bundle_0.trk')
     ret = script_runner.run('scil_tractogram_math.py', 'difference',
@@ -65,8 +65,8 @@ def test_execution_difference_no_color(script_runner):
     assert ret.success
 
 
-def test_execution_concatenate_no_color(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_concatenate_no_color(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_tracto_1 = os.path.join(trk_path, 'fibercup_bundles.trk')
     in_tracto_2 = os.path.join(trk_path, 'fibercup_bundle_0.trk')
     ret = script_runner.run('scil_tractogram_math.py', 'concatenate',
@@ -74,8 +74,8 @@ def test_execution_concatenate_no_color(script_runner):
     assert ret.success
 
 
-def test_execution_union_no_color_robust(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_union_no_color_robust(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_tracto_1 = os.path.join(trk_path, 'fibercup_bundles.trk')
     in_tracto_2 = os.path.join(trk_path, 'fibercup_bundle_0.trk')
     ret = script_runner.run('scil_tractogram_math.py', 'union',
@@ -84,8 +84,8 @@ def test_execution_union_no_color_robust(script_runner):
     assert ret.success
 
 
-def test_execution_intersection_no_color_robust(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_intersection_no_color_robust(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_tracto_1 = os.path.join(trk_path, 'fibercup_bundles.trk')
     in_tracto_2 = os.path.join(trk_path, 'fibercup_bundle_0.trk')
     ret = script_runner.run('scil_tractogram_math.py', 'intersection',
@@ -94,8 +94,8 @@ def test_execution_intersection_no_color_robust(script_runner):
     assert ret.success
 
 
-def test_execution_difference_no_color_robust(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_difference_no_color_robust(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_tracto_1 = os.path.join(trk_path, 'fibercup_bundles.trk')
     in_tracto_2 = os.path.join(trk_path, 'fibercup_bundle_0.trk')
     ret = script_runner.run('scil_tractogram_math.py', 'difference',
@@ -104,8 +104,8 @@ def test_execution_difference_no_color_robust(script_runner):
     assert ret.success
 
 
-def test_execution_union_color(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_union_color(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_tracto_1 = os.path.join(trk_path, 'fibercup_bundles_color.trk')
     in_tracto_2 = os.path.join(trk_path, 'fibercup_bundle_0_color.trk')
     ret = script_runner.run('scil_tractogram_math.py', 'union',
@@ -113,8 +113,8 @@ def test_execution_union_color(script_runner):
     assert ret.success
 
 
-def test_execution_intersection_color(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_intersection_color(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_tracto_1 = os.path.join(trk_path, 'fibercup_bundles_color.trk')
     in_tracto_2 = os.path.join(trk_path, 'fibercup_bundle_0_color.trk')
     ret = script_runner.run('scil_tractogram_math.py', 'intersection',
@@ -122,8 +122,8 @@ def test_execution_intersection_color(script_runner):
     assert ret.success
 
 
-def test_execution_difference_color(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_difference_color(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_tracto_1 = os.path.join(trk_path, 'fibercup_bundles_color.trk')
     in_tracto_2 = os.path.join(trk_path, 'fibercup_bundle_0_color.trk')
     ret = script_runner.run('scil_tractogram_math.py', 'difference',
@@ -131,8 +131,8 @@ def test_execution_difference_color(script_runner):
     assert ret.success
 
 
-def test_execution_concatenate_color(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_concatenate_color(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_tracto_1 = os.path.join(trk_path, 'fibercup_bundles_color.trk')
     in_tracto_2 = os.path.join(trk_path, 'fibercup_bundle_0_color.trk')
     ret = script_runner.run('scil_tractogram_math.py', 'concatenate',
@@ -140,9 +140,9 @@ def test_execution_concatenate_color(script_runner):
     assert ret.success
 
 
-def test_execution_union_mix(script_runner):
+def test_execution_union_mix(script_runner, monkeypatch):
     # This is intentionally failing
-    os.chdir(os.path.expanduser(tmp_dir.name))
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_tracto_1 = os.path.join(trk_path, 'fibercup_bundles_color.trk')
     in_tracto_2 = os.path.join(trk_path, 'fibercup_bundle_0.trk')
     ret = script_runner.run('scil_tractogram_math.py', 'union',
@@ -150,8 +150,8 @@ def test_execution_union_mix(script_runner):
     assert not ret.success
 
 
-def test_execution_intersection_mix_fake(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_intersection_mix_fake(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_tracto_1 = os.path.join(trk_path, 'fibercup_bundles_color.trk')
     in_tracto_2 = os.path.join(trk_path, 'fibercup_bundle_0.trk')
     ret = script_runner.run('scil_tractogram_math.py', 'intersection',
@@ -160,8 +160,8 @@ def test_execution_intersection_mix_fake(script_runner):
     assert ret.success
 
 
-def test_execution_difference_empty_result(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_difference_empty_result(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_tracto_1 = os.path.join(trk_path, 'fibercup_bundle_0.trk')
     in_tracto_2 = os.path.join(trk_path, 'fibercup_bundle_0_color.trk')
     ret = script_runner.run('scil_tractogram_math.py', 'difference',
@@ -170,8 +170,8 @@ def test_execution_difference_empty_result(script_runner):
     assert ret.success
 
 
-def test_execution_difference_empty_input_1(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_difference_empty_input_1(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_tracto_1 = os.path.join(trk_path, 'empty.trk')
     in_tracto_2 = os.path.join(trk_path, 'fibercup_bundle_0_color.trk')
     ret = script_runner.run('scil_tractogram_math.py', 'difference',
@@ -180,8 +180,8 @@ def test_execution_difference_empty_input_1(script_runner):
     assert ret.success
 
 
-def test_execution_difference_empty_input_2(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_difference_empty_input_2(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_tracto_1 = os.path.join(trk_path, 'fibercup_bundle_0_color.trk')
     in_tracto_2 = os.path.join(trk_path, 'empty.trk')
     ret = script_runner.run('scil_tractogram_math.py', 'difference',

--- a/scripts/tests/test_tractogram_pairwise_comparison.py
+++ b/scripts/tests/test_tractogram_pairwise_comparison.py
@@ -19,8 +19,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_bundles_skip(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_bundles_skip(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_1 = os.path.join(SCILPY_HOME, 'bundles', 'bundle_0_reco.tck')
     in_2 = os.path.join(SCILPY_HOME, 'bundles', 'voting_results',
                         'bundle_0.trk')
@@ -30,8 +30,8 @@ def test_execution_bundles_skip(script_runner):
         '--skip_streamlines_distance')
     assert ret.success
 
-def test_execution_bundles(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_bundles(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_1 = os.path.join(SCILPY_HOME, 'bundles', 'bundle_0_reco.tck')
     in_2 = os.path.join(SCILPY_HOME, 'bundles', 'voting_results',
                         'bundle_0.trk')

--- a/scripts/tests/test_tractogram_print_info.py
+++ b/scripts/tests/test_tractogram_print_info.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_filtering(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_filtering(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_bundle = os.path.join(SCILPY_HOME, 'filtering', 'bundle_4.trk')
     ret = script_runner.run('scil_tractogram_print_info.py', in_bundle)
     assert ret.success

--- a/scripts/tests/test_tractogram_project_map_to_streamlines.py
+++ b/scripts/tests/test_tractogram_project_map_to_streamlines.py
@@ -18,8 +18,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_3D_map(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_3D_map(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_t1 = os.path.join(SCILPY_HOME, 'tractometry', 'mni_masked.nii.gz')
     in_tracto_1 = os.path.join(SCILPY_HOME, 'others',
                                'IFGWM_sub.trk')
@@ -31,8 +31,8 @@ def test_execution_3D_map(script_runner):
     assert ret.success
 
 
-def test_execution_4D_map(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_4D_map(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_rgb = os.path.join(SCILPY_HOME, 'others', 'rgb.nii.gz')
     in_tracto_1 = os.path.join(SCILPY_HOME, 'others',
                                'IFGWM_sub.trk')
@@ -44,8 +44,8 @@ def test_execution_4D_map(script_runner):
     assert ret.success
 
 
-def test_execution_3D_map_endpoints_only(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_3D_map_endpoints_only(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_t1 = os.path.join(SCILPY_HOME, 'tractometry', 'mni_masked.nii.gz')
     in_tracto_1 = os.path.join(SCILPY_HOME, 'others',
                                'IFGWM_sub.trk')
@@ -59,8 +59,8 @@ def test_execution_3D_map_endpoints_only(script_runner):
     assert ret.success
 
 
-def test_execution_4D_map_endpoints_only(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_4D_map_endpoints_only(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_rgb = os.path.join(SCILPY_HOME, 'others', 'rgb.nii.gz')
     in_tracto_1 = os.path.join(SCILPY_HOME, 'others',
                                'IFGWM_sub.trk')
@@ -74,8 +74,8 @@ def test_execution_4D_map_endpoints_only(script_runner):
     assert ret.success
 
 
-def test_execution_3D_map_trilinear(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_3D_map_trilinear(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_t1 = os.path.join(SCILPY_HOME, 'tractometry', 'mni_masked.nii.gz')
     in_tracto_1 = os.path.join(SCILPY_HOME, 'others',
                                'IFGWM_sub.trk')

--- a/scripts/tests/test_tractogram_project_streamlines_to_map.py
+++ b/scripts/tests/test_tractogram_project_streamlines_to_map.py
@@ -18,8 +18,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_dpp(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_dpp(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_bundle = os.path.join(SCILPY_HOME, 'tractometry', 'IFGWM_uni.trk')
     in_mni = os.path.join(SCILPY_HOME, 'tractometry', 'mni_masked.nii.gz')
     in_bundle_with_dpp = 'IFGWM_uni_with_dpp.trk'
@@ -50,8 +50,8 @@ def test_execution_dpp(script_runner):
     assert ret.success
 
 
-def test_execution_dps(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_dps(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_bundle = os.path.join(SCILPY_HOME, 'tractometry', 'IFGWM_uni.trk')
     in_mni = os.path.join(SCILPY_HOME, 'tractometry', 'mni_masked.nii.gz')
     in_bundle_with_dpp = 'IFGWM_uni_with_dpp.trk'

--- a/scripts/tests/test_tractogram_qbx.py
+++ b/scripts/tests/test_tractogram_qbx.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_filtering(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_filtering(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_bundle = os.path.join(SCILPY_HOME, 'filtering',
                              'bundle_all_1mm.trk')
     ret = script_runner.run('scil_tractogram_qbx.py', in_bundle, '12',

--- a/scripts/tests/test_tractogram_register.py
+++ b/scripts/tests/test_tractogram_register.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_bundles(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_bundles(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_moving = os.path.join(SCILPY_HOME, 'bundles',
                              'bundle_0_reco.tck')
     in_static = os.path.join(SCILPY_HOME, 'bundles', 'voting_results',

--- a/scripts/tests/test_tractogram_remove_invalid.py
+++ b/scripts/tests/test_tractogram_remove_invalid.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_bundles(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_bundles(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_tractogram = os.path.join(SCILPY_HOME, 'bundles',
                                  'bundle_all_1mm.trk')
     ret = script_runner.run('scil_tractogram_remove_invalid.py',

--- a/scripts/tests/test_tractogram_resample.py
+++ b/scripts/tests/test_tractogram_resample.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_downsample(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_downsample(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_tracto = os.path.join(SCILPY_HOME, 'tracking',
                              'union_shuffle_sub.trk')
     ret = script_runner.run('scil_tractogram_resample.py', in_tracto,
@@ -26,8 +26,8 @@ def test_execution_downsample(script_runner):
     assert ret.success
 
 
-def test_execution_upsample(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_upsample(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_tracto = os.path.join(SCILPY_HOME, 'tracking',
                              'union_shuffle_sub.trk')
 
@@ -50,8 +50,8 @@ def test_execution_upsample(script_runner):
     assert ret.success
 
 
-def test_execution_upsample_ptt(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_upsample_ptt(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_tracto = os.path.join(SCILPY_HOME, 'tracking',
                              'union_shuffle_sub.trk')
 

--- a/scripts/tests/test_tractogram_resample_nb_points.py
+++ b/scripts/tests/test_tractogram_resample_nb_points.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_tractometry(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_tractometry(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_bundle = os.path.join(SCILPY_HOME, 'tractometry',
                              'IFGWM_uni_c.trk')
     ret = script_runner.run('scil_tractogram_resample_nb_points.py',

--- a/scripts/tests/test_tractogram_seed_density_map.py
+++ b/scripts/tests/test_tractogram_seed_density_map.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_processing(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_tracking = os.path.join(SCILPY_HOME, 'processing', 'tracking.trk')
     ret = script_runner.run('scil_tractogram_seed_density_map.py', in_tracking,
                             'seeds_density.nii.gz')

--- a/scripts/tests/test_tractogram_segment_and_score.py
+++ b/scripts/tests/test_tractogram_segment_and_score.py
@@ -15,8 +15,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_score_bundles(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_score_bundles(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_tractogram = os.path.join(SCILPY_HOME, 'tracking', 'pft.trk')
 
     json_contents = {

--- a/scripts/tests/test_tractogram_segment_bundles.py
+++ b/scripts/tests/test_tractogram_segment_bundles.py
@@ -18,12 +18,10 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_bundles(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_bundles(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_tractogram = os.path.join(SCILPY_HOME, 'bundles',
                                  'bundle_all_1mm.trk')
-    in_conf = os.path.join(SCILPY_HOME, 'bundles', 'fibercup_atlas',
-                           'default_config_sim.json')
     in_models = os.path.join(SCILPY_HOME, 'bundles', 'fibercup_atlas')
     in_aff = os.path.join(SCILPY_HOME, 'bundles',
                           'affine.txt')

--- a/scripts/tests/test_tractogram_segment_bundles_for_connectivity.py
+++ b/scripts/tests/test_tractogram_segment_bundles_for_connectivity.py
@@ -18,8 +18,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_connectivity(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_connectivity(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_bundle = os.path.join(SCILPY_HOME, 'connectivity', 'bundle_all_1mm.trk')
     in_atlas = os.path.join(SCILPY_HOME, 'connectivity',
                             'endpoints_atlas.nii.gz')

--- a/scripts/tests/test_tractogram_segment_one_bundles.py
+++ b/scripts/tests/test_tractogram_segment_one_bundles.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_bundles(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_bundles(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_tractogram = os.path.join(SCILPY_HOME, 'bundles',
                                  'bundle_all_1mm.trk')
     in_model = os.path.join(SCILPY_HOME, 'bundles', 'fibercup_atlas',

--- a/scripts/tests/test_tractogram_shuffle.py
+++ b/scripts/tests/test_tractogram_shuffle.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_tracking(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_tracking(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_tracto = os.path.join(SCILPY_HOME, 'tracking', 'union.trk')
     ret = script_runner.run('scil_tractogram_shuffle.py', in_tracto,
                             'union_shuffle.trk')

--- a/scripts/tests/test_tractogram_smooth.py
+++ b/scripts/tests/test_tractogram_smooth.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_tracking(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_tracking(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_tracto = os.path.join(SCILPY_HOME, 'tracking',
                              'union_shuffle_sub.trk')
     ret = script_runner.run('scil_tractogram_smooth.py', in_tracto,

--- a/scripts/tests/test_tractogram_split.py
+++ b/scripts/tests/test_tractogram_split.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_tracking(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_tracking(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_tracto = os.path.join(SCILPY_HOME, 'tracking',
                              'local.trk')
     ret = script_runner.run('scil_tractogram_split.py', in_tracto,

--- a/scripts/tests/test_tractogram_uniformize_endpoints.py
+++ b/scripts/tests/test_tractogram_uniformize_endpoints.py
@@ -18,8 +18,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_tractometry(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_tractometry(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_bundle = os.path.join(SCILPY_HOME, 'tractometry',
                              'IFGWM.trk')
     ret = script_runner.run('scil_tractogram_uniformize_endpoints.py',

--- a/scripts/tests/test_visualize_bingham_fit.py
+++ b/scripts/tests/test_visualize_bingham_fit.py
@@ -16,8 +16,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_silent_without_output(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_silent_without_output(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
 
     # dummy dataset (the script should raise an error before using it)
     in_dummy = os.path.join(SCILPY_HOME, 'tracking', 'fodf.nii.gz')

--- a/scripts/tests/test_visualize_bundles_mosaic.py
+++ b/scripts/tests/test_visualize_bundles_mosaic.py
@@ -13,7 +13,7 @@ def test_help_option(script_runner):
 
 # Tests including VTK do not work on a server without a display
 # def test_image_create(script_runner):
-#     os.chdir(os.path.expanduser(tmp_dir.name))
+#     monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
 #     in_vol = os.path.join(
 #         SCILPY_HOME, 'bundles', 'fibercup_atlas', 'bundle_all_1mm.nii.gz')
 

--- a/scripts/tests/test_visualize_connectivity.py
+++ b/scripts/tests/test_visualize_connectivity.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_connectivity(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_connectivity(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_sc = os.path.join(SCILPY_HOME, 'connectivity',
                          'sc_norm.npy')
     in_labels_list = os.path.join(SCILPY_HOME, 'connectivity',

--- a/scripts/tests/test_visualize_fodf.py
+++ b/scripts/tests/test_visualize_fodf.py
@@ -16,8 +16,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_silent_without_output(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_silent_without_output(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_fodf = os.path.join(SCILPY_HOME, 'tracking', 'fodf.nii.gz')
 
     ret = script_runner.run('scil_visualize_fodf.py', in_fodf, '--silent')

--- a/scripts/tests/test_visualize_histogram.py
+++ b/scripts/tests/test_visualize_histogram.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_processing(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_fa = os.path.join(SCILPY_HOME, 'processing',
                          'fa.nii.gz')
     in_mask = os.path.join(SCILPY_HOME, 'processing',

--- a/scripts/tests/test_visualize_scatterplot.py
+++ b/scripts/tests/test_visualize_scatterplot.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_processing(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_x = os.path.join(SCILPY_HOME, 'plot',
                         'fa.nii.gz')
     in_y = os.path.join(SCILPY_HOME, 'plot',
@@ -28,8 +28,8 @@ def test_execution_processing(script_runner):
     assert ret.success
 
 
-def test_execution_processing_bin_mask(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing_bin_mask(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_x = os.path.join(SCILPY_HOME, 'plot',
                         'fa.nii.gz')
     in_y = os.path.join(SCILPY_HOME, 'plot',
@@ -41,8 +41,8 @@ def test_execution_processing_bin_mask(script_runner):
     assert ret.success
 
 
-def test_execution_processing_prob_map(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing_prob_map(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_x = os.path.join(SCILPY_HOME, 'plot',
                         'fa.nii.gz')
     in_y = os.path.join(SCILPY_HOME, 'plot',
@@ -57,8 +57,8 @@ def test_execution_processing_prob_map(script_runner):
     assert ret.success
 
 
-def test_execution_processing_atlas(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing_atlas(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_x = os.path.join(SCILPY_HOME, 'plot',
                         'fa.nii.gz')
     in_y = os.path.join(SCILPY_HOME, 'plot',
@@ -73,8 +73,8 @@ def test_execution_processing_atlas(script_runner):
     assert ret.success
 
 
-def test_execution_processing_atlas_folder(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing_atlas_folder(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_x = os.path.join(SCILPY_HOME, 'plot',
                         'fa.nii.gz')
     in_y = os.path.join(SCILPY_HOME, 'plot',
@@ -90,8 +90,9 @@ def test_execution_processing_atlas_folder(script_runner):
     assert ret.success
 
 
-def test_execution_processing_atlas_folder_specific_label(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing_atlas_folder_specific_label(script_runner,
+                                                          monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_x = os.path.join(SCILPY_HOME, 'plot',
                         'fa.nii.gz')
     in_y = os.path.join(SCILPY_HOME, 'plot',

--- a/scripts/tests/test_volume_apply_transform.py
+++ b/scripts/tests/test_volume_apply_transform.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_bst(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_bst(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_model = os.path.join(SCILPY_HOME, 'bst', 'template',
                             'template0.nii.gz')
     in_fa = os.path.join(SCILPY_HOME, 'bst',

--- a/scripts/tests/test_volume_b0_synthesis.py
+++ b/scripts/tests/test_volume_b0_synthesis.py
@@ -25,8 +25,8 @@ def test_help_option(script_runner):
 
 
 @pytest.mark.skipif(tensorflow is None, reason="Tensorflow not installed")
-def test_synthesis(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_synthesis(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_t1 = os.path.join(SCILPY_HOME, 'others',
                          't1.nii.gz')
     in_b0 = os.path.join(SCILPY_HOME, 'processing',

--- a/scripts/tests/test_volume_count_non_zero_voxels.py
+++ b/scripts/tests/test_volume_count_non_zero_voxels.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_others(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_others(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_img = os.path.join(SCILPY_HOME, 'others',
                           'rgb.nii.gz')
     ret = script_runner.run('scil_volume_count_non_zero_voxels.py', in_img)

--- a/scripts/tests/test_volume_crop.py
+++ b/scripts/tests/test_volume_crop.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_processing(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi = os.path.join(SCILPY_HOME, 'processing', 'dwi.nii.gz')
     ret = script_runner.run('scil_volume_crop.py', in_dwi, 'dwi_crop.nii.gz')
     assert ret.success

--- a/scripts/tests/test_volume_flip.py
+++ b/scripts/tests/test_volume_flip.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_surface_vtk_fib(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_surface_vtk_fib(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_fa = os.path.join(SCILPY_HOME, 'surface_vtk_fib',
                          'fa.nii.gz')
     ret = script_runner.run('scil_volume_flip.py', in_fa, 'fa_flip.nii.gz',

--- a/scripts/tests/test_volume_math.py
+++ b/scripts/tests/test_volume_math.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_add(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_add(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_img_1 = os.path.join(SCILPY_HOME, 'atlas',
                             'brainstem_173.nii.gz')
     in_img_2 = os.path.join(SCILPY_HOME, 'atlas',
@@ -30,24 +30,24 @@ def test_execution_add(script_runner):
     assert ret.success
 
 
-def test_execution_low_thresh(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_low_thresh(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_img = os.path.join(SCILPY_HOME, 'atlas', 'brainstem.nii.gz')
     ret = script_runner.run('scil_volume_math.py', 'lower_threshold',
                             in_img, '1', 'brainstem_bin.nii.gz')
     assert ret.success
 
 
-def test_execution_low_mult(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_low_mult(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_img = os.path.join(SCILPY_HOME, 'atlas', 'brainstem_bin.nii.gz')
     ret = script_runner.run('scil_volume_math.py', 'multiplication',
                             in_img, '16', 'brainstem_unified.nii.gz')
     assert ret.success
 
 
-def test_execution_concatenate(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_concatenate(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_img_1 = os.path.join(SCILPY_HOME, 'atlas', 'ids', '10.nii.gz')
     in_img_2 = os.path.join(SCILPY_HOME, 'atlas', 'ids', '11.nii.gz')
     in_img_3 = os.path.join(SCILPY_HOME, 'atlas', 'ids', '12.nii.gz')
@@ -60,8 +60,8 @@ def test_execution_concatenate(script_runner):
     assert ret.success
 
 
-def test_execution_concatenate_4D(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_concatenate_4D(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_img_1 = os.path.join(SCILPY_HOME, 'atlas', 'ids', '10.nii.gz')
     in_img_2 = os.path.join(SCILPY_HOME, 'atlas', 'ids', '8_10.nii.gz')
     in_img_3 = os.path.join(SCILPY_HOME, 'atlas', 'ids', '12.nii.gz')

--- a/scripts/tests/test_volume_remove_outliers_ransac.py
+++ b/scripts/tests/test_volume_remove_outliers_ransac.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_processing(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_processing(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_ad = os.path.join(SCILPY_HOME, 'processing',
                          'ad.nii.gz')
     ret = script_runner.run('scil_volume_remove_outliers_ransac.py', in_ad,

--- a/scripts/tests/test_volume_resample.py
+++ b/scripts/tests/test_volume_resample.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_others(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_others(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_img = os.path.join(SCILPY_HOME, 'others',
                           'fa.nii.gz')
     ret = script_runner.run('scil_volume_resample.py', in_img,

--- a/scripts/tests/test_volume_reshape_to_reference.py
+++ b/scripts/tests/test_volume_reshape_to_reference.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_others(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_others(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_img = os.path.join(SCILPY_HOME, 'others', 't1_crop.nii.gz')
     in_ref = os.path.join(SCILPY_HOME, 'others', 't1.nii.gz')
     ret = script_runner.run('scil_volume_reshape_to_reference.py', in_img,
@@ -27,8 +27,8 @@ def test_execution_others(script_runner):
     assert ret.success
 
 
-def test_execution_4D(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_4D(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_img = os.path.join(SCILPY_HOME, 'commit_amico', 'dwi.nii.gz')
     in_ref = os.path.join(SCILPY_HOME, 'others', 't1.nii.gz')
     ret = script_runner.run('scil_volume_reshape_to_reference.py', in_img,

--- a/scripts/tests/test_volume_stats_in_ROI.py
+++ b/scripts/tests/test_volume_stats_in_ROI.py
@@ -17,8 +17,8 @@ def test_help_option(script_runner):
     assert ret.success
 
 
-def test_execution_tractometry(script_runner):
-    os.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_tractometry(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_mask = os.path.join(SCILPY_HOME, 'tractometry',
                            'IFGWM.nii.gz')
     in_ref = os.path.join(SCILPY_HOME, 'tractometry',


### PR DESCRIPTION
# Quick description

Cryptic error raised by #954. In tests, we switch to a temporary directory, which gets deleted when a test module is done and its context is tear down. However, `os.chdir` does not change the directory back after the test case. In some corner cases, the next test case does not change its directory, and thus still lives in the temporary directory of another one. In even deeper corner cases, the temporary directory gets deleted before the test case runs. In that case, any call to `os.getcwd()` fails, such as the one done by `pytest-console-script`, leading to [this failure](https://github.com/scilus/scilpy/actions/runs/8457802675/job/23170612617#step:7:228).

I switched to `monkeypatch.chdir` a pytest fixture which does the switching back after the test ends.

...

## Type of change

Check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [x] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [x] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
