### PR TITLE
Tractogram scripts part 5

### DIFF
--- a/scilpy/tractograms/tractogram_operations.py
+++ b/scilpy/tractograms/tractogram_operations.py
@@ -201,7 +201,6 @@ def perform_tractogram_operation_on_sft(op_name, sft_list, precision,
     sft: StatefulTractogram
         The final SFT
     """
-    # Performing operation
     streamlines_list = [sft.streamlines for sft in sft_list]
     _, indices = perform_tractogram_operation_on_lines(
         OPERATIONS[op_name], streamlines_list, precision=precision)

--- a/scilpy/tractograms/tractogram_operations.py
+++ b/scilpy/tractograms/tractogram_operations.py
@@ -184,11 +184,12 @@ def perform_tractogram_operation_on_sft(op_name, sft_list, precision,
         A callable that takes two streamlines dicts as inputs and preduces a
         new streamline dict.
     sft_list: list[StatefulTractogram]
-        The streamlines used in the operation.
+        The tractograms used in the operation.
     precision: int, optional
         The number of decimals to keep when hashing the points of the
         streamlines. Allows a soft comparison of streamlines. If None, no
-        rounding is performed.
+        rounding is performed. Precision should be in the same space as
+        sfts (ex, mm).
     no_metadata: bool
         If true, remove all metadata.
     fake_metadata: bool
@@ -201,8 +202,7 @@ def perform_tractogram_operation_on_sft(op_name, sft_list, precision,
         The final SFT
     """
     # Performing operation
-    streamlines_list = [sft.streamlines if sft is not None else []
-                        for sft in sft_list]
+    streamlines_list = [sft.streamlines for sft in sft_list]
     _, indices = perform_tractogram_operation_on_lines(
         OPERATIONS[op_name], streamlines_list, precision=precision)
 

--- a/scripts/scil_tractogram_math.py
+++ b/scripts/scil_tractogram_math.py
@@ -119,7 +119,7 @@ def main():
     assert_headers_compatible(parser, args.in_tractograms,
                               reference=args.reference)
 
-    # Lazy: Loading and processing are done on-the-fly. Then exit script.
+    # Lazy operations:
     if args.operation == 'lazy_concatenate':
         logging.info('Using lazy_concatenate, no metadata related checks are '
                      'performed.\nMetadata will be lost.\nOnly '
@@ -133,12 +133,14 @@ def main():
         if os.path.isfile(args.out_tractogram) and args.overwrite:
             os.remove(args.out_tractogram)
 
+        # Reminder: loading and processing are done on-the-fly.
         out_tractogram, header = lazy_concatenate(args.in_tractograms, out_ext)
         nib.streamlines.save(out_tractogram, args.out_tractogram,
                              header=header)
+
         return
 
-    # Non-lazy:
+    # Non-lazy operations:
 
     # Loading
     sft_list = []

--- a/scripts/scil_tractogram_math.py
+++ b/scripts/scil_tractogram_math.py
@@ -75,11 +75,10 @@ def _build_arg_parser():
                         'streamlines. Must\nbe one of the following: '
                         '%(choices)s.')
     p.add_argument('in_tractograms', metavar='INPUT_FILES', nargs='+',
-                   help='The list of files that contain the ' +
-                        'streamlines to operate on.')
+                   help='The list of files that contain the streamlines to '
+                        'operate on.')
     p.add_argument('out_tractogram', metavar='OUTPUT_FILE',
-                   help='The file where the remaining streamlines '
-                        'are saved.')
+                   help='The file where the remaining streamlines are saved.')
 
     p.add_argument('--precision', '-p', metavar='NBR_OF_DECIMALS',
                    type=int, default=4,
@@ -113,22 +112,24 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
+    # Verifications
     assert_inputs_exist(parser, args.in_tractograms, args.reference)
     assert_outputs_exist(parser, args, args.out_tractogram,
                          optional=args.save_indices)
     assert_headers_compatible(parser, args.in_tractograms,
                               reference=args.reference)
 
+    # Lazy: Loading and processing are done on-the-fly. Then exit script.
     if args.operation == 'lazy_concatenate':
-        logging.info('Using lazy_concatenate, no spatial or metadata related '
-                     'checks are performed.\nMetadata will be lost, only '
-                     'trk/tck file are supported.\n To use trk, at least one '
+        logging.info('Using lazy_concatenate, no metadata related checks are '
+                     'performed.\nMetadata will be lost.\nOnly '
+                     'trk/tck file are supported. To use trk, at least one '
                      'input must be a trk.')
         _, out_ext = os.path.splitext(args.out_tractogram)
 
         # In some cases, if -f is used and previous file contained errors
         # (ex, wrong header), the lazy version does not overwrite the file
-        # completely. Deleting manually
+        # completely. Deleting manually.
         if os.path.isfile(args.out_tractogram) and args.overwrite:
             os.remove(args.out_tractogram)
 
@@ -137,24 +138,27 @@ def main():
                              header=header)
         return
 
-    # Load all input streamlines.
+    # Non-lazy:
+
+    # Loading
     sft_list = []
     for f in args.in_tractograms:
         logging.info("Loading file {}".format(f))
         # Using in a millimeter space so that the precision level is in mm.
-        # Note. Sending to_voxmm() returns None with no streamlines.
         tmp_sft = load_tractogram_with_reference(parser, args, f)
         tmp_sft.to_voxmm()
-
         sft_list.append(tmp_sft)
 
     if np.all([len(sft) == 0 for sft in sft_list]):
+        logging.warning("All tractogram files are empty! Nothing to do. "
+                        "Exiting.")
         return
 
-    # Apply the requested operation to each input file.
+    # Processing
+
     if args.operation == 'concatenate':
         logging.info('Performing operation "concatenate"')
-        sft_list = [s for s in sft_list if s is not None]
+        sft_list = [s for s in sft_list if len(s) > 0]
         new_sft = concatenate_sft(sft_list, args.no_metadata,
                                   args.fake_metadata)
         indices_per_sft = [np.arange(len(new_sft), dtype=np.uint32)]

--- a/scripts/scil_tractogram_pairwise_comparison.py
+++ b/scripts/scil_tractogram_pairwise_comparison.py
@@ -2,8 +2,8 @@
 # -*- coding: utf-8 -*-
 
 """
-This script is designed to compare and help visualize differences between
-two tractograms. This can be especially useful in studies where multiple
+This script is designed to compare and help visualize differences between two
+tractograms. This can be especially useful in studies where multiple
 tractograms from different algorithms or parameters need to be compared.
 
 A similar script (scil_bundle_pairwise_comparison.py) is available for bundles,
@@ -29,11 +29,11 @@ import os
 
 import nibabel as nib
 
+from scilpy.io.image import get_data_as_mask
 from scilpy.io.streamlines import load_tractogram_with_reference
 from scilpy.io.utils import (add_overwrite_arg, add_reference_arg,
                              assert_inputs_exist,
                              assert_outputs_exist,
-                             assert_output_dirs_exist_and_empty,
                              add_processes_arg,
                              add_verbose_arg,
                              assert_headers_compatible,
@@ -54,8 +54,8 @@ def _build_arg_parser():
                    help='Input tractogram 2.')
 
     p.add_argument('--out_dir', default='',
-                   help='Directory where all output files will be saved. '
-                        '\nIf not specified, outputs will be saved in the '
+                   help='Directory where all output files will be saved.\n'
+                        'If not specified, outputs will be saved in the '
                         'current directory.')
     p.add_argument('--out_prefix', default='out',
                    help='Prefix for output files. Useful for distinguishing '
@@ -77,15 +77,14 @@ def _build_arg_parser():
 def main():
     parser = _build_arg_parser()
     args = parser.parse_args()
-
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
+    # Verifications
     assert_inputs_exist(parser, [args.in_tractogram_1, args.in_tractogram_2],
                         [args.in_mask, args.reference])
-    to_verify = [args.in_tractogram_1, args.in_tractogram_2]
-    if args.in_mask:
-        to_verify.append(args.in_mask)
-    assert_headers_compatible(parser, to_verify, reference=args.reference)
+    assert_headers_compatible(parser,
+                              [args.in_tractogram_1, args.in_tractogram_2],
+                              args.in_mask, reference=args.reference)
 
     if args.out_prefix and args.out_prefix[-1] == '_':
         args.out_prefix = args.out_prefix[:-1]
@@ -97,22 +96,24 @@ def main():
         args.out_dir, '{}_diff.nii.gz'.format(args.out_prefix))
     out_merge_filename = os.path.join(
         args.out_dir, '{}_heatmap.nii.gz'.format(args.out_prefix))
-    assert_output_dirs_exist_and_empty(parser, args, [], optional=args.out_dir)
     assert_outputs_exist(parser, args, [out_corr_filename,
                                         out_acc_filename,
                                         out_merge_filename],
                          out_diff_filename)
     nbr_cpu = validate_nbr_processes(parser, args)
 
+    # Loading
     logging.info('Loading tractograms...')
     sft_1 = load_tractogram_with_reference(parser, args, args.in_tractogram_1)
     sft_2 = load_tractogram_with_reference(parser, args, args.in_tractogram_2)
-    mask = nib.load(args.in_mask) if args.in_mask else None
+    mask = get_data_as_mask(nib.load(args.in_mask)) if args.in_mask else None
 
+    # Processing
     acc_data, corr_data, diff_data, heatmap, _ = \
         tractogram_pairwise_comparison(sft_1, sft_2, mask, nbr_cpu,
                                        args.skip_streamlines_distance)
 
+    # Saving
     logging.info('Saving results...')
     nib.save(nib.Nifti1Image(acc_data, sft_1.affine), out_acc_filename)
     nib.save(nib.Nifti1Image(corr_data, sft_1.affine), out_corr_filename)

--- a/scripts/scil_tractogram_project_streamlines_to_map.py
+++ b/scripts/scil_tractogram_project_streamlines_to_map.py
@@ -62,7 +62,7 @@ def _build_arg_parser():
                         'will output \nmy_path/subjX_bundleY_key1.nii.gz')
 
     p1 = p.add_argument_group(
-        description='Where to get the statistics from. (Choose one)')
+        'Where to get the statistics from. (Choose one)')
     p1 = p1.add_mutually_exclusive_group(required=True)
     p1.add_argument('--use_dps', metavar='key', nargs='+',
                     help='Use the data_per_streamline from the tractogram.\n'
@@ -77,7 +77,7 @@ def _build_arg_parser():
                     help='Load data per point (scalar) from .txt or .npy.\n'
                          'Must load an array with the right shape.')
 
-    p2 = p.add_argument_group(description='Processing choices. (Choose one)')
+    p2 = p.add_argument_group('Processing choices. (Choose one)')
     p2 = p2.add_mutually_exclusive_group(required=True)
     p2.add_argument('--mean_endpoints', action='store_true',
                     help="Uses one single value per streamline: the mean "
@@ -90,7 +90,7 @@ def _build_arg_parser():
                          "map.\n")
 
     p3 = p.add_argument_group(
-        description='Where to send the statistics. (Choose one)')
+        'Where to send the statistics. (Choose one)')
     p3 = p3.add_mutually_exclusive_group(required=True)
     p3.add_argument('--to_endpoints', action='store_true',
                     help="Project metrics onto a mask of the endpoints.")
@@ -189,7 +189,7 @@ def main():
     out_files = [args.out_prefix + m + '.nii.gz' for m in metrics_names]
     assert_outputs_exist(parser, args, out_files)
 
-    # -------- Load streamlines and checking compatibility ----------
+    # -------- Load streamlines ----------
     logging.info("Loading tractogram {}".format(args.in_bundle))
     sft = load_tractogram_with_reference(parser, args, args.in_bundle)
     sft.to_vox()

--- a/scripts/scil_tractogram_register.py
+++ b/scripts/scil_tractogram_register.py
@@ -2,12 +2,12 @@
 # -*- coding: utf-8 -*-
 
 """
-Generate a linear transformation matrix from the registration of
-2 tractograms. Typically, this script is run before
-scil_tractogram_apply_transform.py.
+Generate a linear transformation matrix from the registration of 2 tractograms.
+Typically, this script is run before scil_tractogram_apply_transform.py.
 
-For more informations on how to use the various registration scripts
-see the doc/tractogram_registration.md readme file
+For more information on how to use the various registration scripts, see the
+doc at:
+https://scilpy.readthedocs.io/en/latest/documentation/tractogram_registration.html
 
 Formerly: scil_register_tractogram.py
 """
@@ -42,12 +42,13 @@ def _build_arg_parser():
                    help='Path of the target tractogram.')
 
     p.add_argument('--out_name', default='transformation.txt',
-                   help='Filename of the transformation matrix, \n'
-                        'the registration type will be appended as a suffix,\n'
-                        '[<out_name>_<affine/rigid>.txt]')
+                   help='Filename of the transformation matrix. \n'
+                        'The registration type will be appended as a suffix,\n'
+                        '[<out_name>_<affine/rigid>.txt]. \n'
+                        'Default: [%(default)s]')
     p.add_argument('--only_rigid', action='store_true',
-                   help='Will only use a rigid transformation, '
-                        'uses affine by default.')
+                   help='If set, will only use a rigid transformation '
+                        '(uses affine by default).')
 
     add_reference_arg(p, 'moving_tractogram')
     add_reference_arg(p, 'static_tractogram')

--- a/scripts/tests/test_tractogram_pairwise_comparison.py
+++ b/scripts/tests/test_tractogram_pairwise_comparison.py
@@ -7,10 +7,12 @@ import tempfile
 from scilpy import SCILPY_HOME
 from scilpy.io.fetcher import get_testing_files_dict, fetch_data
 
-
 # If they already exist, this only takes 5 seconds (check md5sum)
 fetch_data(get_testing_files_dict(), keys=['bundles.zip'])
 tmp_dir = tempfile.TemporaryDirectory()
+in_1 = os.path.join(SCILPY_HOME, 'bundles', 'bundle_0_reco.tck')
+in_2 = os.path.join(SCILPY_HOME, 'bundles', 'voting_results', 'bundle_0.trk')
+in_ref = os.path.join(SCILPY_HOME, 'bundles', 'bundle_all_1mm.nii.gz')
 
 
 def test_help_option(script_runner):
@@ -21,22 +23,17 @@ def test_help_option(script_runner):
 
 def test_execution_bundles_skip(script_runner, monkeypatch):
     monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
-    in_1 = os.path.join(SCILPY_HOME, 'bundles', 'bundle_0_reco.tck')
-    in_2 = os.path.join(SCILPY_HOME, 'bundles', 'voting_results',
-                        'bundle_0.trk')
-    in_ref = os.path.join(SCILPY_HOME, 'bundles', 'bundle_all_1mm.nii.gz')
     ret = script_runner.run('scil_tractogram_pairwise_comparison.py',
-        in_1, in_2, '--out_dir', tmp_dir.name, '--reference', in_ref,
-        '--skip_streamlines_distance')
+                            in_1, in_2, '--out_dir', tmp_dir.name,
+                            '--reference', in_ref,
+                            '--skip_streamlines_distance')
     assert ret.success
+
 
 def test_execution_bundles(script_runner, monkeypatch):
     monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
-    in_1 = os.path.join(SCILPY_HOME, 'bundles', 'bundle_0_reco.tck')
-    in_2 = os.path.join(SCILPY_HOME, 'bundles', 'voting_results',
-                        'bundle_0.trk')
-    in_ref = os.path.join(SCILPY_HOME, 'bundles', 'bundle_all_1mm.nii.gz')
     ret = script_runner.run('scil_tractogram_pairwise_comparison.py',
-        in_1, in_2, '--out_dir', tmp_dir.name, '--reference', in_ref, '-f',
-        '--skip_streamlines_distance')
+                            in_1, in_2, '--out_dir', tmp_dir.name,
+                            '--reference', in_ref, '-f',
+                            '--skip_streamlines_distance')
     assert ret.success

--- a/scripts/tests/test_tractogram_project_map_to_streamlines.py
+++ b/scripts/tests/test_tractogram_project_map_to_streamlines.py
@@ -11,6 +11,10 @@ from scilpy.io.fetcher import fetch_data, get_testing_files_dict
 fetch_data(get_testing_files_dict(), keys=['others.zip'])
 tmp_dir = tempfile.TemporaryDirectory()
 
+in_tracto_1 = os.path.join(SCILPY_HOME, 'tracking', 'local_split_0.trk')
+in_3d_map = os.path.join(SCILPY_HOME, 'tracking', 'fa.nii.gz')
+in_4d_map = os.path.join(SCILPY_HOME, 'tracking', 'peaks.nii.gz')
+
 
 def test_help_option(script_runner):
     ret = script_runner.run(
@@ -20,40 +24,31 @@ def test_help_option(script_runner):
 
 def test_execution_3D_map(script_runner, monkeypatch):
     monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
-    in_t1 = os.path.join(SCILPY_HOME, 'tractometry', 'mni_masked.nii.gz')
-    in_tracto_1 = os.path.join(SCILPY_HOME, 'others',
-                               'IFGWM_sub.trk')
 
     ret = script_runner.run('scil_tractogram_project_map_to_streamlines.py',
                             in_tracto_1, 't1_on_streamlines.trk',
-                            '--in_maps', in_t1,
+                            '--in_maps', in_3d_map,
                             '--out_dpp_name', 't1')
     assert ret.success
 
 
 def test_execution_4D_map(script_runner, monkeypatch):
     monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
-    in_rgb = os.path.join(SCILPY_HOME, 'others', 'rgb.nii.gz')
-    in_tracto_1 = os.path.join(SCILPY_HOME, 'others',
-                               'IFGWM_sub.trk')
 
     ret = script_runner.run('scil_tractogram_project_map_to_streamlines.py',
                             in_tracto_1, 'rgb_on_streamlines.trk',
-                            '--in_maps', in_rgb,
+                            '--in_maps', in_4d_map,
                             '--out_dpp_name', 'rgb')
     assert ret.success
 
 
 def test_execution_3D_map_endpoints_only(script_runner, monkeypatch):
     monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
-    in_t1 = os.path.join(SCILPY_HOME, 'tractometry', 'mni_masked.nii.gz')
-    in_tracto_1 = os.path.join(SCILPY_HOME, 'others',
-                               'IFGWM_sub.trk')
 
     ret = script_runner.run('scil_tractogram_project_map_to_streamlines.py',
                             in_tracto_1,
                             't1_on_streamlines_endpoints.trk',
-                            '--in_maps', in_t1,
+                            '--in_maps', in_3d_map,
                             '--out_dpp_name', 't1',
                             '--endpoints_only')
     assert ret.success
@@ -61,14 +56,11 @@ def test_execution_3D_map_endpoints_only(script_runner, monkeypatch):
 
 def test_execution_4D_map_endpoints_only(script_runner, monkeypatch):
     monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
-    in_rgb = os.path.join(SCILPY_HOME, 'others', 'rgb.nii.gz')
-    in_tracto_1 = os.path.join(SCILPY_HOME, 'others',
-                               'IFGWM_sub.trk')
 
     ret = script_runner.run('scil_tractogram_project_map_to_streamlines.py',
                             in_tracto_1,
                             'rgb_on_streamlines_endpoints.trk',
-                            '--in_maps', in_rgb,
+                            '--in_maps', in_4d_map,
                             '--out_dpp_name', 'rgb',
                             '--endpoints_only')
     assert ret.success
@@ -76,14 +68,11 @@ def test_execution_4D_map_endpoints_only(script_runner, monkeypatch):
 
 def test_execution_3D_map_trilinear(script_runner, monkeypatch):
     monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
-    in_t1 = os.path.join(SCILPY_HOME, 'tractometry', 'mni_masked.nii.gz')
-    in_tracto_1 = os.path.join(SCILPY_HOME, 'others',
-                               'IFGWM_sub.trk')
 
     ret = script_runner.run('scil_tractogram_project_map_to_streamlines.py',
                             in_tracto_1,
                             't1_on_streamlines_trilinear.trk',
-                            '--in_maps', in_t1,
+                            '--in_maps', in_3d_map,
                             '--out_dpp_name', 't1',
                             '--trilinear')
     assert ret.success

--- a/scripts/tests/test_tractogram_project_streamlines_to_map.py
+++ b/scripts/tests/test_tractogram_project_streamlines_to_map.py
@@ -11,6 +11,9 @@ from scilpy.io.fetcher import fetch_data, get_testing_files_dict
 fetch_data(get_testing_files_dict(), keys=['tractometry.zip'])
 tmp_dir = tempfile.TemporaryDirectory()
 
+# toDo. For more coverage, save some DPS and DPP in a text file, and test
+#  options --load_dpp, --load_dps.
+
 
 def test_help_option(script_runner):
     ret = script_runner.run('scil_tractogram_project_streamlines_to_map.py',


### PR DESCRIPTION
# Quick description

Next step in tractogram scripts verification. All the next scripts were already pretty much ok! Yeah! Pretty much only formatting changes, and more verifications!

Stopped after 6 scripts. A part 6 will follow :)

- `scil_tractogram_math`
- `scil_tractogram_pairwise_comparison`
- `scil_tractogram_project_maps_to_streamlines`
- `scil_tractogram_project_streamlines_to_map`
- `scil_tractogram_qbx`
- `scil_tractogram_register`


## Type of change

Check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist

- [x] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [x] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
