### PR TITLE
Removing unused argument in scil_bundle_fixel_analysis.py

### DIFF
--- a/scripts/scil_bundle_fixel_analysis.py
+++ b/scripts/scil_bundle_fixel_analysis.py
@@ -149,21 +149,20 @@ def _build_arg_parser():
     g2 = p.add_argument_group(title='Output options')
 
     g2.add_argument('--split_bundles', action='store_true',
-                    help='If set, save the density maps for each bundle '
-                         'separately \nin addition to the all in one version.')
+                    help='If set, save the density maps and masks for each '
+                         'bundle separately \nin addition to the all in one '
+                         'version.')
 
     g2.add_argument('--split_fixels', action='store_true',
-                    help='If set, save the density maps for each fixel '
-                         'separately \nin addition to the all in one version.')
+                    help='If set, save the density maps and masks for each '
+                         'fixel separately \nin addition to the all in one '
+                         'version.')
 
     g2.add_argument('--single_bundle', action='store_true',
                     help='If set, will save the single-fiber single-bundle '
                          'masks as well. \nThese are obtained by '
                          'selecting the voxels where only one bundle is '
                          'present \n(and one fiber/fixel).')
-
-    g2.add_argument('--bundles_mask', action='store_true',
-                    help='If set, save the bundle mask for each bundle.')
 
     g2.add_argument('--out_dir', default="fixel_analysis/",
                     help='Path to the output directory where all the output '


### PR DESCRIPTION
# Quick description

I found a fossil in `scil_bundle_fixel_analysis.py`. The argument `bundles_mask` in the parser was not useful anymore. This should be quite simple to review and merge.

...

## Type of change

Check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [ ] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
