### PR TITLE
[FIX] 10 colors in BASE10 colors for visualization

### DIFF
--- a/scilpy/viz/color.py
+++ b/scilpy/viz/color.py
@@ -26,14 +26,16 @@ def convert_color_names_to_rgb(names):
     return [get_color_by_name(name) for name in names]
 
 
-BASE_10_COLORS = convert_color_names_to_rgb(["Blue",
-                                             "Yellow",
-                                             "Purple",
-                                             "Green",
+BASE_10_COLORS = convert_color_names_to_rgb(["Red",
+                                             "DeepPink",
                                              "Orange",
-                                             "White",
-                                             "Brown",
-                                             "Grey"])
+                                             "Gold",
+                                             "Purple",
+                                             "Magenta",
+                                             "Green",
+                                             "Blue",
+                                             "Cyan",
+                                             "Brown"])
 
 
 def generate_n_colors(n, generator=distinguishable_colormap,


### PR DESCRIPTION
# Quick description

There was only 8 colors in the BASE10 colors for visualization (with a white and a grey). Fixed, now there is 10, and they are all colors, no grayscale.

...

## Type of change

Check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [x] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [x] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
