### PR TITLE
[FIX] Empty remaining indices when filtering for a bundle

### DIFF
--- a/scilpy/segment/tests/test_tractogram_from_roi.py
+++ b/scilpy/segment/tests/test_tractogram_from_roi.py
@@ -10,6 +10,8 @@ from scilpy.segment.tractogram_from_roi import _extract_vb_one_bundle, _extract_
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
 
 def test_extract_vb_one_bundle():
+    # Testing extraction of VS corresponding to a bundle using 
+    # an empty tractogram which shouldn't raise any error.
     fake_reference = nib.Nifti1Image(np.zeros((10, 10, 10, 1)), affine=np.eye(4))
     empty_sft = StatefulTractogram([], fake_reference, Space.RASMM) # The Space type is not important here
 
@@ -19,8 +21,6 @@ def test_extract_vb_one_bundle():
         nib.save(nib.Nifti1Image(np.zeros((10, 10, 10)), affine=np.eye(4), dtype=np.int8), fake_mask1_name)
         nib.save(nib.Nifti1Image(np.zeros((10, 10, 10)), affine=np.eye(4), dtype=np.int8), fake_mask2_name)
 
-        # Test extraction of a single bundle of empty streamlines.
-        # This should not raise any error.
         vs_ids, wpc_ids, bundle_stats = _extract_vb_one_bundle(empty_sft, fake_mask1_name, fake_mask2_name,
                                                None, None, None,
                                                None, None, None, None)
@@ -29,6 +29,8 @@ def test_extract_vb_one_bundle():
         assert_equal(bundle_stats["VS"], 0)
 
 def test_extract_ib_one_bundle():
+    # Testing extraction of IS corresponding to a bundle using 
+    # an empty tractogram which shouldn't raise any error.
     fake_reference = nib.Nifti1Image(np.zeros((10, 10, 10, 1)), affine=np.eye(4))
     empty_sft = StatefulTractogram([], fake_reference, Space.RASMM) # The Space type is not important here
 
@@ -38,8 +40,7 @@ def test_extract_ib_one_bundle():
         nib.save(nib.Nifti1Image(np.zeros((10, 10, 10)), affine=np.eye(4), dtype=np.int8), fake_mask1_name)
         nib.save(nib.Nifti1Image(np.zeros((10, 10, 10)), affine=np.eye(4), dtype=np.int8), fake_mask2_name)
 
-        # Test extraction of a single bundle of empty streamlines.
-        # This should not raise any error.
         fc_sft, fc_ids = _extract_ib_one_bundle(empty_sft, fake_mask1_name, fake_mask2_name, None)
+        
         assert_equal(len(fc_sft), 0)
         assert_array_equal(fc_ids, [])

--- a/scilpy/segment/tests/test_tractogram_from_roi.py
+++ b/scilpy/segment/tests/test_tractogram_from_roi.py
@@ -9,38 +9,77 @@ from numpy.testing import (assert_array_equal,
 from scilpy.segment.tractogram_from_roi import _extract_vb_one_bundle, _extract_ib_one_bundle
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
 
+
 def test_extract_vb_one_bundle():
-    # Testing extraction of VS corresponding to a bundle using 
+    # Testing extraction of VS corresponding to a bundle using
     # an empty tractogram which shouldn't raise any error.
-    fake_reference = nib.Nifti1Image(np.zeros((10, 10, 10, 1)), affine=np.eye(4))
-    empty_sft = StatefulTractogram([], fake_reference, Space.RASMM) # The Space type is not important here
+    fake_reference = nib.Nifti1Image(
+        np.zeros((10, 10, 10, 1)), affine=np.eye(4))
+    # The Space type is not important here
+    empty_sft = StatefulTractogram([], fake_reference, Space.RASMM)
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         fake_mask1_name = os.path.join(tmp_dir, 'fake_mask1.nii.gz')
         fake_mask2_name = os.path.join(tmp_dir, 'fake_mask2.nii.gz')
-        nib.save(nib.Nifti1Image(np.zeros((10, 10, 10)), affine=np.eye(4), dtype=np.int8), fake_mask1_name)
-        nib.save(nib.Nifti1Image(np.zeros((10, 10, 10)), affine=np.eye(4), dtype=np.int8), fake_mask2_name)
+        nib.save(
+            nib.Nifti1Image(
+                np.zeros(
+                    (10,
+                     10,
+                     10)),
+                affine=np.eye(4),
+                dtype=np.int8),
+            fake_mask1_name)
+        nib.save(
+            nib.Nifti1Image(
+                np.zeros(
+                    (10,
+                     10,
+                     10)),
+                affine=np.eye(4),
+                dtype=np.int8),
+            fake_mask2_name)
 
         vs_ids, wpc_ids, bundle_stats = _extract_vb_one_bundle(empty_sft, fake_mask1_name, fake_mask2_name,
-                                               None, None, None,
-                                               None, None, None, None)
+                                                               None, None, None,
+                                                               None, None, None, None)
         assert_array_equal(vs_ids, [])
         assert_array_equal(wpc_ids, [])
         assert_equal(bundle_stats["VS"], 0)
 
+
 def test_extract_ib_one_bundle():
-    # Testing extraction of IS corresponding to a bundle using 
+    # Testing extraction of IS corresponding to a bundle using
     # an empty tractogram which shouldn't raise any error.
-    fake_reference = nib.Nifti1Image(np.zeros((10, 10, 10, 1)), affine=np.eye(4))
-    empty_sft = StatefulTractogram([], fake_reference, Space.RASMM) # The Space type is not important here
+    fake_reference = nib.Nifti1Image(
+        np.zeros((10, 10, 10, 1)), affine=np.eye(4))
+    # The Space type is not important here
+    empty_sft = StatefulTractogram([], fake_reference, Space.RASMM)
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         fake_mask1_name = os.path.join(tmp_dir, 'fake_mask1.nii.gz')
         fake_mask2_name = os.path.join(tmp_dir, 'fake_mask2.nii.gz')
-        nib.save(nib.Nifti1Image(np.zeros((10, 10, 10)), affine=np.eye(4), dtype=np.int8), fake_mask1_name)
-        nib.save(nib.Nifti1Image(np.zeros((10, 10, 10)), affine=np.eye(4), dtype=np.int8), fake_mask2_name)
+        nib.save(
+            nib.Nifti1Image(
+                np.zeros(
+                    (10,
+                     10,
+                     10)),
+                affine=np.eye(4),
+                dtype=np.int8),
+            fake_mask1_name)
+        nib.save(
+            nib.Nifti1Image(
+                np.zeros(
+                    (10,
+                     10,
+                     10)),
+                affine=np.eye(4),
+                dtype=np.int8),
+            fake_mask2_name)
 
-        fc_sft, fc_ids = _extract_ib_one_bundle(empty_sft, fake_mask1_name, fake_mask2_name, None)
-        
+        fc_sft, fc_ids = _extract_ib_one_bundle(
+            empty_sft, fake_mask1_name, fake_mask2_name, None)
+
         assert_equal(len(fc_sft), 0)
         assert_array_equal(fc_ids, [])

--- a/scilpy/segment/tests/test_tractogram_from_roi.py
+++ b/scilpy/segment/tests/test_tractogram_from_roi.py
@@ -1,0 +1,45 @@
+import os
+import tempfile
+import nibabel as nib
+import numpy as np
+
+from numpy.testing import (assert_array_equal,
+                           assert_equal)
+
+from scilpy.segment.tractogram_from_roi import _extract_vb_one_bundle, _extract_ib_one_bundle
+from dipy.io.stateful_tractogram import Space, StatefulTractogram
+
+def test_extract_vb_one_bundle():
+    fake_reference = nib.Nifti1Image(np.zeros((10, 10, 10, 1)), affine=np.eye(4))
+    empty_sft = StatefulTractogram([], fake_reference, Space.RASMM) # The Space type is not important here
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        fake_mask1_name = os.path.join(tmp_dir, 'fake_mask1.nii.gz')
+        fake_mask2_name = os.path.join(tmp_dir, 'fake_mask2.nii.gz')
+        nib.save(nib.Nifti1Image(np.zeros((10, 10, 10)), affine=np.eye(4), dtype=np.int8), fake_mask1_name)
+        nib.save(nib.Nifti1Image(np.zeros((10, 10, 10)), affine=np.eye(4), dtype=np.int8), fake_mask2_name)
+
+        # Test extraction of a single bundle of empty streamlines.
+        # This should not raise any error.
+        vs_ids, wpc_ids, bundle_stats = _extract_vb_one_bundle(empty_sft, fake_mask1_name, fake_mask2_name,
+                                               None, None, None,
+                                               None, None, None, None)
+        assert_array_equal(vs_ids, [])
+        assert_array_equal(wpc_ids, [])
+        assert_equal(bundle_stats["VS"], 0)
+
+def test_extract_ib_one_bundle():
+    fake_reference = nib.Nifti1Image(np.zeros((10, 10, 10, 1)), affine=np.eye(4))
+    empty_sft = StatefulTractogram([], fake_reference, Space.RASMM) # The Space type is not important here
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        fake_mask1_name = os.path.join(tmp_dir, 'fake_mask1.nii.gz')
+        fake_mask2_name = os.path.join(tmp_dir, 'fake_mask2.nii.gz')
+        nib.save(nib.Nifti1Image(np.zeros((10, 10, 10)), affine=np.eye(4), dtype=np.int8), fake_mask1_name)
+        nib.save(nib.Nifti1Image(np.zeros((10, 10, 10)), affine=np.eye(4), dtype=np.int8), fake_mask2_name)
+
+        # Test extraction of a single bundle of empty streamlines.
+        # This should not raise any error.
+        fc_sft, fc_ids = _extract_ib_one_bundle(empty_sft, fake_mask1_name, fake_mask2_name, None)
+        assert_equal(len(fc_sft), 0)
+        assert_array_equal(fc_ids, [])

--- a/scilpy/segment/tests/test_tractogram_from_roi.py
+++ b/scilpy/segment/tests/test_tractogram_from_roi.py
@@ -6,7 +6,8 @@ import numpy as np
 from numpy.testing import (assert_array_equal,
                            assert_equal)
 
-from scilpy.segment.tractogram_from_roi import _extract_vb_one_bundle, _extract_ib_one_bundle
+from scilpy.segment.tractogram_from_roi import (_extract_vb_one_bundle,
+                                                _extract_ib_one_bundle)
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
 
 
@@ -21,28 +22,17 @@ def test_extract_vb_one_bundle():
     with tempfile.TemporaryDirectory() as tmp_dir:
         fake_mask1_name = os.path.join(tmp_dir, 'fake_mask1.nii.gz')
         fake_mask2_name = os.path.join(tmp_dir, 'fake_mask2.nii.gz')
-        nib.save(
-            nib.Nifti1Image(
-                np.zeros(
-                    (10,
-                     10,
-                     10)),
-                affine=np.eye(4),
-                dtype=np.int8),
-            fake_mask1_name)
-        nib.save(
-            nib.Nifti1Image(
-                np.zeros(
-                    (10,
-                     10,
-                     10)),
-                affine=np.eye(4),
-                dtype=np.int8),
-            fake_mask2_name)
+        nib.save(nib.Nifti1Image(np.zeros((10, 10, 10)),
+                 affine=np.eye(4), dtype=np.int8), fake_mask1_name)
+        nib.save(nib.Nifti1Image(np.zeros((10, 10, 10)),
+                 affine=np.eye(4), dtype=np.int8), fake_mask2_name)
 
-        vs_ids, wpc_ids, bundle_stats = _extract_vb_one_bundle(empty_sft, fake_mask1_name, fake_mask2_name,
-                                                               None, None, None,
-                                                               None, None, None, None)
+        vs_ids, wpc_ids, bundle_stats = \
+            _extract_vb_one_bundle(empty_sft,
+                                   fake_mask1_name,
+                                   fake_mask2_name,
+                                   None, None, None,
+                                   None, None, None, None)
         assert_array_equal(vs_ids, [])
         assert_array_equal(wpc_ids, [])
         assert_equal(bundle_stats["VS"], 0)
@@ -59,24 +49,10 @@ def test_extract_ib_one_bundle():
     with tempfile.TemporaryDirectory() as tmp_dir:
         fake_mask1_name = os.path.join(tmp_dir, 'fake_mask1.nii.gz')
         fake_mask2_name = os.path.join(tmp_dir, 'fake_mask2.nii.gz')
-        nib.save(
-            nib.Nifti1Image(
-                np.zeros(
-                    (10,
-                     10,
-                     10)),
-                affine=np.eye(4),
-                dtype=np.int8),
-            fake_mask1_name)
-        nib.save(
-            nib.Nifti1Image(
-                np.zeros(
-                    (10,
-                     10,
-                     10)),
-                affine=np.eye(4),
-                dtype=np.int8),
-            fake_mask2_name)
+        nib.save(nib.Nifti1Image(np.zeros((10, 10, 10)),
+                 affine=np.eye(4), dtype=np.int8), fake_mask1_name)
+        nib.save(nib.Nifti1Image(np.zeros((10, 10, 10)),
+                 affine=np.eye(4), dtype=np.int8), fake_mask2_name)
 
         fc_sft, fc_ids = _extract_ib_one_bundle(
             empty_sft, fake_mask1_name, fake_mask2_name, None)

--- a/scilpy/segment/tractogram_from_roi.py
+++ b/scilpy/segment/tractogram_from_roi.py
@@ -351,16 +351,16 @@ def _extract_vb_one_bundle(
     bundle_stats: dict
         Dictionary of recognized streamlines statistics
     """
-    mask_1_img = nib.load(head_filename)
-    mask_2_img = nib.load(tail_filename)
-    mask_1 = get_data_as_mask(mask_1_img)
-    mask_2 = get_data_as_mask(mask_2_img)
-
-    if dilate_endpoints:
-        mask_1 = binary_dilation(mask_1, iterations=dilate_endpoints)
-        mask_2 = binary_dilation(mask_2, iterations=dilate_endpoints)
-
     if len(sft) > 0:
+        mask_1_img = nib.load(head_filename)
+        mask_2_img = nib.load(tail_filename)
+        mask_1 = get_data_as_mask(mask_1_img)
+        mask_2 = get_data_as_mask(mask_2_img)
+
+        if dilate_endpoints:
+            mask_1 = binary_dilation(mask_1, iterations=dilate_endpoints)
+            mask_2 = binary_dilation(mask_2, iterations=dilate_endpoints)
+
         _, vs_ids = filter_grid_roi_both(sft, mask_1, mask_2)
     else:
         vs_ids = np.array([])
@@ -502,16 +502,16 @@ def _extract_ib_one_bundle(sft, mask_1_filename, mask_2_filename,
         SFT of remaining streamlines.
     """
 
-    mask_1_img = nib.load(mask_1_filename)
-    mask_2_img = nib.load(mask_2_filename)
-    mask_1 = get_data_as_mask(mask_1_img)
-    mask_2 = get_data_as_mask(mask_2_img)
-
-    if dilate_endpoints:
-        mask_1 = binary_dilation(mask_1, iterations=dilate_endpoints)
-        mask_2 = binary_dilation(mask_2, iterations=dilate_endpoints)
-
     if len(sft) > 0:
+        mask_1_img = nib.load(mask_1_filename)
+        mask_2_img = nib.load(mask_2_filename)
+        mask_1 = get_data_as_mask(mask_1_img)
+        mask_2 = get_data_as_mask(mask_2_img)
+
+        if dilate_endpoints:
+            mask_1 = binary_dilation(mask_1, iterations=dilate_endpoints)
+            mask_2 = binary_dilation(mask_2, iterations=dilate_endpoints)
+
         _, fc_ids = filter_grid_roi_both(sft, mask_1, mask_2)
     else:
         fc_ids = []

--- a/scilpy/segment/tractogram_from_roi.py
+++ b/scilpy/segment/tractogram_from_roi.py
@@ -360,7 +360,10 @@ def _extract_vb_one_bundle(
         mask_1 = binary_dilation(mask_1, iterations=dilate_endpoints)
         mask_2 = binary_dilation(mask_2, iterations=dilate_endpoints)
 
-    _, vs_ids = filter_grid_roi_both(sft, mask_1, mask_2)
+    if len(sft) > 0:
+        _, vs_ids = filter_grid_roi_both(sft, mask_1, mask_2)
+    else:
+        vs_ids = np.array([])
 
     wpc_ids = []
     bundle_stats = {"Initial count head to tail": len(vs_ids)}
@@ -508,7 +511,10 @@ def _extract_ib_one_bundle(sft, mask_1_filename, mask_2_filename,
         mask_1 = binary_dilation(mask_1, iterations=dilate_endpoints)
         mask_2 = binary_dilation(mask_2, iterations=dilate_endpoints)
 
-    _, fc_ids = filter_grid_roi_both(sft, mask_1, mask_2)
+    if len(sft) > 0:
+        _, fc_ids = filter_grid_roi_both(sft, mask_1, mask_2)
+    else:
+        fc_ids = []
 
     fc_sft = sft[fc_ids]
     return fc_sft, fc_ids


### PR DESCRIPTION
# Quick description

When using the _extract_vb_and_wpc_all_bundles function from the file `tractogram_from_roi.py`, there's a loop that updates and uses the **remaining_ids** list. While iterating over the bundles, it is possible that the list of remaining indices becomes empty thus creating an empty StatefulTractogram. This was causing some issues with the sub-function `filter_grid_roi_both` which internally was trying to transpose an empty matrix, which is invalid.

I added a quick check and some simple tests to make sure the sft provided as an input is not empty before filtering the streamlines w.r.t. the ROI.

## Type of change

Check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)
```pytest scilpy/segment/tests/test_tractogram_from_roi.py```

# Checklist

- [x] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [x] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
