### PR TITLE
ENH: cut streamlines min length

### DIFF
--- a/scripts/scil_tractogram_cut_streamlines.py
+++ b/scripts/scil_tractogram_cut_streamlines.py
@@ -81,7 +81,7 @@ def _build_arg_parser():
     p.add_argument('--resample', dest='step_size', type=float, default=None,
                    help='Resample streamlines to a specific step-size in mm '
                         '[%(default)s].')
-    p.add_argument('--min_length', type=float, default=20,
+    p.add_argument('--min_length', type=float, default=0,
                    help='Minimum length of streamlines to keep (in mm) '
                         '[%(default)s].')
     g = p.add_argument_group('Cutting options', 'Options for cutting '


### PR DESCRIPTION
# Quick description

Change the minimum length of streamlines output by `scil_tractogram_cut_streamlines` to 0, as the previous behavior was confusing.

...

## Type of change

Check the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist

- [X] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [X] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- X ] My changes generate no new warnings
- [X] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
