### PR TITLE
Add no norm option to scil_bundle_fixel_analysis

### DIFF
--- a/scilpy/tractanalysis/fixel_density.py
+++ b/scilpy/tractanalysis/fixel_density.py
@@ -110,9 +110,10 @@ def maps_to_masks(maps, abs_thr, rel_thr, norm, nb_bundles):
     rel_thr : float
         Value of density maps threshold to obtain density masks, as a ratio of
         the normalized density. Must be between 0 and 1.
-    norm : string, ["fixel", "voxel"]
+    norm : string, ["fixel", "voxel", "none"]
         Way of normalizing the density maps. If fixel, will normalize the maps
         per fixel, in each voxel. If voxel, will normalize the maps per voxel.
+        If none, will not normalize the maps.
     nb_bundles : int (N)
         Number of bundles (N).
 
@@ -140,7 +141,10 @@ def maps_to_masks(maps, abs_thr, rel_thr, norm, nb_bundles):
             maps[..., i] /= fixel_sum
 
     # Apply a threshold on the normalized density
-    masks_rel = maps > rel_thr
+    if norm == "voxel" or norm == "fixel":
+        masks_rel = maps > rel_thr
+    else:
+        masks_rel = maps > 0
     # Compute the fixel density masks from the rel and abs versions
     masks = masks_rel * masks_abs
 

--- a/scripts/scil_bundle_fixel_analysis.py
+++ b/scripts/scil_bundle_fixel_analysis.py
@@ -27,7 +27,7 @@ The script produces various output:
       as the fixel-type, then the sum of the density over each fixel is 1, so
       the sum over a voxel will be higher than 1 (except in the single-fiber
       case). The density maps can be computed using the streamline count, or
-      any streamline weighting like COMMIT or SIF, through the
+      any streamline weighting like COMMIT or SIFT, through the
       data_per_streamline using the --dps_key argument. NOTE: This is a 5D file
       that will not be easily inputed to a regular viewer. Use --split_bundles
       or --split_fixels options to save the 4D versions for visualization.

--- a/scripts/scil_bundle_fixel_analysis.py
+++ b/scripts/scil_bundle_fixel_analysis.py
@@ -89,6 +89,10 @@ The script produces various output:
     be one single_bundle_mask_{bundle_name}.nii.gz per bundle, and a whole WM
     version single_bundle_mask_WM.nii.gz.
     These will have the shape (x, y, z).
+
+    WARNING: If multiple normalization types are given, along with the
+    split_bundles, split_fixels and single_bundle arguments, this script will
+    produce a lot of outputs.
 """
 
 import argparse
@@ -256,8 +260,9 @@ def main():
         norm_name = norm + "-norm"
         logging.info("Performing normalization of type {}.".format(norm))
         logging.info("Computing density masks from density maps.")
-        fd_masks, fd_maps = maps_to_masks(fd_maps_original, args.abs_thr,
-                                          args.rel_thr, norm, len(bundles))
+        fd_masks, fd_maps = maps_to_masks(np.copy(fd_maps_original),
+                                          args.abs_thr, args.rel_thr, norm,
+                                          len(bundles))
 
         logging.info("Computing additional derivatives.")
         # Compute number of bundles per fixel

--- a/scripts/scil_bundle_fixel_analysis.py
+++ b/scripts/scil_bundle_fixel_analysis.py
@@ -248,15 +248,16 @@ def main():
 
     # Compute fixel density (FD) maps and masks
     logging.info("Computing fixel density for all bundles.")
-    fd_maps = fixel_density(peaks, bundles, args.dps_key, args.max_theta,
-                            nbr_processes=args.nbr_processes)
+    fd_maps_original = fixel_density(peaks, bundles, args.dps_key,
+                                     args.max_theta,
+                              		 nbr_processes=args.nbr_processes)
 
     for norm in args.norm:
         norm_name = norm + "-norm"
         logging.info("Performing normalization of type {}.".format(norm))
         logging.info("Computing density masks from density maps.")
-        fd_masks, fd_maps = maps_to_masks(fd_maps, args.abs_thr, args.rel_thr,
-                                          norm, len(bundles))
+        fd_masks, fd_maps = maps_to_masks(fd_maps_original, args.abs_thr,
+                                          args.rel_thr, norm, len(bundles))
 
         logging.info("Computing additional derivatives.")
         # Compute number of bundles per fixel

--- a/scripts/scil_bundle_fixel_analysis.py
+++ b/scripts/scil_bundle_fixel_analysis.py
@@ -252,7 +252,7 @@ def main():
                             nbr_processes=args.nbr_processes)
 
     for norm in args.norm:
-        norm_name = norm + "norm"
+        norm_name = norm + "-norm"
         logging.info("Performing normalization of type {}.".format(norm))
         logging.info("Computing density masks from density maps.")
         fd_masks, fd_maps = maps_to_masks(fd_maps, args.abs_thr, args.rel_thr,

--- a/scripts/scil_bundle_fixel_analysis.py
+++ b/scripts/scil_bundle_fixel_analysis.py
@@ -267,8 +267,7 @@ def main():
         # Since a bundle can be present twice in a single voxel by being
         # associated with more than one fixel, we count the presence of a
         # bundle if > 0.
-        vd_masks = np.where(np.sum(fd_masks, axis=-2) > 0,
-                                    1, 0)
+        vd_masks = np.where(np.sum(fd_masks, axis=-2) > 0, 1, 0)
         # Compute number of bundles per voxel by taking the sum of the mask
         nb_bundles_per_voxel = np.sum(vd_masks, axis=-1)
 
@@ -282,7 +281,7 @@ def main():
                 nib.save(nib.Nifti1Image(fd_masks[..., i], affine),
                          "{}_{}_{}{}.nii.gz".format(fd_mask_name, norm_name,
                                                     bundle_n, suffix))
-                if norm != "fixel": # If fixel, voxel maps mean nothing
+                if norm != "fixel":  # If fixel, voxel maps mean nothing
                     nib.save(nib.Nifti1Image(vd_maps[..., i], affine),
                              "{}_{}_{}{}.nii.gz".format(vd_map_name, norm_name,
                                                         bundle_n, suffix))
@@ -354,7 +353,7 @@ def main():
     bundles_idx = np.arange(0, len(bundles_names), 1)
     lookup_table = np.array([bundles_names, bundles_idx])
     np.savetxt("{}{}bundles_LUT{}.txt".format(out_dir, prefix, suffix),
-                lookup_table, fmt='%s')
+               lookup_table, fmt='%s')
 
 
 if __name__ == "__main__":

--- a/scripts/scil_bundle_fixel_analysis.py
+++ b/scripts/scil_bundle_fixel_analysis.py
@@ -69,7 +69,7 @@ The script produces various output:
 
     If more than one normalization type is given, every output will be computed
     for each normalization. In any case, the normalization type is added after
-    the basename of the output, such as fixel_density_maps_voxel_norm.
+    the basename of the output, such as fixel_density_maps_voxel-norm.
 
     If the split_bundles argument is given, the script will also save the
     fixel_density_maps and fixel_density_masks separated by bundles, with

--- a/scripts/scil_bundle_fixel_analysis.py
+++ b/scripts/scil_bundle_fixel_analysis.py
@@ -254,7 +254,7 @@ def main():
     logging.info("Computing fixel density for all bundles.")
     fd_maps_original = fixel_density(peaks, bundles, args.dps_key,
                                      args.max_theta,
-                              		 nbr_processes=args.nbr_processes)
+                                     nbr_processes=args.nbr_processes)
 
     for norm in args.norm:
         norm_name = norm + "-norm"

--- a/scripts/tests/test_bundle_fixel_analysis.py
+++ b/scripts/tests/test_bundle_fixel_analysis.py
@@ -61,18 +61,25 @@ def test_multiple_norm(script_runner, monkeypatch):
                             '--processes', '1', '-f')
     assert ret.success
     assert os.path.isfile('bundles_LUT.txt')
-    assert os.path.isfile('fixel_density_maps_voxel-norm.nii.gz')
-    assert os.path.isfile('fixel_density_maps_fixel-norm.nii.gz')
-    assert os.path.isfile('fixel_density_maps_none-norm.nii.gz')
+    for n in ['voxel', 'fixel', 'none']:
+        assert os.path.isfile('fixel_density_maps_{}-norm.nii.gz'.format(n))
+        assert os.path.isfile('fixel_density_map_{}-norm_f1.nii.gz'.format(n))
+        assert os.path.isfile('fixel_density_map_{}-norm_f2.nii.gz'.format(n))
+        assert os.path.isfile('fixel_density_map_{}-norm_f3.nii.gz'.format(n))
+        assert os.path.isfile('fixel_density_map_{}-norm_f4.nii.gz'.format(n))
+        assert os.path.isfile('fixel_density_map_{}-norm_f5.nii.gz'.format(n))
+        assert os.path.isfile('fixel_density_map_{}-'
+                              'norm_test.nii.gz'.format(n))
+        assert os.path.isfile('nb_bundles_per_fixel_{}-norm.nii.gz'.format(n))
+        assert os.path.isfile('nb_bundles_per_voxel_{}-norm.nii.gz'.format(n))
+        assert os.path.isfile('single_bundle_mask_{}-'
+                              'norm_WM.nii.gz'.format(n))
+        assert os.path.isfile('single_bundle_mask_{}-'
+                              'norm_test.nii.gz'.format(n))
+    
     assert os.path.isfile('voxel_density_maps_voxel-norm.nii.gz')
     assert not os.path.isfile('voxel_density_maps_fixel-norm.nii.gz')
     assert os.path.isfile('voxel_density_maps_none-norm.nii.gz')
-    assert os.path.isfile('fixel_density_map_fixel-norm_f1.nii.gz')
-    assert os.path.isfile('fixel_density_map_fixel-norm_test.nii.gz')
-    assert os.path.isfile('nb_bundles_per_fixel_voxel-norm.nii.gz')
-    assert os.path.isfile('nb_bundles_per_voxel_voxel-norm.nii.gz')
-    assert os.path.isfile('single_bundle_mask_fixel-norm_WM.nii.gz')
-    assert os.path.isfile('single_bundle_mask_fixel-norm_test.nii.gz')
 
 # We would need a tractogram with data_per_streamline to test the --dps_key
 # option

--- a/scripts/tests/test_bundle_fixel_analysis.py
+++ b/scripts/tests/test_bundle_fixel_analysis.py
@@ -57,10 +57,22 @@ def test_multiple_norm(script_runner, monkeypatch):
                             '--norm', 'fixel', 'none', 'voxel',
                             '--split_bundles', '--split_fixels',
                             '--single_bundle',
+                            '--out_dir', '.',
                             '--processes', '1', '-f')
     assert ret.success
-    print(tmp_dir.name + "/fixel_density_maps.nii.gz")
-    assert os.path.exists(tmp_dir.name + "/fixel_density_maps.nii.gz")
+    assert os.path.isfile('bundles_LUT.txt')
+    assert os.path.isfile('fixel_density_maps_voxel-norm.nii.gz')
+    assert os.path.isfile('fixel_density_maps_fixel-norm.nii.gz')
+    assert os.path.isfile('fixel_density_maps_none-norm.nii.gz')
+    assert os.path.isfile('voxel_density_maps_voxel-norm.nii.gz')
+    assert not os.path.isfile('voxel_density_maps_fixel-norm.nii.gz')
+    assert os.path.isfile('voxel_density_maps_none-norm.nii.gz')
+    assert os.path.isfile('fixel_density_map_fixel-norm_f1.nii.gz')
+    assert os.path.isfile('fixel_density_map_fixel-norm_test.nii.gz')
+    assert os.path.isfile('nb_bundles_per_fixel_voxel-norm.nii.gz')
+    assert os.path.isfile('nb_bundles_per_voxel_voxel-norm.nii.gz')
+    assert os.path.isfile('single_bundle_mask_fixel-norm_WM.nii.gz')
+    assert os.path.isfile('single_bundle_mask_fixel-norm_test.nii.gz')
 
 # We would need a tractogram with data_per_streamline to test the --dps_key
 # option

--- a/scripts/tests/test_bundle_fixel_analysis.py
+++ b/scripts/tests/test_bundle_fixel_analysis.py
@@ -43,5 +43,24 @@ def test_all_parameters(script_runner, monkeypatch):
                             '--processes', '1', '-f')
     assert ret.success
 
+
+def test_multiple_norm(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+    in_peaks = os.path.join(SCILPY_HOME, 'commit_amico', 'peaks.nii.gz')
+    in_bundle = os.path.join(SCILPY_HOME, 'commit_amico', 'tracking.trk')
+
+    ret = script_runner.run('scil_bundle_fixel_analysis.py', in_peaks,
+                            '--in_bundles', in_bundle,
+                            '--in_bundles_names', 'test',
+                            '--abs_thr', '5',
+                            '--rel_thr', '0.05',
+                            '--norm', 'fixel', 'none', 'voxel',
+                            '--split_bundles', '--split_fixels',
+                            '--single_bundle',
+                            '--processes', '1', '-f')
+    assert ret.success
+    print(tmp_dir.name + "/fixel_density_maps.nii.gz")
+    assert os.path.exists(tmp_dir.name + "/fixel_density_maps.nii.gz")
+
 # We would need a tractogram with data_per_streamline to test the --dps_key
 # option


### PR DESCRIPTION
# Quick description

This is a small PR to add the option of not normalizing the density maps. For instance, if you want to keep the information about the streamline count or the sift2 weight, you can now use `--norm none`. You can also use multiple choices like `--norm voxel none` and it will produce outputs for both.

The for loop on the norm options makes it look like all the code has changed in the script, but it is basically the same as before inside the loop, with shorter variable names to respect pep8.

## Type of change

Enhancement

Check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [ ] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
