### PR TITLE
[ENH] Improve fodf max in ventricules for different species

### DIFF
--- a/scripts/scil_fodf_max_in_ventricles.py
+++ b/scripts/scil_fodf_max_in_ventricles.py
@@ -43,9 +43,11 @@ def _build_arg_parser():
     p.add_argument('--md',  metavar='MD',
                    help='Path to the mean diffusivity (MD) volume.')
     p.add_argument('--mask', metavar='mask',
-                     help='Path to the mask volume. If set, the mask will be used '
-                            'to compute the ventricles.\nOtherwise, the ventricles '
-                            'will be computed using the FA and MD volumes.')
+                     help='Path to the ventricles mask volume.\n'
+                          'If set, the mask will be used '
+                          'to compute the maximum fODF in the ventricles.\n'
+                          'Otherwise, the ventricles '
+                          'will be computed using the FA and MD volumes.')
 
     p.add_argument('--fa_threshold', type=float, default='0.1',
                    help='Maximal threshold of FA (voxels under that threshold '

--- a/scripts/tests/test_fodf_max_in_ventricles.py
+++ b/scripts/tests/test_fodf_max_in_ventricles.py
@@ -26,5 +26,33 @@ def test_execution_processing(script_runner, monkeypatch):
     in_md = os.path.join(SCILPY_HOME, 'processing',
                          'md.nii.gz')
     ret = script_runner.run('scil_fodf_max_in_ventricles.py', in_fodf,
-                            in_fa, in_md, '--sh_basis', 'tournier07')
+                            '--fa', in_fa, 
+                            '--md', in_md,
+                            '--sh_basis', 'tournier07')
     assert ret.success
+
+
+def test_execution_processing_w_mask(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+    in_fodf = os.path.join(SCILPY_HOME, 'processing',
+                           'fodf.nii.gz')
+    in_mask = os.path.join(SCILPY_HOME, 'processing',
+                         'small_roi_gm_mask.nii.gz')
+    ret = script_runner.run('scil_fodf_max_in_ventricles.py', in_fodf,
+                            '--mask', in_mask, 
+                            '--sh_basis', 'tournier07')
+    assert ret.success
+
+def test_execution_processing_fail(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+    in_fodf = os.path.join(SCILPY_HOME, 'processing',
+                           'fodf.nii.gz')
+    in_mask = os.path.join(SCILPY_HOME, 'processing',
+                         'small_roi_gm_mask.nii.gz')
+    in_fa = os.path.join(SCILPY_HOME, 'processing',
+                         'fa.nii.gz')    
+    ret = script_runner.run('scil_fodf_max_in_ventricles.py', in_fodf,
+                            '--fa', in_fa,
+                            '--mask', in_mask, 
+                            '--sh_basis', 'tournier07')
+    assert not ret.success

--- a/scripts/tests/test_fodf_max_in_ventricles.py
+++ b/scripts/tests/test_fodf_max_in_ventricles.py
@@ -53,6 +53,5 @@ def test_execution_processing_fail(script_runner, monkeypatch):
                          'fa.nii.gz')    
     ret = script_runner.run('scil_fodf_max_in_ventricles.py', in_fodf,
                             '--fa', in_fa,
-                            '--mask', in_mask, 
-                            '--sh_basis', 'tournier07')
+                            '--mask', in_mask)
     assert not ret.success


### PR DESCRIPTION
# Quick description

Add the possibility to provide a mask of the ventricles instead of FA and MD maps.

## Type of change

Check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [ ] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
