### PR TITLE
FIX: scorer crash if only NC and --unique

### DIFF
--- a/scilpy/segment/tractogram_from_roi.py
+++ b/scilpy/segment/tractogram_from_roi.py
@@ -626,7 +626,7 @@ def segment_tractogram_from_roi(
             comb_filename.remove(vb_roi_pair)
         ib_sft_list, ic_ids_list, ib_names = _extract_ib_all_bundles(
             comb_filename, sft[remaining_ids], args)
-        if args.unique:
+        if args.unique and len(ic_ids_list) > 0:
             for i in range(len(ic_ids_list)):
                 # Assign actual ids
                 ic_ids_list[i] = remaining_ids[ic_ids_list[i]]


### PR DESCRIPTION
# Quick description

The scoring script (`scil_tractogram_segment_and_score.py`) crashes if it only has NCs due to a restriction of np.concatenate (can't concatenate nothing). 

## Type of change

Check the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

To test:

Data: https://drive.google.com/file/d/1Y0faJeSrvujcwaOUUbMsKwo9-DWyWrtw/view?usp=sharing

Requires the FiberCup's scoring data to be in your working folder. Then:
`scil_tractogram_segment_and_score.py tractogram_Angular30FiberCup__2024-04-17-05_50_50_fibercup.trk scil_scoring_config.json crash -f -v --dilate 2 --compute_ic --unique`

# Checklist

- [X] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [X] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [x] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
