### PR TITLE
ENH: add interpolation to `scil_volume_apply_transform`

### DIFF
--- a/scripts/scil_volume_apply_transform.py
+++ b/scripts/scil_volume_apply_transform.py
@@ -41,6 +41,9 @@ def _build_arg_parser():
     p.add_argument('--keep_dtype', action='store_true',
                    help='If True, keeps the data_type of the input image '
                         '(in_file) when saving the output image (out_name).')
+    p.add_argument('--interpolation', default='linear',
+                   choices=['linear', 'nearest'],
+                   help='Interpolation: "linear" or "nearest". [%(default)s]')
 
     add_verbose_arg(p)
     add_overwrite_arg(p)
@@ -75,7 +78,8 @@ def main():
 
     # Processing, saving
     warped_img = apply_transform(
-        transfo, reference, moving, keep_dtype=args.keep_dtype)
+        transfo, reference, moving, keep_dtype=args.keep_dtype,
+        interp=args.interpolation)
 
     nib.save(warped_img, args.out_name)
 

--- a/scripts/tests/test_volume_apply_transform.py
+++ b/scripts/tests/test_volume_apply_transform.py
@@ -27,5 +27,36 @@ def test_execution_bst(script_runner, monkeypatch):
                           'output0GenericAffine.mat')
     ret = script_runner.run('scil_volume_apply_transform.py',
                             in_model, in_fa, in_aff,
-                            'template_lin.nii.gz', '--inverse')
+                            'template_lin.nii.gz', '--inverse',
+                            '-f')
+    assert ret.success
+
+
+def test_execution_interp_nearest(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+    in_model = os.path.join(SCILPY_HOME, 'bst', 'template',
+                            'template0.nii.gz')
+    in_fa = os.path.join(SCILPY_HOME, 'bst',
+                         'fa.nii.gz')
+    in_aff = os.path.join(SCILPY_HOME, 'bst',
+                          'output0GenericAffine.mat')
+    ret = script_runner.run('scil_volume_apply_transform.py',
+                            in_model, in_fa, in_aff,
+                            'template_lin.nii.gz', '--inverse',
+                            '--interp', 'nearest', '-f')
+    assert ret.success
+
+
+def test_execution_interp_lin(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+    in_model = os.path.join(SCILPY_HOME, 'bst', 'template',
+                            'template0.nii.gz')
+    in_fa = os.path.join(SCILPY_HOME, 'bst',
+                         'fa.nii.gz')
+    in_aff = os.path.join(SCILPY_HOME, 'bst',
+                          'output0GenericAffine.mat')
+    ret = script_runner.run('scil_volume_apply_transform.py',
+                            in_model, in_fa, in_aff,
+                            'template_lin.nii.gz', '--inverse',
+                            '--interp', 'linear', '-f')
     assert ret.success


### PR DESCRIPTION
# Quick description

Add interpolation option to "scil_volume_apply_transform". Useful when transforming label maps where linear interpolation produces undesirable effects.

## Type of change

Check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

TODO

# Checklist

- [X] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
