### PR TITLE
Modify lesions_info to support labels instead of mask

### DIFF
--- a/scilpy/image/labels.py
+++ b/scilpy/image/labels.py
@@ -99,6 +99,7 @@ def get_labels_from_mask(mask_data, labels=None, background_label=0,
         for label in range(1, nb_structures + 1):
             if np.count_nonzero(label_map == label) < min_voxel_count:
                 label_map[label_map == label] = 0
+        mask_data = label_map > 0
         label_map, nb_structures = ndi.label(mask_data)
 
     # Assign labels to each blob if provided

--- a/scilpy/image/labels.py
+++ b/scilpy/image/labels.py
@@ -96,11 +96,17 @@ def get_labels_from_mask(mask_data, labels=None, background_label=0,
     # Get the number of structures and assign labels to each blob
     label_map, nb_structures = ndi.label(mask_data)
     if min_voxel_count:
+        new_count = 0
         for label in range(1, nb_structures + 1):
             if np.count_nonzero(label_map == label) < min_voxel_count:
                 label_map[label_map == label] = 0
-        mask_data = label_map > 0
-        label_map, nb_structures = ndi.label(mask_data)
+            else:
+                new_count += 1
+                label_map[label_map == label] = new_count
+        logging.debug(
+            f"Ignored blob {nb_structures-new_count} with fewer "
+            "than {min_voxel_count} voxels")
+        nb_structures = new_count
 
     # Assign labels to each blob if provided
     if labels:

--- a/scilpy/image/labels.py
+++ b/scilpy/image/labels.py
@@ -68,7 +68,8 @@ def get_binary_mask_from_labels(atlas, label_list):
     return mask
 
 
-def get_labels_from_mask(mask_data, labels=None, background_label=0):
+def get_labels_from_mask(mask_data, labels=None, background_label=0,
+                         min_voxel_count=0):
     """
     Get labels from a binary mask which contains multiple blobs. Each blob
     will be assigned a label, by default starting from 1. Background will
@@ -83,6 +84,9 @@ def get_labels_from_mask(mask_data, labels=None, background_label=0):
         label.
     background_label: int
         Label for the background.
+    min_voxel_count: int, optional
+        Minimum number of voxels for a blob to be considered. Blobs with fewer
+        voxels will be ignored.
 
     Returns
     -------
@@ -91,6 +95,12 @@ def get_labels_from_mask(mask_data, labels=None, background_label=0):
     """
     # Get the number of structures and assign labels to each blob
     label_map, nb_structures = ndi.label(mask_data)
+    if min_voxel_count:
+        for label in range(1, nb_structures + 1):
+            if np.count_nonzero(label_map == label) < min_voxel_count:
+                label_map[label_map == label] = 0
+        label_map, nb_structures = ndi.label(mask_data)
+
     # Assign labels to each blob if provided
     if labels:
         # Only keep the first nb_structures labels if the number of labels

--- a/scripts/scil_labels_from_mask.py
+++ b/scripts/scil_labels_from_mask.py
@@ -34,6 +34,10 @@ def _build_arg_parser():
     p.add_argument('--background_label', default=0, type=int,
                    help='Label to assign to the background. [%(default)s]')
 
+    p.add_argument('--min_volume', type=float, default=7,
+                   help='Minimum volume in mm3 [%(default)s],'
+                        'Useful for lesions.')
+
     add_verbose_arg(p)
     add_overwrite_arg(p)
 
@@ -50,9 +54,13 @@ def main():
     # Load mask and get data
     mask_img = nib.load(args.in_mask)
     mask_data = get_data_as_mask(mask_img)
+    voxel_volume = np.prod(np.diag(mask_img.affine)[:3])
+    min_voxel_count = args.min_volume // voxel_volume
+
     # Get labels from mask
     label_map = get_labels_from_mask(
-        mask_data, args.labels, args.background_label)
+        mask_data, args.labels, args.background_label,
+        min_voxel_count=min_voxel_count)
     # Save result
     out_img = nib.Nifti1Image(label_map.astype(np.uint16), mask_img.affine)
     nib.save(out_img, args.out_labels)

--- a/scripts/scil_lesions_info.py
+++ b/scripts/scil_lesions_info.py
@@ -10,10 +10,6 @@ scil_labels_from_mask.py
 Then, the second input can either be streamlines, binary bundle mask, or a
 bundle voxel label map.
 
-To be considered a valid lesion, the lesion volume must be at least
---min_lesion_vol mm3. This avoid the detection of thousand of single voxel
-lesions if an automatic lesion segmentation tool is used.
-
 Formerly: scil_analyse_lesions_load.py
 """
 

--- a/scripts/scil_lesions_info.py
+++ b/scripts/scil_lesions_info.py
@@ -54,8 +54,6 @@ def _build_arg_parser():
     p1.add_argument('--bundle_labels_map',
                     help='Path of the bundle labels map (.nii.gz).')
 
-    p.add_argument('--min_lesion_vol', type=float, default=7,
-                   help='Minimum lesion volume in mm3 [%(default)s].')
     p.add_argument('--out_lesion_atlas', metavar='FILE',
                    help='Save the labelized lesion(s) map (.nii.gz).')
     p.add_argument('--out_lesion_stats', metavar='FILE',

--- a/scripts/scil_lesions_info.py
+++ b/scripts/scil_lesions_info.py
@@ -3,11 +3,15 @@
 
 """
 This script will output informations about lesion load in bundle(s).
-The input can either be streamlines, binary bundle map, or a bundle voxel
+The input can either be streamlines, binary bundle mask, or a bundle voxel
 label map.
 
+The input lesion file is a labeled volume (.nii.gz) where each lesion is
+represented by a unique label. To label a lesion file use
+scil_labels_from_mask.py
+
 To be considered a valid lesion, the lesion volume must be at least
-min_lesion_vol mm3. This avoid the detection of thousand of single voxel
+--min_lesion_vol mm3. This avoid the detection of thousand of single voxel
 lesions if an automatic lesion segmentation tool is used.
 
 Formerly: scil_analyse_lesions_load.py

--- a/scripts/scil_lesions_info.py
+++ b/scripts/scil_lesions_info.py
@@ -3,12 +3,12 @@
 
 """
 This script will output informations about lesion load in bundle(s).
-The input can either be streamlines, binary bundle mask, or a bundle voxel
-label map.
-
 The input lesion file is a labeled volume (.nii.gz) where each lesion is
 represented by a unique label. To label a lesion file use
 scil_labels_from_mask.py
+
+Then, the second input can either be streamlines, binary bundle mask, or a
+bundle voxel label map.
 
 To be considered a valid lesion, the lesion volume must be at least
 --min_lesion_vol mm3. This avoid the detection of thousand of single voxel

--- a/scripts/tests/test_labels_from_mask.py
+++ b/scripts/tests/test_labels_from_mask.py
@@ -24,7 +24,7 @@ def test_execution(script_runner, monkeypatch):
                            'bundle_4_head_tail_offset.nii.gz')
     ret = script_runner.run('scil_labels_from_mask.py',
                             in_mask, 'labels_from_mask.nii.gz',
-                            '-f')
+                            '--min_volume', '0', '-f')
     assert ret.success
 
 


### PR DESCRIPTION
# Quick description

lesions_info now use labels as input because @AntoineTheb created the script scil_labels_from_mask.py. This avoids duplicated processing in the script, this also will be required in the future because I will add a few lesions-related scripts.
...

## Type of change

Check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [x] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
