### PR TITLE
[ENH] Bundle fixel analysis script

### DIFF
--- a/scilpy/tractanalysis/fixel_density.py
+++ b/scilpy/tractanalysis/fixel_density.py
@@ -55,7 +55,8 @@ def _fixel_density_parallel(args):
     return fixel_density_maps
 
 
-def fixel_density(peaks, bundles, dps_key=None, max_theta=45, nbr_processes=None):
+def fixel_density(peaks, bundles, dps_key=None, max_theta=45,
+                  nbr_processes=None):
     """Compute the fixel density map per bundle. Can use parallel processing.
 
     Parameters
@@ -103,9 +104,9 @@ def maps_to_masks(maps, abs_thr, rel_thr, norm, nb_bundles):
     ----------
     maps : np.ndarray (x, y, z, 5, N)
         Density per fixel per bundle.
-    abs_thr : int
+    abs_thr : float
         Value of density maps threshold to obtain density masks, in number of
-        streamlines.
+        streamlines or streamline weighting.
     rel_thr : float
         Value of density maps threshold to obtain density masks, as a ratio of
         the normalized density. Must be between 0 and 1.
@@ -123,7 +124,7 @@ def maps_to_masks(maps, abs_thr, rel_thr, norm, nb_bundles):
         Normalized density maps per fixel per bundle.
     """
     # Apply a threshold on the number of streamlines
-    masks_abs = maps >= abs_thr
+    masks_abs = maps > abs_thr
 
     # Normalizing the density maps per voxel or fixel
     fixel_sum = np.sum(maps, axis=-1)
@@ -139,7 +140,7 @@ def maps_to_masks(maps, abs_thr, rel_thr, norm, nb_bundles):
             maps[..., i] /= fixel_sum
 
     # Apply a threshold on the normalized density
-    masks_rel = maps >= rel_thr
+    masks_rel = maps > rel_thr
     # Compute the fixel density masks from the rel and abs versions
     masks = masks_rel * masks_abs
 

--- a/scilpy/tractanalysis/fixel_density.py
+++ b/scilpy/tractanalysis/fixel_density.py
@@ -1,0 +1,88 @@
+import itertools
+import multiprocessing
+import numpy as np
+
+from dipy.io.streamline import load_tractogram
+from scilpy.tractanalysis.grid_intersections import grid_intersections
+
+
+def _compute_fixel_density_parallel(args):
+    peaks = args[0]
+    max_theta = args[1]
+    bundle = args[2]
+
+    sft = load_tractogram(bundle, 'same')
+    sft.to_vox()
+    sft.to_corner()
+
+    fixel_density_maps = np.zeros((peaks.shape[:-1]) + (5,))
+
+    min_cos_theta = np.cos(np.radians(max_theta))
+
+    all_crossed_indices = grid_intersections(sft.streamlines)
+    for crossed_indices in all_crossed_indices:
+        segments = crossed_indices[1:] - crossed_indices[:-1]
+        seg_lengths = np.linalg.norm(segments, axis=1)
+
+        # Remove points where the segment is zero.
+        # This removes numpy warnings of division by zero.
+        non_zero_lengths = np.nonzero(seg_lengths)[0]
+        segments = segments[non_zero_lengths]
+        seg_lengths = seg_lengths[non_zero_lengths]
+
+        # Those starting points are used for the segment vox_idx computations
+        seg_start = crossed_indices[non_zero_lengths]
+        vox_indices = (seg_start + (0.5 * segments)).astype(int)
+
+        normalized_seg = np.reshape(segments / seg_lengths[..., None], (-1, 3))
+
+        for vox_idx, seg_dir in zip(vox_indices, normalized_seg):
+            vox_idx = tuple(vox_idx)
+            peaks_at_idx = peaks[vox_idx].reshape((5, 3))
+
+            cos_theta = np.abs(np.dot(seg_dir.reshape((-1, 3)),
+                                      peaks_at_idx.T))
+
+            if (cos_theta > min_cos_theta).any():
+                lobe_idx = np.argmax(np.squeeze(cos_theta), axis=0)  # (n_segs)
+                # TODO Change that for commit weight if given
+                fixel_density_maps[vox_idx][lobe_idx] += 1
+
+    return fixel_density_maps
+
+
+def compute_fixel_density(peaks, bundles, max_theta=45, nbr_processes=None):
+    """Compute the fixel density per bundle. Can use parallel processing.
+
+    Parameters
+    ----------
+    peaks: np.ndarray (x, y, z, 15)
+        Five principal fiber orientations for each voxel.
+    bundles : list or np.array (N)
+        List of (N) paths to bundles.
+    max_theta : int, optional
+        Maximum angle between streamline and peak to be associated.
+    nbr_processes : int, optional
+        The number of subprocesses to use.
+        Default: multiprocessing.cpu_count()
+
+    Returns
+    -------
+    fixel_density : np.ndarray (x, y, z, 5, N)
+        Density per fixel per bundle.
+    """
+    nbr_processes = multiprocessing.cpu_count() \
+        if nbr_processes is None or nbr_processes <= 0 \
+        else nbr_processes
+
+    pool = multiprocessing.Pool(nbr_processes)
+    results = pool.map(_compute_fixel_density_parallel,
+                       zip(itertools.repeat(peaks),
+                           itertools.repeat(max_theta),
+                           bundles))
+    pool.close()
+    pool.join()
+
+    fixel_density = np.moveaxis(np.asarray(results), 0, -1)
+
+    return fixel_density

--- a/scilpy/tractanalysis/fixel_density.py
+++ b/scilpy/tractanalysis/fixel_density.py
@@ -111,6 +111,8 @@ def maps_to_masks(maps, abs_thr, rel_thr, norm, nb_bundles):
     -------
     masks : np.ndarray (x, y, z, 5, N)
         Density masks per fixel per bundle.
+    maps : np.ndarray (x, y, z, 5, N)
+        Normalized density maps per fixel per bundle.
     """
     # Apply a threshold on the number of streamlines
     masks_abs = maps >= abs_thr
@@ -133,4 +135,4 @@ def maps_to_masks(maps, abs_thr, rel_thr, norm, nb_bundles):
     # Compute the fixel density masks from the rel and abs versions
     masks = masks_rel * masks_abs
 
-    return masks.astype(np.uint8)
+    return masks.astype(np.uint8), maps

--- a/scilpy/tractanalysis/fixel_density.py
+++ b/scilpy/tractanalysis/fixel_density.py
@@ -128,7 +128,7 @@ def maps_to_masks(maps, abs_thr, rel_thr, norm, nb_bundles):
         elif norm == "fixel":
             maps[..., i] /= fixel_sum
 
-    # Apply a threshold on the normalized density (percentage)
+    # Apply a threshold on the normalized density
     masks_rel = maps >= rel_thr
     # Compute the fixel density masks from the rel and abs versions
     masks = masks_rel * masks_abs

--- a/scilpy/tractanalysis/tests/test_fixel_density.py
+++ b/scilpy/tractanalysis/tests/test_fixel_density.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+
+
+def test_fixel_density():
+    # toDO
+    pass
+
+
+def test_maps_to_masks():
+    # toDO
+    pass

--- a/scripts/scil_bundle_fixel_analysis.py
+++ b/scripts/scil_bundle_fixel_analysis.py
@@ -148,7 +148,7 @@ def _build_arg_parser():
                         'masks as well. \nThese are obtained by '
                         'selecting the voxels where only one bundle is '
                         'present \n(and one fiber/fixel).')
-    
+
     p.add_argument('--bundles_mask', action='store_true',
                    help='If set, save the bundle mask for each bundle.')
 

--- a/scripts/scil_bundle_fixel_analysis.py
+++ b/scripts/scil_bundle_fixel_analysis.py
@@ -137,11 +137,11 @@ def _build_arg_parser():
 
     p.add_argument('--split_bundles', action='store_true',
                    help='If set, save the density maps for each bundle '
-                        'separately \ninstead of all in one file.')
+                        'separately \nin addition to the all in one version.')
 
     p.add_argument('--split_fixels', action='store_true',
                    help='If set, save the density maps for each fixel '
-                        'separately \ninstead of all in one file.')
+                        'separately \nin addition to the all in one version.')
 
     p.add_argument('--single_bundle', action='store_true',
                    help='If set, will save the single-fiber single-bundle '

--- a/scripts/scil_bundle_fixel_analysis.py
+++ b/scripts/scil_bundle_fixel_analysis.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Analyze bundles at the fixel level, producing various results:
+
+-
+-
+-
+
+"""
+
+import argparse
+import nibabel as nib
+import numpy as np
+from pathlib import Path
+
+from scilpy.io.utils import (add_overwrite_arg, add_processes_arg,
+                             add_reference_arg)
+from scilpy.tractanalysis.fixel_density import compute_fixel_density
+
+
+def _build_arg_parser():
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+    p.add_argument('in_peaks',
+                   help='Path of the fODF peaks. The peaks are expected to be '
+                        'given as unit directions.')
+    p.add_argument('out_folder',
+                   help='Path of the output folder for txt, png, masks and '
+                        'measures.')
+
+    p.add_argument('--in_bundles', nargs='+', default=[],
+                   action='append', required=True,
+                   help='Path to the bundle trk for where to analyze.')
+
+    p.add_argument('--abs_thr', default=1, type=int,
+                   help='Value of density maps threshold to obtain density '
+                        'masks, in number of streamlines. Any number of '
+                        'streamlines above or equal to this value will pass '
+                        'the absolute threshold test [%(default)s].')
+
+    p.add_argument('--rel_thr', default=0.01, type=float,
+                   help='Value of density maps threshold to obtain density '
+                        'masks, as a ratio of the normalized density. Any '
+                        'normalized density above or equal to this value will '
+                        'pass the relative threshold test [%(default)s].')
+
+    p.add_argument('--max_theta', default=45,
+                   help='Maximum angle between streamline and peak to be '
+                        'associated [%(default)s].')
+
+    p.add_argument('--separate_bundles', action='store_true',
+                   help='If set, save the density maps for each bundle '
+                        'separately instead of all in one file.')
+
+    p.add_argument('--save_masks', action='store_true',
+                   help='If set, save the density masks for each bundle.')
+
+    p.add_argument('--select_single_bundle', action='store_true',
+                   help='If set, select the voxels where only one bundle is '
+                        'present and save the corresponding masks '
+                        '(if save_masks), separated by bundles.')
+
+    p.add_argument('--norm', default="voxel", choices=["fixel", "voxel"],
+                   help='Way of normalizing the density maps. If fixel, '
+                        'will normalize the maps per fixel, in each voxel. '
+                        'If voxel, will normalize the maps per voxel. '
+                        '[%(default)s].')
+
+    add_overwrite_arg(p)
+    add_processes_arg(p)
+    add_reference_arg(p)
+    return p
+
+
+def main():
+    parser = _build_arg_parser()
+    args = parser.parse_args()
+
+    out_folder = Path(args.out_folder)
+
+    # Load the data
+    peaks_img = nib.load(args.in_peaks)
+    peaks = peaks_img.get_fdata()
+    affine = peaks_img.affine
+
+    # Compute NuFo SF from peaks
+    if args.select_single_bundle:
+        is_first_peak = np.sum(peaks[..., 0:3], axis=-1) != 0
+        is_second_peak = np.sum(peaks[..., 3:6], axis=-1) == 0
+        nufo_sf = np.logical_and(is_first_peak, is_second_peak)
+
+    bundles = []
+    bundles_names = []
+    for bundle in args.in_bundles[0]:
+        bundles.append(bundle)
+        bundles_names.append(Path(bundle).name.split(".")[0])
+
+    fixel_density_maps = compute_fixel_density(peaks, bundles, args.max_theta,
+                                               nbr_processes=args.nbr_processes)
+
+    # This applies a threshold on the number of streamlines.
+    fixel_density_masks_abs = fixel_density_maps >= args.abs_thr
+
+    # Normalizing the density maps
+    fixel_sum = np.sum(fixel_density_maps, axis=-1)
+    voxel_sum = np.sum(fixel_sum, axis=-1)
+
+    for i, (bundle, bundle_name) in enumerate(zip(bundles, bundles_names)):
+
+        if args.norm == "voxel":
+            fixel_density_maps[..., 0, i] /= voxel_sum
+            fixel_density_maps[..., 1, i] /= voxel_sum
+            fixel_density_maps[..., 2, i] /= voxel_sum
+            fixel_density_maps[..., 3, i] /= voxel_sum
+            fixel_density_maps[..., 4, i] /= voxel_sum
+
+        elif args.norm == "fixel":
+            fixel_density_maps[..., i] /= fixel_sum
+
+        if args.separate_bundles:
+            nib.save(nib.Nifti1Image(fixel_density_maps[..., i], affine),
+                     out_folder / "fixel_density_map_{}.nii.gz".format(bundle_name))
+
+    if not args.separate_bundles:
+        nib.save(nib.Nifti1Image(fixel_density_maps, affine),
+                 out_folder / "fixel_density_maps.nii.gz")
+        bundles_idx = np.arange(0, len(bundles_names), 1)
+        lookup_table = np.array([bundles_names, bundles_idx])
+        np.savetxt(out_folder / "bundles_lookup_table.txt",
+                   lookup_table, fmt='%s')
+
+    # This applies a threshold on the normalized density (percentage)
+    fixel_density_masks_rel = fixel_density_maps >= args.rel_thr
+
+    # Compute the fixel density masks from the rel and abs versions
+    fixel_density_masks = fixel_density_masks_rel * fixel_density_masks_abs
+
+    # Compute number of bundles per fixel
+    nb_bundles_per_fixel = np.sum(fixel_density_masks, axis=-1)
+    # Compute a mask of the present of each bundle
+    nb_unique_bundles_per_fixel = np.where(np.sum(fixel_density_masks,
+                                                  axis=-2) > 0, 1, 0)
+    # Compute number of bundles per fixel by taking the sum of the mask
+    nb_bundles_per_voxel = np.sum(nb_unique_bundles_per_fixel, axis=-1)
+
+    if args.save_masks:
+        for i, (bundle, bundle_name) in enumerate(zip(bundles, bundles_names)):
+
+            if args.separate_bundles:
+                nib.save(nib.Nifti1Image(fixel_density_masks[..., i].astype(np.uint8), affine),
+                         out_folder / "fixel_density_mask_{}.nii.gz".format(bundle_name))
+
+            if args.select_single_bundle:
+                # Single-fiber single-bundle voxels
+                single_bundle_per_voxel = nb_bundles_per_voxel == 1
+                # Making sure we also have single-fiber voxels only
+                single_bundle_per_voxel *= nufo_sf
+
+                nib.save(nib.Nifti1Image(single_bundle_per_voxel.astype(np.uint8),
+                                         affine),
+                         out_folder / "bundle_mask_only_WM.nii.gz")
+
+                bundle_mask = fixel_density_masks[..., 0, i] * single_bundle_per_voxel
+                nib.save(nib.Nifti1Image(bundle_mask.astype(np.uint8), affine),
+                         out_folder / "bundle_mask_only_{}.nii.gz".format(bundle_name))
+
+        if not args.separate_bundles:
+            nib.save(nib.Nifti1Image(fixel_density_masks.astype(np.uint8),
+                                     affine),
+                     out_folder / "fixel_density_masks.nii.gz")
+
+    nib.save(nib.Nifti1Image(nb_bundles_per_fixel.astype(np.uint8),
+             affine), out_folder / "nb_bundles_per_fixel.nii.gz")
+
+    nib.save(nib.Nifti1Image(nb_bundles_per_voxel.astype(np.uint8),
+             affine), out_folder / "nb_bundles_per_voxel.nii.gz")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/scil_bundle_fixel_analysis.py
+++ b/scripts/scil_bundle_fixel_analysis.py
@@ -199,8 +199,8 @@ def main():
         out_dir += "/"
 
     assert_output_dirs_exist_and_empty(parser, args, out_dir, create_dir=True)
-    assert_inputs_exist(parser, [args.in_peaks] + args.in_bundles[0])
-    assert_headers_compatible(parser, [args.in_peaks] + args.in_bundles[0])
+    assert_inputs_exist(parser, [args.in_peaks] + args.in_bundles)
+    assert_headers_compatible(parser, [args.in_peaks] + args.in_bundles)
 
     if args.rel_thr < 0 or args.rel_thr > 1:
         parser.error("Argument rel_thr must be a value between 0 and 1.")

--- a/scripts/scil_bundle_fixel_analysis.py
+++ b/scripts/scil_bundle_fixel_analysis.py
@@ -100,10 +100,10 @@ def _build_arg_parser():
                         'or SH data, use the script scil_fodf_metrics.py '
                         '\nwith the abs_peaks_and_values option.')
 
-    p.add_argument('--in_bundles', nargs='+', action='append', required=True,
+    p.add_argument('--in_bundles', nargs='+', required=True,
                    help='List of paths of the bundles (.trk) to analyze.')
 
-    p.add_argument('--in_bundles_names', nargs='+', action='append',
+    p.add_argument('--in_bundles_names', nargs='+',
                    help='List of the names of the bundles, in the same order '
                         'as they were given. \nIf this argument is not used, '
                         'the script assumes that the name of the bundle \nis '
@@ -184,14 +184,14 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
-    assert_inputs_exist(parser, [args.in_peaks] + args.in_bundles[0])
+    assert_inputs_exist(parser, [args.in_peaks] + args.in_bundles)
     assert_outputs_exist(parser, args, ["bundles_LUT.txt",
                                         "fixel_density_maps.nii.gz",
                                         "fixel_density_masks.nii.gz",
                                         "voxel_density_masks.nii.gz",
                                         "nb_bundles_per_fixel.nii.gz",
                                         "nb_bundles_per_voxel.nii.gz"])
-    assert_headers_compatible(parser, [args.in_peaks] + args.in_bundles[0])
+    assert_headers_compatible(parser, [args.in_peaks] + args.in_bundles)
 
     if args.rel_thr < 0 or args.rel_thr > 1:
         parser.error("Argument rel_thr must be a value between 0 and 1.")
@@ -209,12 +209,12 @@ def main():
         nufo_sf = np.logical_and(is_first_peak, is_second_peak)
 
     # Extract bundles and names
-    bundles = args.in_bundles[0]
+    bundles = args.in_bundles
     if args.in_bundles_names:  # If names are given
-        if len(args.in_bundles_names[0]) != len(bundles):
+        if len(args.in_bundles_names) != len(bundles):
             parser.error("--in_bundles_names must contain the same number of "
                          "elements as in --in_bundles.")
-        bundles_names = args.in_bundles_names[0]
+        bundles_names = args.in_bundles_names
     else:
         logging.info("Extracting bundles names.")
         bundles_names = []

--- a/scripts/scil_bundle_fixel_analysis.py
+++ b/scripts/scil_bundle_fixel_analysis.py
@@ -23,7 +23,7 @@ The script produces various output:
       the sum over a voxel will be higher than 1 (except in the single-fiber
       case). The density maps can be computed using the streamline count, or
       any streamline weighting like COMMIT or SIF, through the
-      data_per_streamline.
+      data_per_streamline using the --dps_key argument.
     
     - fixel_density_masks.nii.gz : np.ndarray (x, y, z, 5, N)
       For each voxel, it gives whether or not each bundle is associated
@@ -72,7 +72,6 @@ The script produces various output:
     be one single_bundle_mask_{bundle_name}.nii.gz per bundle, and a whole WM
     version single_bundle_mask_WM.nii.gz.
     These will have the shape (x, y, z).
-
 """
 
 import argparse
@@ -104,6 +103,11 @@ def _build_arg_parser():
                         'as they were given. \nIf this argument is not used, '
                         'the script assumes that the name of the bundle \nis '
                         'its filename without extensions.')
+    
+    p.add_argument('--dps_key', default=None,
+                   help='Key to access the data per streamline to use as '
+                        'weight when computing the maps, \ninstead of the '
+                        'number of streamlines. [%(default)s].')
 
     g = p.add_argument_group(title='Mask parameters')
 
@@ -188,7 +192,8 @@ def main():
         bundles_names = args.in_bundles_names[0]
 
     # Compute fixel density maps and masks
-    fixel_density_maps = fixel_density(peaks, bundles, args.max_theta,
+    fixel_density_maps = fixel_density(peaks, bundles, args.dps_key,
+                                       args.max_theta,
                                        nbr_processes=args.nbr_processes)
 
     fixel_density_masks, fixel_density_maps = maps_to_masks(fixel_density_maps,

--- a/scripts/scil_bundle_fixel_analysis.py
+++ b/scripts/scil_bundle_fixel_analysis.py
@@ -165,13 +165,13 @@ def _build_arg_parser():
     
     g2.add_argument('--prefix', default="",
                     help='Prefix to add to all predetermined output '
-                         'filenames. We recommand finishing with an '
+                         'filenames. \nWe recommand finishing with an '
                          'underscore for better readability [%(default)s].')
     
     g2.add_argument('--suffix', default="",
                     help='Suffix to add to all predetermined output '
-                         'filenames. We recommand starting with an underscore '
-                         'for better readability [%(default)s].')
+                         'filenames. \nWe recommand starting with an '
+                         'underscore for better readability [%(default)s].')
 
     add_overwrite_arg(p)
     add_processes_arg(p)
@@ -209,17 +209,17 @@ def main():
         nufo_sf = np.logical_and(is_first_peak, is_second_peak)
 
     # Extract bundles and names
-    logging.info("Extracting bundles.")
-    bundles = []
-    bundles_names = []
-    for bundle in args.in_bundles[0]:
-        bundles.append(bundle)
-        bundles_names.append(Path(bundle).name.split(".")[0])
+    bundles = args.in_bundles[0]
     if args.in_bundles_names:  # If names are given
-        if len(args.in_bundles_names) != len(bundles):
-            parser.error("""--in_bundles_names must contain the same number of
-                         element as in --in_bundles.""")
+        if len(args.in_bundles_names[0]) != len(bundles):
+            parser.error("--in_bundles_names must contain the same number of "
+                         "elements as in --in_bundles.")
         bundles_names = args.in_bundles_names[0]
+    else:
+      logging.info("Extracting bundles names.")
+      bundles_names = []
+      for bundle in bundles:
+          bundles_names.append(Path(bundle).name.split(".")[0])
 
     # Set up saving filename options
     out_dir = args.out_dir

--- a/scripts/scil_bundle_fixel_analysis.py
+++ b/scripts/scil_bundle_fixel_analysis.py
@@ -148,6 +148,9 @@ def _build_arg_parser():
                         'masks as well. \nThese are obtained by '
                         'selecting the voxels where only one bundle is '
                         'present \n(and one fiber/fixel).')
+    
+    p.add_argument('--bundles_mask', action='store_true',
+                   help='If set, save the bundle mask for each bundle.')
 
     add_overwrite_arg(p)
     add_processes_arg(p)
@@ -222,6 +225,12 @@ def main():
                      "fixel_density_map_{}.nii.gz".format(bundle_name))
             nib.save(nib.Nifti1Image(fixel_density_masks[..., i], affine),
                      "fixel_density_mask_{}.nii.gz".format(bundle_name))
+            if args.norm == "voxel":  # If fixel, voxel maps mean nothing
+                nib.save(nib.Nifti1Image(voxel_density_maps[..., i], affine),
+                         "voxel_density_map_{}.nii.gz".format(bundle_name))
+            bundle_mask = voxel_density_masks[..., i].astype(np.uint8)
+            nib.save(nib.Nifti1Image(bundle_mask, affine),
+                     "voxel_density_mask_{}.nii.gz".format(bundle_name))
 
         if args.single_bundle:
             # Single-fiber single-bundle voxels
@@ -243,6 +252,13 @@ def main():
                      "fixel_density_map_f{}.nii.gz".format(i + 1))
             nib.save(nib.Nifti1Image(fixel_density_masks[..., i, :], affine),
                      "fixel_density_mask_f{}.nii.gz".format(i + 1))
+            if args.norm == "voxel":  # If fixel, voxel maps mean nothing
+                nib.save(nib.Nifti1Image(voxel_density_maps[..., i, :],
+                                         affine),
+                         "voxel_density_map_f{}.nii.gz".format(i + 1))
+            bundle_mask = voxel_density_masks[..., i, :].astype(np.uint8)
+            nib.save(nib.Nifti1Image(bundle_mask, affine),
+                     "voxel_density_mask_f{}.nii.gz".format(i + 1))
 
     # Save bundles lookup table to know the order of the bundles
     bundles_idx = np.arange(0, len(bundles_names), 1)
@@ -258,7 +274,7 @@ def main():
              "fixel_density_masks.nii.gz")
 
     # Save full voxel density maps and masks
-    if args.norm == "voxel":  # If fixel, the voxel maps do not mean anything
+    if args.norm == "voxel":  # If fixel, voxel maps mean nothing
         nib.save(nib.Nifti1Image(voxel_density_maps, affine),
                  "voxel_density_maps.nii.gz")
     nib.save(nib.Nifti1Image(voxel_density_masks.astype(np.uint8), affine),

--- a/scripts/scil_bundle_fixel_analysis.py
+++ b/scripts/scil_bundle_fixel_analysis.py
@@ -113,7 +113,7 @@ def _build_arg_parser():
                    help='Key to access the data per streamline to use as '
                         'weight when computing the maps, \ninstead of the '
                         'number of streamlines. [%(default)s].')
-    
+
     p.add_argument('--max_theta', default=45,
                    help='Maximum angle between streamline and peak to be '
                         'associated [%(default)s].')
@@ -139,7 +139,7 @@ def _build_arg_parser():
                          'will normalize the maps per fixel, \nin each voxel. '
                          'If voxel, will normalize the maps per voxel '
                          '[%(default)s].')
-    
+
     g2 = p.add_argument_group(title='Output options')
 
     g2.add_argument('--split_bundles', action='store_true',
@@ -158,16 +158,16 @@ def _build_arg_parser():
 
     g2.add_argument('--bundles_mask', action='store_true',
                     help='If set, save the bundle mask for each bundle.')
-    
+
     g2.add_argument('--out_dir', default="./",
                     help='Path to the output directory where all the output '
                          'files will be saved [%(default)s].')
-    
+
     g2.add_argument('--prefix', default="",
                     help='Prefix to add to all predetermined output '
                          'filenames. \nWe recommand finishing with an '
                          'underscore for better readability [%(default)s].')
-    
+
     g2.add_argument('--suffix', default="",
                     help='Suffix to add to all predetermined output '
                          'filenames. \nWe recommand starting with an '
@@ -216,10 +216,10 @@ def main():
                          "elements as in --in_bundles.")
         bundles_names = args.in_bundles_names[0]
     else:
-      logging.info("Extracting bundles names.")
-      bundles_names = []
-      for bundle in bundles:
-          bundles_names.append(Path(bundle).name.split(".")[0])
+        logging.info("Extracting bundles names.")
+        bundles_names = []
+        for bundle in bundles:
+            bundles_names.append(Path(bundle).name.split(".")[0])
 
     # Set up saving filename options
     out_dir = args.out_dir

--- a/scripts/scil_bundle_fixel_analysis.py
+++ b/scripts/scil_bundle_fixel_analysis.py
@@ -89,8 +89,8 @@ def main():
     peaks = peaks_img.get_fdata()
     affine = peaks_img.affine
 
-    # Compute NuFo SF from peaks
-    if args.select_single_bundle:
+    # Compute NuFo single-fiber from peaks
+    if args.single_bundle:
         is_first_peak = np.sum(peaks[..., 0:3], axis=-1) != 0
         is_second_peak = np.sum(peaks[..., 3:6], axis=-1) == 0
         nufo_sf = np.logical_and(is_first_peak, is_second_peak)
@@ -101,7 +101,7 @@ def main():
     for bundle in args.in_bundles[0]:
         bundles.append(bundle)
         bundles_names.append(Path(bundle).name.split(".")[0])
-    if args.in_bundles_names[0] != []: # If names are given
+    if args.in_bundles_names: # If names are given
         bundles_names = args.in_bundles_names[0]
 
     # Compute fixel density maps and masks

--- a/scripts/scil_bundle_fixel_analysis.py
+++ b/scripts/scil_bundle_fixel_analysis.py
@@ -14,70 +14,75 @@ import nibabel as nib
 import numpy as np
 from pathlib import Path
 
-from scilpy.io.utils import (add_overwrite_arg, add_processes_arg,
-                             add_reference_arg)
-from scilpy.tractanalysis.fixel_density import compute_fixel_density
+from scilpy.io.utils import (add_overwrite_arg, add_processes_arg)
+from scilpy.tractanalysis.fixel_density import (fixel_density, maps_to_masks)
 
 
 def _build_arg_parser():
     p = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
     p.add_argument('in_peaks',
-                   help='Path of the fODF peaks. The peaks are expected to be '
-                        'given as unit directions.')
-    p.add_argument('out_folder',
-                   help='Path of the output folder for txt, png, masks and '
-                        'measures.')
+                   help='Path of the peaks. The peaks are expected to be '
+                        'given as unit directions. \nTo get these from fODF '
+                        'or SH data, use the script scil_fodf_metrics.py '
+                        '\nwith the abs_peaks_and_values option.')
 
-    p.add_argument('--in_bundles', nargs='+', default=[],
-                   action='append', required=True,
-                   help='Path to the bundle trk for where to analyze.')
+    p.add_argument('--in_bundles', nargs='+', action='append', required=True,
+                   help='List of paths of the bundles (.trk) to analyze.')
 
-    p.add_argument('--abs_thr', default=1, type=int,
+    p.add_argument('--in_bundles_names', nargs='+', action='append',
+                   help='List of the names of the bundles, in the same order '
+                        'as they were given. \nIf this argument is not used, '
+                        'the script assumes that the name of the bundle \nis '
+                        'its filename without extensions.')
+
+    g = p.add_argument_group(title='Mask parameters')
+
+    g.add_argument('--abs_thr', default=1, type=int,
                    help='Value of density maps threshold to obtain density '
-                        'masks, in number of streamlines. Any number of '
-                        'streamlines above or equal to this value will pass '
+                        'masks, in number of streamlines. \nAny number of '
+                        'streamlines above or equal this value will pass '
                         'the absolute threshold test [%(default)s].')
 
-    p.add_argument('--rel_thr', default=0.01, type=float,
+    g.add_argument('--rel_thr', default=0.01, type=float,
                    help='Value of density maps threshold to obtain density '
-                        'masks, as a ratio of the normalized density. Any '
-                        'normalized density above or equal to this value will '
-                        'pass the relative threshold test [%(default)s].')
+                        'masks, as a ratio of the normalized density '
+                        '\nAny normalized density above or equal to '
+                        'this value will pass the relative threshold test. '
+                        '\nMust be between 0 and 1 [%(default)s].')
+    
+    g.add_argument('--norm', default="voxel", choices=["fixel", "voxel"],
+                   help='Way of normalizing the density maps. If fixel, '
+                        'will normalize the maps per fixel, \nin each voxel. '
+                        'If voxel, will normalize the maps per voxel. '
+                        '[%(default)s]')
 
     p.add_argument('--max_theta', default=45,
                    help='Maximum angle between streamline and peak to be '
                         'associated [%(default)s].')
 
-    p.add_argument('--separate_bundles', action='store_true',
+    p.add_argument('--split_bundles', action='store_true',
                    help='If set, save the density maps for each bundle '
-                        'separately instead of all in one file.')
+                        'separately \ninstead of all in one file.')
 
-    p.add_argument('--save_masks', action='store_true',
-                   help='If set, save the density masks for each bundle.')
+    p.add_argument('--split_fixels', action='store_true',
+                   help='If set, save the density maps for each fixel '
+                        'separately \ninstead of all in one file.')
 
-    p.add_argument('--select_single_bundle', action='store_true',
-                   help='If set, select the voxels where only one bundle is '
-                        'present and save the corresponding masks '
-                        '(if save_masks), separated by bundles.')
-
-    p.add_argument('--norm', default="voxel", choices=["fixel", "voxel"],
-                   help='Way of normalizing the density maps. If fixel, '
-                        'will normalize the maps per fixel, in each voxel. '
-                        'If voxel, will normalize the maps per voxel. '
-                        '[%(default)s].')
+    p.add_argument('--single_bundle', action='store_true',
+                   help='If set, will save the single-fiber single-bundle '
+                        'masks as well. \nThese are obtained by '
+                        'selecting the voxels where only one bundle is '
+                        'present \n(and one fiber/fixel).')
 
     add_overwrite_arg(p)
     add_processes_arg(p)
-    add_reference_arg(p)
     return p
 
 
 def main():
     parser = _build_arg_parser()
     args = parser.parse_args()
-
-    out_folder = Path(args.out_folder)
 
     # Load the data
     peaks_img = nib.load(args.in_peaks)
@@ -90,91 +95,81 @@ def main():
         is_second_peak = np.sum(peaks[..., 3:6], axis=-1) == 0
         nufo_sf = np.logical_and(is_first_peak, is_second_peak)
 
+    # Extract bundles and names
     bundles = []
     bundles_names = []
     for bundle in args.in_bundles[0]:
         bundles.append(bundle)
         bundles_names.append(Path(bundle).name.split(".")[0])
+    if args.in_bundles_names[0] != []: # If names are given
+        bundles_names = args.in_bundles_names[0]
 
-    fixel_density_maps = compute_fixel_density(peaks, bundles, args.max_theta,
-                                               nbr_processes=args.nbr_processes)
-
-    # This applies a threshold on the number of streamlines.
-    fixel_density_masks_abs = fixel_density_maps >= args.abs_thr
-
-    # Normalizing the density maps
-    fixel_sum = np.sum(fixel_density_maps, axis=-1)
-    voxel_sum = np.sum(fixel_sum, axis=-1)
-
-    for i, (bundle, bundle_name) in enumerate(zip(bundles, bundles_names)):
-
-        if args.norm == "voxel":
-            fixel_density_maps[..., 0, i] /= voxel_sum
-            fixel_density_maps[..., 1, i] /= voxel_sum
-            fixel_density_maps[..., 2, i] /= voxel_sum
-            fixel_density_maps[..., 3, i] /= voxel_sum
-            fixel_density_maps[..., 4, i] /= voxel_sum
-
-        elif args.norm == "fixel":
-            fixel_density_maps[..., i] /= fixel_sum
-
-        if args.separate_bundles:
-            nib.save(nib.Nifti1Image(fixel_density_maps[..., i], affine),
-                     out_folder / "fixel_density_map_{}.nii.gz".format(bundle_name))
-
-    if not args.separate_bundles:
-        nib.save(nib.Nifti1Image(fixel_density_maps, affine),
-                 out_folder / "fixel_density_maps.nii.gz")
-        bundles_idx = np.arange(0, len(bundles_names), 1)
-        lookup_table = np.array([bundles_names, bundles_idx])
-        np.savetxt(out_folder / "bundles_lookup_table.txt",
-                   lookup_table, fmt='%s')
-
-    # This applies a threshold on the normalized density (percentage)
-    fixel_density_masks_rel = fixel_density_maps >= args.rel_thr
-
-    # Compute the fixel density masks from the rel and abs versions
-    fixel_density_masks = fixel_density_masks_rel * fixel_density_masks_abs
+    # Compute fixel density maps and masks
+    fixel_density_maps = fixel_density(peaks, bundles, args.max_theta,
+                                       nbr_processes=args.nbr_processes)
+    
+    fixel_density_masks = maps_to_masks(fixel_density_maps, args.abs_thr,
+                                        args.rel_thr, args.norm,
+                                        len(bundles))
 
     # Compute number of bundles per fixel
     nb_bundles_per_fixel = np.sum(fixel_density_masks, axis=-1)
-    # Compute a mask of the present of each bundle
-    nb_unique_bundles_per_fixel = np.where(np.sum(fixel_density_masks,
-                                                  axis=-2) > 0, 1, 0)
-    # Compute number of bundles per fixel by taking the sum of the mask
-    nb_bundles_per_voxel = np.sum(nb_unique_bundles_per_fixel, axis=-1)
+    # Compute a mask of the presence of each bundle per voxel
+    # Since a bundle can be present twice in a single voxel by being associated
+    # with more than one fixel, we count the presence of a bundle if > 0.
+    presence_of_bundles_per_voxel = np.where(np.sum(fixel_density_masks,
+                                                    axis=-2) > 0, 1, 0)
+    # Compute number of bundles per voxel by taking the sum of the mask
+    nb_bundles_per_voxel = np.sum(presence_of_bundles_per_voxel, axis=-1)
 
-    if args.save_masks:
-        for i, (bundle, bundle_name) in enumerate(zip(bundles, bundles_names)):
+    # Save all results
+    for i, bundle_name in enumerate(bundles_names):
+        if args.split_bundles: # Save the maps and masks for each bundle
+            nib.save(nib.Nifti1Image(fixel_density_maps[..., i], affine),
+                     "fixel_density_map_{}.nii.gz".format(bundle_name))
+            nib.save(nib.Nifti1Image(fixel_density_masks[..., i], affine),
+                     "fixel_density_mask_{}.nii.gz".format(bundle_name))
 
-            if args.separate_bundles:
-                nib.save(nib.Nifti1Image(fixel_density_masks[..., i].astype(np.uint8), affine),
-                         out_folder / "fixel_density_mask_{}.nii.gz".format(bundle_name))
-
-            if args.select_single_bundle:
-                # Single-fiber single-bundle voxels
-                single_bundle_per_voxel = nb_bundles_per_voxel == 1
-                # Making sure we also have single-fiber voxels only
-                single_bundle_per_voxel *= nufo_sf
-
-                nib.save(nib.Nifti1Image(single_bundle_per_voxel.astype(np.uint8),
-                                         affine),
-                         out_folder / "bundle_mask_only_WM.nii.gz")
-
-                bundle_mask = fixel_density_masks[..., 0, i] * single_bundle_per_voxel
-                nib.save(nib.Nifti1Image(bundle_mask.astype(np.uint8), affine),
-                         out_folder / "bundle_mask_only_{}.nii.gz".format(bundle_name))
-
-        if not args.separate_bundles:
-            nib.save(nib.Nifti1Image(fixel_density_masks.astype(np.uint8),
+        if args.single_bundle:
+            # Single-fiber single-bundle voxels
+            one_bundle_per_voxel = nb_bundles_per_voxel == 1
+            # Making sure we also have single-fiber voxels only
+            one_bundle_per_voxel *= nufo_sf
+            # Save a single-fiber single-bundle mask for the whole WM
+            nib.save(nib.Nifti1Image(one_bundle_per_voxel.astype(np.uint8),
                                      affine),
-                     out_folder / "fixel_density_masks.nii.gz")
+                     "single_bundle_mask_WM.nii.gz")
+            # Save a single-fiber single-bundle mask for each bundle
+            bundle_mask = fixel_density_masks[..., 0, i] * one_bundle_per_voxel
+            nib.save(nib.Nifti1Image(bundle_mask.astype(np.uint8), affine),
+                     "single_bundle_mask_{}.nii.gz".format(bundle_name))
+    
+    if args.split_fixels: # Save the maps and masks for each fixel
+        for i in range(5):
+            nib.save(nib.Nifti1Image(fixel_density_maps[..., i, :], affine),
+                     "fixel_density_map_f{}.nii.gz".format(i))
+            nib.save(nib.Nifti1Image(fixel_density_masks[..., i, :], affine),
+                     "fixel_density_mask_f{}.nii.gz".format(i))
 
-    nib.save(nib.Nifti1Image(nb_bundles_per_fixel.astype(np.uint8),
-             affine), out_folder / "nb_bundles_per_fixel.nii.gz")
+    # Save bundles lookup table to know the order of the bundles
+    bundles_idx = np.arange(0, len(bundles_names), 1)
+    lookup_table = np.array([bundles_names, bundles_idx])
+    np.savetxt("bundles_lookup_table.txt",
+                lookup_table, fmt='%s')
 
-    nib.save(nib.Nifti1Image(nb_bundles_per_voxel.astype(np.uint8),
-             affine), out_folder / "nb_bundles_per_voxel.nii.gz")
+    # Save full fixel density maps, all fixels and bundles combined
+    nib.save(nib.Nifti1Image(fixel_density_maps, affine),
+             "fixel_density_maps.nii.gz")
+
+    # Save full fixel density masks, all fixels and bundles combined
+    nib.save(nib.Nifti1Image(fixel_density_masks, affine),
+             "fixel_density_masks.nii.gz")
+
+    # Save number of bundles per fixel and per voxel
+    nib.save(nib.Nifti1Image(nb_bundles_per_fixel, affine),
+             "nb_bundles_per_fixel.nii.gz")
+    nib.save(nib.Nifti1Image(nb_bundles_per_voxel, affine),
+             "nb_bundles_per_voxel.nii.gz")
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_bundle_fixel_analysis.py
+++ b/scripts/tests/test_bundle_fixel_analysis.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import os
+import tempfile
+
+from scilpy import SCILPY_HOME
+from scilpy.io.fetcher import fetch_data, get_testing_files_dict
+
+fetch_data(get_testing_files_dict(), keys=['commit_amico.zip'])
+tmp_dir = tempfile.TemporaryDirectory()
+
+
+def test_help_option(script_runner):
+    ret = script_runner.run('scil_bundle_fixel_analysis.py', '--help')
+    assert ret.success
+
+
+def test_default_parameters(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+    in_peaks = os.path.join(SCILPY_HOME, 'commit_amico', 'peaks.nii.gz')
+    in_bundle = os.path.join(SCILPY_HOME, 'commit_amico', 'tracking.trk')
+
+    ret = script_runner.run('scil_bundle_fixel_analysis.py', in_peaks,
+                            '--in_bundles', in_bundle,
+                            '--processes', '1', '-f')
+    assert ret.success
+
+
+def test_all_parameters(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+    in_peaks = os.path.join(SCILPY_HOME, 'commit_amico', 'peaks.nii.gz')
+    in_bundle = os.path.join(SCILPY_HOME, 'commit_amico', 'tracking.trk')
+
+    ret = script_runner.run('scil_bundle_fixel_analysis.py', in_peaks,
+                            '--in_bundles', in_bundle,
+                            '--in_bundles_names', 'test',
+                            '--abs_thr', '5',
+                            '--rel_thr', '0.05',
+                            '--norm', 'fixel',
+                            '--split_bundles', '--split_fixels',
+                            '--single_bundle',
+                            '--processes', '1', '-f')
+    assert ret.success
+
+# We would need a tractogram with data_per_streamline to test the --dps_key
+# option


### PR DESCRIPTION
# Quick description

Here is a script that computes a `fixel_density_maps` by associating each segment of streamlines in each voxel to one of the fixels. In other words, you give peaks and a list of bundles (.trk) as input, and it computes the fraction of each bundle per peak, for every voxel. It uses either the streamline count or some streamline weight in data_per_streamline, to compute the density of bundles. From the `fixel_density_maps`, we also get the `fixel_density_masks` (masked version of the map using thresholds), the `voxel_density_maps`, the `voxel_density_masks`, the `nb_bundles_per_fixel` and the `nb_bundles_per_voxel`. Please read the documentation of the script for more info.

@mdesco, @frheault  this is the script we talked about! I would recommend using the default values to start with. So simply give the peaks and --in_bundles.

...

## Type of change

Check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [ ] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
