### PR TITLE
Update to work with Trimeshpy 0.0.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ kiwisolver==1.4.*
 matplotlib==3.6.*
 nibabel==5.2.*
 nilearn==0.9.*
-numpy==1.23.*
+numpy==1.24.*
 openpyxl==3.0.*
 packaging == 23.2.*
 Pillow==10.2.*
@@ -39,9 +39,9 @@ pytz==2022.6.*
 requests==2.28.*
 scikit-learn==1.2.*
 scikit-image==0.22.*
-scipy==1.9.*
+scipy==1.10.*
 six==1.16.*
 spams==2.6.*
 statsmodels==0.13.*
-trimeshpy==0.0.3
+trimeshpy==0.0.4
 vtk==9.2.*

--- a/scripts/scil_tractogram_convert.py
+++ b/scripts/scil_tractogram_convert.py
@@ -81,7 +81,7 @@ def main():
         sft.streamlines = transform_streamlines(sft.streamlines,
                                                 transform)
         polydata = lines_to_vtk_polydata(sft.streamlines)
-        save_polydata(polydata, args.output_name, binary=False,
+        save_polydata(polydata, args.output_name, binary=True,
                       legacy_vtk_format=args.legacy_vtk)
 
 

--- a/scripts/scil_tractogram_convert.py
+++ b/scripts/scil_tractogram_convert.py
@@ -13,11 +13,14 @@ import logging
 import os
 
 from dipy.io.streamline import save_tractogram
+from dipy.tracking.streamline import transform_streamlines
+import numpy as np
 
 from scilpy.io.streamlines import load_tractogram_with_reference
 from scilpy.io.utils import (add_bbox_arg, add_overwrite_arg,
                              add_reference_arg, assert_inputs_exist,
                              assert_outputs_exist, add_verbose_arg)
+from trimeshpy.vtk_util import lines_to_vtk_polydata, save_polydata
 
 
 def _build_arg_parser():
@@ -31,6 +34,11 @@ def _build_arg_parser():
     p.add_argument('output_name',
                    help='Output filename. Format must be one of \n'
                         'trk, tck, vtk, fib, dpy')
+
+    p.add_argument('--legacy_vtk', action='store_true',
+                   help='Use the legacy VTK format for streamlines. '
+                        'This is the old VTK format, which is supported '
+                        'by MI-Brain.')
 
     add_bbox_arg(p)
     add_reference_arg(p)
@@ -50,13 +58,31 @@ def main():
     in_extension = os.path.splitext(args.in_tractogram)[1]
     out_extension = os.path.splitext(args.output_name)[1]
 
+    if out_extension not in ['.vtk', '.fib'] and args.legacy_vtk:
+        parser.error(
+            'The legacy VTK format is only available for VTK and FIB files')
+
     if in_extension == out_extension:
         parser.error('Input and output cannot be of the same file format')
 
     assert_outputs_exist(parser, args, args.output_name)
 
     sft = load_tractogram_with_reference(parser, args, args.in_tractogram)
-    save_tractogram(sft, args.output_name, bbox_valid_check=args.bbox_check)
+
+    if not args.legacy_vtk:
+        save_tractogram(sft, args.output_name,
+                        bbox_valid_check=args.bbox_check)
+    else:
+        # This is outside of StatefulTractogram because it is only useful for
+        # QC or debugging. Older VTK format is not supported by Dipy.
+        transform = np.eye(4)
+        transform[0, 0] = -1
+        transform[1, 1] = -1
+        sft.streamlines = transform_streamlines(sft.streamlines,
+                                                transform)
+        polydata = lines_to_vtk_polydata(sft.streamlines)
+        save_polydata(polydata, args.output_name, binary=False,
+                      legacy_vtk_format=args.legacy_vtk)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Quick description

Allows user to save the good old VTK/FIB format in MI-Brain, similar logic to Stanislas PR for legacy surfaces, now for tractograms.
...

## Type of change

Check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [x] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
