### PR TITLE
[FIX] Typo in scil_dti_metrics script

### DIFF
--- a/scripts/scil_dti_metrics.py
+++ b/scripts/scil_dti_metrics.py
@@ -305,7 +305,7 @@ def main():
 
         del tensor_vals, fiber_tensors, tensor_vals_reordered
 
-    if args.fa or args.RGB:
+    if args.fa or args.rgb:
         FA = fractional_anisotropy(tenfit.evals)
         FA[np.isnan(FA)] = 0
         FA = np.clip(FA, 0, 1)

--- a/scripts/tests/test_dti_metrics.py
+++ b/scripts/tests/test_dti_metrics.py
@@ -43,3 +43,8 @@ def test_execution_processing(script_runner, monkeypatch):
                             in_bval, in_bvec, '--not_all',
                             '--fa', 'fa.nii.gz', '--b0_threshold', '1', '-f')
     assert not ret.success
+
+    ret = script_runner.run('scil_dti_metrics.py', in_dwi,
+                            in_bval, in_bvec, '--not_all',
+                            '--rgb', 'rgb.nii.gz', '-f')
+    assert ret.success


### PR DESCRIPTION
# Quick description

`scil_dti_metrics.py` is unusable due to a typo in the script. I assume in the tests and most usages, we ask to output FA, and it must be why we didn't detect this error, since `or` shortcuts evaluating `args.RGB`.

...

## Type of change

Check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [x] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [x] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
