### PR TITLE
Removing xform from convert script

### DIFF
--- a/scilpy/surfaces/tests/test_surfaces_utils.py
+++ b/scilpy/surfaces/tests/test_surfaces_utils.py
@@ -1,8 +1,4 @@
-import numpy as np
-
-from scilpy.surfaces.utils import (extract_xform)
-from scilpy.tests.arrays import (xform, xform_matrix_ref)
-
+# -*- coding: utf-8 -*-
 
 def test_convert_freesurfer_into_polydata():
     pass
@@ -10,8 +6,3 @@ def test_convert_freesurfer_into_polydata():
 
 def test_flip_LPS():
     pass
-
-
-def test_extract_xform():
-    out = extract_xform(xform)
-    assert np.allclose(out, xform_matrix_ref)

--- a/scripts/scil_surface_convert.py
+++ b/scripts/scil_surface_convert.py
@@ -41,7 +41,8 @@ def _build_arg_parser():
     p.add_argument('in_surface',
                    help='Input a surface (FreeSurfer or supported by VTK).')
     p.add_argument('out_surface',
-                   help='Output surface (formats supported by VTK).')
+                   help='Output surface (formats supported by VTK).\n'
+                        'Recommended extension: .vtk or .ply')
 
     p.add_argument('--flip_axes', default=[-1, -1, 1], type=int, nargs=3,
                    help='Flip axes for RAS or LPS convention. '
@@ -60,10 +61,12 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
-    assert_inputs_exist(parser, args.in_surface)
+    assert_inputs_exist(parser, args.in_surface, optional=args.reference)
     assert_outputs_exist(parser, args, args.out_surface)
 
     _, ext = os.path.splitext(args.in_surface)
+    # FreeSurfer surfaces have no extension, verify if the input has one of the
+    # many supported extensions, otherwise it is (likely) a FreeSurfer surface
     if ext not in ['.vtk', '.vtp', '.fib', '.ply', '.stl', '.xml', '.obj']:
         if args.reference is None:
             parser.error('The reference image is required for FreeSurfer '

--- a/scripts/scil_surface_convert.py
+++ b/scripts/scil_surface_convert.py
@@ -20,8 +20,7 @@ from trimeshpy.vtk_util import (load_polydata,
                                 save_polydata)
 
 from scilpy.surfaces.utils import (convert_freesurfer_into_polydata,
-                                   extract_xform,
-                                   flip_LPS)
+                                   flip_surfaces_axes)
 
 from scilpy.io.utils import (add_overwrite_arg,
                              add_verbose_arg,
@@ -41,18 +40,15 @@ def _build_arg_parser():
 
     p.add_argument('in_surface',
                    help='Input a surface (FreeSurfer or supported by VTK).')
-
     p.add_argument('out_surface',
                    help='Output surface (formats supported by VTK).')
 
-    p.add_argument('--xform',
-                   help='Path of the copy-paste output from mri_info \n'
-                        'Using: mri_info $input >> log.txt, \n'
-                        'The file log.txt would be this parameter')
-
-    p.add_argument('--to_lps', action='store_true',
-                   help='Flip for Surface/MI-Brain LPS')
-
+    p.add_argument('--flip_axes', default=[-1, -1, 1], type=int, nargs=3,
+                   help='Flip axes for RAS or LPS convention. '
+                        'Default is LPS convention (MI-Brain) %(default)s.')
+    p.add_argument('--reference',
+                   help='Reference image to extract the transformation matrix '
+                        'to align the freesurfer surface with the T1.')
     add_verbose_arg(p)
     add_overwrite_arg(p)
 
@@ -67,24 +63,19 @@ def main():
     assert_inputs_exist(parser, args.in_surface)
     assert_outputs_exist(parser, args, args.out_surface)
 
-    if args.xform:
-        with open(args.xform) as f:
-            content = f.readlines()
-        xform = [x.strip() for x in content]
-        xform_matrix = extract_xform(xform)
-        xform_translation = xform_matrix[0:3, 3]
-    else:
-        xform_translation = [0, 0, 0]
+    _, ext = os.path.splitext(args.in_surface)
+    if ext not in ['.vtk', '.vtp', '.fib', '.ply', '.stl', '.xml', '.obj']:
+        if args.reference is None:
+            parser.error('The reference image is required for FreeSurfer '
+                         'surfaces.')
 
-    if not ((os.path.splitext(args.in_surface)[1])
-            in ['.vtk', '.vtp', '.fib', '.ply', '.stl', '.xml', '.obj']):
         polydata = convert_freesurfer_into_polydata(args.in_surface,
-                                                    xform_translation)
+                                                    args.reference)
     else:
         polydata = load_polydata(args.in_surface)
 
-    if args.to_lps:
-        polydata = flip_LPS(polydata)
+    if args.flip_axes:
+        polydata = flip_surfaces_axes(polydata, args.flip_axes)
 
     save_polydata(polydata, args.out_surface, legacy_vtk_format=True)
 

--- a/scripts/tests/test_surface_convert.py
+++ b/scripts/tests/test_surface_convert.py
@@ -30,9 +30,8 @@ def test_execution_surface_vtk_xfrom(script_runner, monkeypatch):
     monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_surf = os.path.join(SCILPY_HOME, 'surface_vtk_fib',
                            'lh.pialt_xform')
-    x_form = os.path.join(SCILPY_HOME, 'surface_vtk_fib',
-                          'log.txt')
+    ref = os.path.join(SCILPY_HOME, 'surface_vtk_fib', 'fa.nii.gz')
     ret = script_runner.run('scil_surface_convert.py', in_surf,
-                            'lh.pialt_xform.vtk', '--xform', x_form,
-                            '--to_lps')
+                            'lh.pialt_xform.vtk', '--reference', ref,
+                            '--flip_axes', '-1', '-1', '1')
     assert ret.success

--- a/scripts/tests/test_tractogram_assign_uniform_color.py
+++ b/scripts/tests/test_tractogram_assign_uniform_color.py
@@ -40,5 +40,5 @@ def test_execution_dict(script_runner, monkeypatch):
 
     ret = script_runner.run('scil_tractogram_assign_uniform_color.py',
                             in_bundle, '--dict_colors', json_file,
-                            '--out_suffix', 'colored')
+                            '--out_suffix', 'colored', '-f')
     assert ret.success


### PR DESCRIPTION
# Quick description

Instead of using mri_info to get the xform, we can now use a reference file to convert the freesurfer surface to VTK for MI-Brain.

...

## Type of change

Check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [x] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
