### PR TITLE
NF - add PTT options to the local tracking script

### DIFF
--- a/scilpy/tracking/utils.py
+++ b/scilpy/tracking/utils.py
@@ -86,7 +86,7 @@ def add_tracking_ptt_options(p):
     track_g = p.add_argument_group('PTT options')
     track_g.add_argument('--probe_length', dest='probe_length',
                          type=float, default=1.0,
-                         help='The length of the probes. Shorter probe_length\n'
+                         help='The length of the probes. Smaller value\n'
                               'yields more dispersed fibers. [%(default)s]')
     track_g.add_argument('--probe_radius', dest='probe_radius',
                          type=float, default=0,

--- a/scilpy/tracking/utils.py
+++ b/scilpy/tracking/utils.py
@@ -87,29 +87,29 @@ def add_tracking_ptt_options(p):
     track_g.add_argument('--probe_length', dest='probe_length',
                          type=float, default=1.0,
                          help='The length of the probes. Shorter probe_length '
-                              + 'yields more dispersed fibers. [%(default)s]')
+                              'yields more dispersed fibers. [%(default)s]')
     track_g.add_argument('--probe_radius', dest='probe_radius',
                          type=float, default=0,
                          help='The radius of the probe. A large probe_radius '
-                              + 'helps mitigate noise in the pmf but it might '
-                              + 'make it harder to sample thin and intricate '
-                              + 'connections, also the boundary of fiber '
-                              + 'bundles might be eroded. [%(default)s]')
+                              'helps mitigate noise in the pmf but it might '
+                              'make it harder to sample thin and intricate '
+                              'connections, also the boundary of fiber '
+                              'bundles might be eroded. [%(default)s]')
     track_g.add_argument('--probe_quality', dest='probe_quality',
                          type=int, default=3,
                          help='The quality of the probe. This parameter sets '
-                              + 'the number of segments to split the cylinder '
-                              + 'along the length of the probe (minimum=2) '
-                              + '[%(default)s]')
+                              'the number of segments to split the cylinder '
+                              'along the length of the probe (minimum=2) '
+                              '[%(default)s]')
     track_g.add_argument('--probe_count', dest='probe_count',
                          type=int, default=1,
                          help='The number of probes. This parameter sets the '
-                              + 'number of parallel lines used to model the '
-                              + 'cylinder (minimum=1). [%(default)s]')
+                              'number of parallel lines used to model the '
+                              'cylinder (minimum=1). [%(default)s]')
     track_g.add_argument('--support_exponent',
                          type=float, default=3,
                          help='Data support exponent, used for rejection '
-                              + 'sampling. [%(default)s]')
+                              'sampling. [%(default)s]')
 
     return track_g
 

--- a/scilpy/tracking/utils.py
+++ b/scilpy/tracking/utils.py
@@ -86,29 +86,29 @@ def add_tracking_ptt_options(p):
     track_g = p.add_argument_group('PTT options')
     track_g.add_argument('--probe_length', dest='probe_length',
                          type=float, default=1.0,
-                         help='The length of the probes. Shorter probe_length '
+                         help='The length of the probes. Shorter probe_length\n'
                               'yields more dispersed fibers. [%(default)s]')
     track_g.add_argument('--probe_radius', dest='probe_radius',
                          type=float, default=0,
-                         help='The radius of the probe. A large probe_radius '
-                              'helps mitigate noise in the pmf but it might '
-                              'make it harder to sample thin and intricate '
-                              'connections, also the boundary of fiber '
+                         help='The radius of the probe. A large probe_radius\n'
+                              'helps mitigate noise in the pmf but it might\n'
+                              'make it harder to sample thin and intricate\n'
+                              'connections, also the boundary of fiber\n'
                               'bundles might be eroded. [%(default)s]')
     track_g.add_argument('--probe_quality', dest='probe_quality',
                          type=int, default=3,
-                         help='The quality of the probe. This parameter sets '
-                              'the number of segments to split the cylinder '
+                         help='The quality of the probe. This parameter sets\n'
+                              'the number of segments to split the cylinder\n'
                               'along the length of the probe (minimum=2) '
                               '[%(default)s]')
     track_g.add_argument('--probe_count', dest='probe_count',
                          type=int, default=1,
-                         help='The number of probes. This parameter sets the '
-                              'number of parallel lines used to model the '
+                         help='The number of probes. This parameter sets the\n'
+                              'number of parallel lines used to model the\n'
                               'cylinder (minimum=1). [%(default)s]')
     track_g.add_argument('--support_exponent',
                          type=float, default=3,
-                         help='Data support exponent, used for rejection '
+                         help='Data support exponent, used for rejection\n'
                               'sampling. [%(default)s]')
 
     return track_g

--- a/scilpy/tracking/utils.py
+++ b/scilpy/tracking/utils.py
@@ -1,27 +1,24 @@
 # -*- coding: utf-8 -*-
 import logging
+from typing import Iterable
+
 import nibabel as nib
 import numpy as np
-
+from nibabel.streamlines import TrkFile
+from nibabel.streamlines.tractogram import LazyTractogram, TractogramItem
 from tqdm import tqdm
-from typing import Iterable
 
 from dipy.core.sphere import HemiSphere
 from dipy.data import get_sphere
 from dipy.direction import (DeterministicMaximumDirectionGetter,
-                            ProbabilisticDirectionGetter,
-                            PTTDirectionGetter)
+                            ProbabilisticDirectionGetter, PTTDirectionGetter)
 from dipy.direction.peaks import PeaksAndMetrics
-from dipy.io.utils import (get_reference_info,
-                           create_tractogram_header)
+from dipy.io.utils import create_tractogram_header, get_reference_info
 from dipy.reconst.shm import sh_to_sf_matrix
-from dipy.tracking.streamlinespeed import length, compress_streamlines
+from dipy.tracking.streamlinespeed import compress_streamlines, length
+from scilpy.io.utils import (add_compression_arg, add_overwrite_arg,
+                             add_sh_basis_args)
 from scilpy.reconst.utils import find_order_from_nb_coeff, get_maximas
-from nibabel.streamlines import TrkFile
-from nibabel.streamlines.tractogram import LazyTractogram, TractogramItem
-
-from scilpy.io.utils import add_sh_basis_args, add_overwrite_arg, \
-    add_compression_arg
 
 
 class TrackingDirection(list):
@@ -86,7 +83,6 @@ def add_tracking_options(p):
 
 
 def add_tracking_ptt_options(p):
-    """ NOT USED IN SCILPY!!! TO DELETE??? """
     track_g = p.add_argument_group('PTT options')
     track_g.add_argument('--probe_length', dest='probe_length',
                          type=float, default=1.0,
@@ -110,11 +106,10 @@ def add_tracking_ptt_options(p):
                          help='The number of probes. This parameter sets the '
                               + 'number of parallel lines used to model the '
                               + 'cylinder (minimum=1). [%(default)s]')
-    track_g.add_argument('--data_support_exponent', dest='support_exponent',
+    track_g.add_argument('--support_exponent',
                          type=float, default=3,
-                         help='Data support to the power dataSupportExponent '
-                              + 'is used for rejection sampling.'
-                              + '[%(default)s]')
+                         help='Data support exponent, used for rejection '
+                              + 'sampling. [%(default)s]')
 
     return track_g
 
@@ -264,7 +259,9 @@ def save_tractogram(
 
 
 def get_direction_getter(in_img, algo, sphere, sub_sphere, theta, sh_basis,
-                         voxel_size, sf_threshold, sh_to_pmf, is_legacy=True):
+                         voxel_size, sf_threshold, sh_to_pmf,
+                         probe_length, probe_radius, probe_quality,
+                         probe_count, support_exponent, is_legacy=True):
     """ Return the direction getter object.
 
     Parameters
@@ -288,6 +285,25 @@ def get_direction_getter(in_img, algo, sphere, sub_sphere, theta, sh_basis,
     sh_to_pmf: bool
         Map sherical harmonics to spherical function (pmf) before tracking
         (faster, requires more memory).
+    probe_length : float
+        The length of the probes. Shorter probe_length
+        yields more dispersed fibers.
+    probe_radius : float
+        The radius of the probe. A large probe_radius
+        helps mitigate noise in the pmf but it might
+        make it harder to sample thin and intricate
+        connections, also the boundary of fiber
+        bundles might be eroded.
+    probe_quality : int
+        The quality of the probe. This parameter sets
+        the number of segments to split the cylinder
+        along the length of the probe (minimum=2).
+    probe_count : int
+        The number of probes. This parameter sets the
+        number of parallel lines used to model the
+        cylinder (minimum=1).
+    support_exponent : float
+        Data support exponent, used for rejection sampling.
     is_legacy : bool, optional
         Whether or not the SH basis is in its legacy form.
 
@@ -322,7 +338,11 @@ def get_direction_getter(in_img, algo, sphere, sub_sphere, theta, sh_basis,
             dg_class = PTTDirectionGetter
             # Considering the step size usually used, the probe length
             # can be set as the voxel size.
-            kwargs = {'probe_length': voxel_size}
+            kwargs = {'probe_length': probe_length,
+                      'probe_radius': probe_radius,
+                      'probe_quality' : probe_quality,
+                      'probe_count' : probe_count,
+                      'data_support_exponent' : support_exponent}
         elif algo == 'det':
             dg_class = DeterministicMaximumDirectionGetter
         else:

--- a/scilpy/tracking/utils.py
+++ b/scilpy/tracking/utils.py
@@ -243,7 +243,7 @@ def save_tractogram(
                     # Streamlines are dumped in true world space with
                     # origin center as expected by .tck files.
                     strl = np.dot(strl, ref_img.affine[:3, :3]) + \
-                           ref_img.affine[:3, 3]
+                        ref_img.affine[:3, 3]
 
                 yield TractogramItem(strl, dps, {})
 
@@ -340,9 +340,9 @@ def get_direction_getter(in_img, algo, sphere, sub_sphere, theta, sh_basis,
             # can be set as the voxel size.
             kwargs = {'probe_length': probe_length,
                       'probe_radius': probe_radius,
-                      'probe_quality' : probe_quality,
-                      'probe_count' : probe_count,
-                      'data_support_exponent' : support_exponent}
+                      'probe_quality': probe_quality,
+                      'probe_count': probe_count,
+                      'data_support_exponent': support_exponent}
         elif algo == 'det':
             dg_class = DeterministicMaximumDirectionGetter
         else:

--- a/scripts/tests/test_tracking_local.py
+++ b/scripts/tests/test_tracking_local.py
@@ -169,3 +169,17 @@ def test_execution_tracking_fodf_prob_pmf_mapping(script_runner, monkeypatch):
                             '--min_length', '20', '--max_length', '200',
                             '--sh_to_pmf', '-v')
     assert ret.success
+
+
+def test_execution_tracking_ptt(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+    in_fodf = os.path.join(SCILPY_HOME, 'tracking', 'fodf.nii.gz')
+    in_mask = os.path.join(SCILPY_HOME, 'tracking', 'seeding_mask.nii.gz')
+
+    ret = script_runner.run('scil_tracking_local.py', in_fodf,
+                            in_mask, in_mask, 'local_ptt.trk', '--nt', '100',
+                            '--compress', '0.1', '--sh_basis', 'descoteaux07',
+                            '--min_length', '20', '--max_length', '200',
+                            '--sh_to_pmf', '-v', '--probe_length', '2',
+                            '--probe_quality', '5', '--algo', 'ptt')
+    assert ret.success


### PR DESCRIPTION
# Quick description

PR #750 forgot to include the PTT options for the `script scil_tracking_local.py` (issue #952). This PR fixed the issue.


## Type of change

Check the relevant options.

- [x] New feature (non-breaking change which adds functionality)



## Provide data, screenshots, command line to test (if relevant)

`scil_tracking_local.py disco/fODF.nii.gz disco/DiSCo1_ROIs.nii.gz disco/mask.nii.gz scil_test2.tck --step 0.2 --theta 20 --npv 1 --algo ptt --sphere repulsion724 -f --probe_quality 5 --probe_length 2`


# Checklist

- [x] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
