### PR TITLE
[FIX] fixed typo in surface convert script

### DIFF
--- a/scripts/scil_surface_convert.py
+++ b/scripts/scil_surface_convert.py
@@ -81,7 +81,7 @@ def main():
         polydata = convert_freesurfer_into_polydata(args.in_surface,
                                                     xform_translation)
     else:
-        polydata = load_polydata(args.out_surface)
+        polydata = load_polydata(args.in_surface)
 
     if args.to_lps:
         polydata = flip_LPS(polydata)


### PR DESCRIPTION
# Quick description

Big start to scilpy mesh refactoring.  Fixed a typo in convert surface script.  Before fix script would only work with FreeSurfer surfaces.

...

## Type of change

Check the relevant options.

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [x ] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [x ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [ x] I have performed a self-review of my code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ x] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
