### PR TITLE
return option min_vol_lesion

### DIFF
--- a/scripts/scil_lesions_info.py
+++ b/scripts/scil_lesions_info.py
@@ -49,6 +49,8 @@ def _build_arg_parser():
                     help='Path of the bundle binary mask (.nii.gz).')
     p1.add_argument('--bundle_labels_map',
                     help='Path of the bundle labels map (.nii.gz).')
+    p.add_argument('--min_lesion_vol', type=float, default=7,
+                   help='Minimum lesion volume in mm3 [%(default)s].')
 
     p.add_argument('--out_lesion_atlas', metavar='FILE',
                    help='Save the labelized lesion(s) map (.nii.gz).')


### PR DESCRIPTION
# Quick description
I've put the min_lesion_volume option back in because the script doesn't work without it and the problem is that if I remove the option, the compute_lesion_stats script in scilpy.utils.metrics_tools takes a default value of 7mm without being able to change it. so we'll just have to make sure for now that when we use this script after scil_label_from_mask.py we keep the same minimum volume between the two scripts.

## Type of change

- Bug fix 