### PR TITLE
[FIX] Missing parameter for background viz

### DIFF
--- a/scripts/scil_viz_fodf.py
+++ b/scripts/scil_viz_fodf.py
@@ -307,12 +307,11 @@ def main():
         bg_actor = create_texture_slicer(data['bg'],
                                          args.axis_name,
                                          args.slice_index,
-                                         mask,
-                                         args.bg_range,
-                                         args.bg_opacity,
-                                         args.bg_offset,
-                                         None,
-                                         args.bg_interpolation)
+                                         mask=mask,
+                                         value_range=args.bg_range,
+                                         opacity=args.bg_opacity,
+                                         offset=args.bg_offset,
+                                         interpolation=args.bg_interpolation)
         actors.append(bg_actor)
 
     # Instantiate a peaks slicer actor if peaks are supplied

--- a/scripts/scil_viz_fodf.py
+++ b/scripts/scil_viz_fodf.py
@@ -311,6 +311,7 @@ def main():
                                          args.bg_range,
                                          args.bg_opacity,
                                          args.bg_offset,
+                                         None,
                                          args.bg_interpolation)
         actors.append(bg_actor)
 


### PR DESCRIPTION
# Quick description
When running `scil_viz_fodf.py path/to/fodf.nii.gz --background path/to/bg/image.nii.gz`, I get an issue saying that 'nearest' isn't a matplotlib colormap. This is caused because the interpolation argument is given as a positional argument whilst there's a missing argument to specify the colormap.

I explicitly put the default value there (None), but I'm also opened to change it to some other value. I could also change the function call to use keyword arguments instead of positional arguments (e.g. `interpolation=args.bg_interpolation`). 

...

## Type of change

Check the relevant options.

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [ ] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
