### PR TITLE
RF - Input to volume stats scripts

### DIFF
--- a/scripts/scil_volume_stats_in_ROI.py
+++ b/scripts/scil_volume_stats_in_ROI.py
@@ -76,9 +76,7 @@ def main():
                          .format(args.metrics_dir))
         assert_inputs_exist(parser, args.in_rois)
 
-        tmp_file_list = glob.glob(os.path.join(args.metrics_dir, '*nii.gz'))
-        args.metrics_file_list = [os.path.join(args.metrics_dir, f)
-                                  for f in tmp_file_list]
+        args.metrics_file_list = glob.glob(os.path.join(args.metrics_dir, '*nii.gz'))
     else:
         assert_inputs_exist(parser, args.in_rois + args.metrics_file_list)
     assert_headers_compatible(parser, args.in_rois + args.metrics_file_list)

--- a/scripts/scil_volume_stats_in_ROI.py
+++ b/scripts/scil_volume_stats_in_ROI.py
@@ -129,6 +129,9 @@ def main():
                     'Metric {} is not a 3D image ({}D shape).'
                     .format(f, len(metric_img.shape)))
 
+
+    if len(args.in_masks) == 1:
+        json_stats = json_stats[roi_name]
     # Print results
     print(json.dumps(json_stats, indent=args.indent, sort_keys=args.sort_keys))
 

--- a/scripts/scil_volume_stats_in_ROI.py
+++ b/scripts/scil_volume_stats_in_ROI.py
@@ -125,7 +125,7 @@ def main():
                                     .format(os.path.basename(f)))
                 mean, std = weighted_mean_std(roi_data, data)
                 json_stats[roi_name][metric_name] = {'mean': mean,
-                                                    'std': std}
+                                                     'std': std}
             else:
                 parser.error(
                     'Metric {} is not a 3D image ({}D shape).'

--- a/scripts/scil_volume_stats_in_ROI.py
+++ b/scripts/scil_volume_stats_in_ROI.py
@@ -33,9 +33,9 @@ def _build_arg_parser():
     p = argparse.ArgumentParser(description=__doc__,
                                 formatter_class=argparse.RawTextHelpFormatter)
 
-    p.add_argument('in_mask',
-                   help='Mask volume filename.\nCan be a binary mask or a '
-                        'weighted mask.')
+    p.add_argument('in_masks', nargs='+',
+                   help='Mask volume filenames.\nCan be binary masks or '
+                        'weighted masks.')
 
     g = p.add_argument_group('Metrics input options')
     gg = g.add_mutually_exclusive_group(required=True)
@@ -74,59 +74,60 @@ def main():
         if not os.path.exists(args.metrics_dir):
             parser.error("Metrics directory does not exist: {}"
                          .format(args.metrics_dir))
-        assert_inputs_exist(parser, args.in_mask)
+        assert_inputs_exist(parser, args.in_masks)
 
         tmp_file_list = glob.glob(os.path.join(args.metrics_dir, '*nii.gz'))
         args.metrics_file_list = [os.path.join(args.metrics_dir, f)
                                   for f in tmp_file_list]
     else:
-        assert_inputs_exist(parser, [args.in_mask] + args.metrics_file_list)
-    assert_headers_compatible(parser,
-                              [args.in_mask] + args.metrics_file_list)
+        assert_inputs_exist(parser, args.in_masks + args.metrics_file_list)
+    assert_headers_compatible(parser, args.in_masks + args.metrics_file_list)
 
-    # Loading
-    mask_data = nib.load(args.in_mask).get_fdata(dtype=np.float32)
-    if len(mask_data.shape) > 3:
-        parser.error('Mask should be a 3D image.')
-    if np.min(mask_data) < 0:
-        parser.error('Mask should not contain negative values.')
-    roi_name = split_name_with_nii(os.path.basename(args.in_mask))[0]
+    # Computing stats for all masks and metrics files
+    json_stats = {}
+    for mask_filename in args.in_masks:
+        mask_data = nib.load(mask_filename).get_fdata(dtype=np.float32)
+        if len(mask_data.shape) > 3:
+            parser.error('Mask should be a 3D image.')
+        if np.min(mask_data) < 0:
+            parser.error('Mask should not contain negative values.')
+        roi_name = split_name_with_nii(os.path.basename(mask_filename))[0]
 
-    # Discussion about the way the normalization is done.
-    # https://github.com/scilus/scilpy/pull/202#discussion_r411355609
-    # Summary:
-    # 1) We don't want to normalize with data = (data-min) / (max-min) because
-    # it zeroes out the minimal values of the array. This is not a large error
-    # source, but not preferable.
-    # 2) data = data / max(data) or data = data / sum(data): in practice, when
-    # we use them in numpy using their weights argument, leads to the same
-    # result.
-    if args.normalize_weights:
-        mask_data /= np.max(mask_data)
-    elif args.bin:
-        mask_data[np.where(mask_data > 0.0)] = 1.0
-    elif np.min(mask_data) < 0.0 or np.max(mask_data) > 1.0:
-        parser.error('Mask data should only contain values between 0 and 1. '
-                     'Try --normalize_weights.')
+        # Discussion about the way the normalization is done.
+        # https://github.com/scilus/scilpy/pull/202#discussion_r411355609
+        # Summary:
+        # 1) We don't want to normalize with data = (data-min) / (max-min) because
+        # it zeroes out the minimal values of the array. This is not a large error
+        # source, but not preferable.
+        # 2) data = data / max(data) or data = data / sum(data): in practice, when
+        # we use them in numpy using their weights argument, leads to the same
+        # result.
+        if args.normalize_weights:
+            mask_data /= np.max(mask_data)
+        elif args.bin:
+            mask_data[np.where(mask_data > 0.0)] = 1.0
+        elif np.min(mask_data) < 0.0 or np.max(mask_data) > 1.0:
+            parser.error('Mask data should only contain values between 0 and 1. '
+                        'Try --normalize_weights.')
 
-    # Load and process all metrics files.
-    json_stats = {roi_name: {}}
-    for f in args.metrics_file_list:
-        metric_img = nib.load(f)
-        metric_name = split_name_with_nii(os.path.basename(f))[0]
-        if len(metric_img.shape) == 3:
-            data = metric_img.get_fdata(dtype=np.float64)
-            if np.any(np.isnan(data)):
-                logging.warning("Metric '{}' contains some NaN. Ignoring "
-                                "voxels with NaN."
-                                .format(os.path.basename(f)))
-            mean, std = weighted_mean_std(mask_data, data)
-            json_stats[roi_name][metric_name] = {'mean': mean,
-                                                 'std': std}
-        else:
-            parser.error(
-                'Metric {} is not a 3D image ({}D shape).'
-                .format(f, len(metric_img.shape)))
+        # Load and process all metrics files.
+        json_stats[roi_name] = {}
+        for f in args.metrics_file_list:
+            metric_img = nib.load(f)
+            metric_name = split_name_with_nii(os.path.basename(f))[0]
+            if len(metric_img.shape) == 3:
+                data = metric_img.get_fdata(dtype=np.float64)
+                if np.any(np.isnan(data)):
+                    logging.warning("Metric '{}' contains some NaN. Ignoring "
+                                    "voxels with NaN."
+                                    .format(os.path.basename(f)))
+                mean, std = weighted_mean_std(mask_data, data)
+                json_stats[roi_name][metric_name] = {'mean': mean,
+                                                    'std': std}
+            else:
+                parser.error(
+                    'Metric {} is not a 3D image ({}D shape).'
+                    .format(f, len(metric_img.shape)))
 
     # Print results
     print(json.dumps(json_stats, indent=args.indent, sort_keys=args.sort_keys))

--- a/scripts/scil_volume_stats_in_ROI.py
+++ b/scripts/scil_volume_stats_in_ROI.py
@@ -5,8 +5,8 @@
 Compute the statistics (mean, std) of scalar maps, which can represent
 diffusion metrics, in ROIs. Prints the results.
 
-The ROIs can either be a binary masks, or a weighting masks. If the ROIs are
- weighting masks it should either contain floats between 0 and 1 or should be
+The ROIs can either be binary masks, or weighting masks. If the ROIs are
+ weighting masks, they should either contain floats between 0 and 1 or should be
 normalized with --normalize_weights. IMPORTANT: if the ROIs contain weights
 (and not 0 and 1 exclusively), the standard deviation will also be weighted.
 """

--- a/scripts/scil_volume_stats_in_ROI.py
+++ b/scripts/scil_volume_stats_in_ROI.py
@@ -97,19 +97,19 @@ def main():
         # Discussion about the way the normalization is done.
         # https://github.com/scilus/scilpy/pull/202#discussion_r411355609
         # Summary:
-        # 1) We don't want to normalize with data = (data-min) / (max-min) because
-        # it zeroes out the minimal values of the array. This is not a large error
-        # source, but not preferable.
-        # 2) data = data / max(data) or data = data / sum(data): in practice, when
-        # we use them in numpy using their weights argument, leads to the same
-        # result.
+        # 1) We don't want to normalize with data = (data-min) / (max-min)
+        # because it zeroes out the minimal values of the array. This is
+        # not a large error source, but not preferable.
+        # 2) data = data / max(data) or data = data / sum(data): in practice,
+        # when we use them in numpy using their weights argument, leads to the
+        # same result.
         if args.normalize_weights:
             roi_data /= np.max(roi_data)
         elif args.bin:
             roi_data[np.where(roi_data > 0.0)] = 1.0
         elif np.min(roi_data) < 0.0 or np.max(roi_data) > 1.0:
-            parser.error('ROI {} data should only contain values between 0 and 1. '
-                         'Try --normalize_weights.'
+            parser.error('ROI {} data should only contain values between 0 '
+                         'and 1. Try --normalize_weights.'
                          .format(roi_filename))
 
         # Load and process all metrics files.

--- a/scripts/scil_volume_stats_in_labels.py
+++ b/scripts/scil_volume_stats_in_labels.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-Computes the information from the input map for each cortical region
-(corresponding to an atlas).
+Computes the information from the input metrics for each cortical region
+(corresponding to an atlas). If more than one metric are provided, statistics are 
+computed separately for each.
 
 Hint: For instance, this script could be useful if you have a seed map from a
 specific bundle, to know from which regions it originated.
@@ -81,7 +82,7 @@ def main():
         metric_data = nib.load(metric_filename).get_fdata(dtype=np.float32)
         metric_name = split_name_with_nii(os.path.basename(metric_filename))[0]
         if len(metric_data.shape) > 3:
-            parser.error('Mask should be a 3D image.')
+            parser.error('Input metrics should be 3D images.')
 
         # Process
         out_dict = get_stats_in_label(metric_data, label_data, label_dict)

--- a/scripts/scil_volume_stats_in_labels.py
+++ b/scripts/scil_volume_stats_in_labels.py
@@ -71,7 +71,6 @@ def main():
         assert_inputs_exist(parser, [args.in_labels] + args.metrics_file_list)
     assert_headers_compatible(parser, [args.in_labels] + args.metrics_file_list)
 
-
     # Loading
     label_data = get_data_as_labels(nib.load(args.in_labels))
     with open(args.in_labels_lut) as f:
@@ -88,7 +87,7 @@ def main():
         # Process
         out_dict = get_stats_in_label(metric_data, label_data, label_dict)
         json_stats[metric_name] = out_dict
-    
+
     if len(args.metrics_file_list) == 1:
         json_stats = json_stats[metric_name]
     print(json.dumps(json_stats))

--- a/scripts/scil_volume_stats_in_labels.py
+++ b/scripts/scil_volume_stats_in_labels.py
@@ -64,9 +64,7 @@ def main():
                          .format(args.metrics_dir))
         assert_inputs_exist(parser, [args.in_labels, args.in_labels_lut])
 
-        tmp_file_list = glob.glob(os.path.join(args.metrics_dir, '*nii.gz'))
-        args.metrics_file_list = [os.path.join(args.metrics_dir, f)
-                                  for f in tmp_file_list]
+        args.metrics_file_list = glob.glob(os.path.join(args.metrics_dir, '*nii.gz'))
     else:
         assert_inputs_exist(parser, [args.in_labels] + args.metrics_file_list)
     assert_headers_compatible(parser,

--- a/scripts/scil_volume_stats_in_labels.py
+++ b/scripts/scil_volume_stats_in_labels.py
@@ -20,7 +20,7 @@ import nibabel as nib
 import numpy as np
 
 from scilpy.image.labels import get_data_as_labels, get_stats_in_label
-from scilpy.io.utils import (add_overwrite_arg, add_verbose_arg,
+from scilpy.io.utils import (add_json_args, add_overwrite_arg, add_verbose_arg,
                              assert_inputs_exist, assert_headers_compatible)
 from scilpy.utils.filenames import split_name_with_nii
 
@@ -43,7 +43,7 @@ def _build_arg_parser():
                     metavar='file',
                     help='Metrics nifti filename. List of the names of the '
                          'metrics file, \nin nifti format.')
-
+    add_json_args(p)
     add_verbose_arg(p)
     add_overwrite_arg(p)
 
@@ -69,7 +69,8 @@ def main():
                                   for f in tmp_file_list]
     else:
         assert_inputs_exist(parser, [args.in_labels] + args.metrics_file_list)
-    assert_headers_compatible(parser, [args.in_labels] + args.metrics_file_list)
+    assert_headers_compatible(parser,
+                              [args.in_labels] + args.metrics_file_list)
 
     # Loading
     label_data = get_data_as_labels(nib.load(args.in_labels))
@@ -90,7 +91,7 @@ def main():
 
     if len(args.metrics_file_list) == 1:
         json_stats = json_stats[metric_name]
-    print(json.dumps(json_stats))
+    print(json.dumps(json_stats, indent=args.indent, sort_keys=args.sort_keys))
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_volume_stats_in_ROI.py
+++ b/scripts/tests/test_volume_stats_in_ROI.py
@@ -19,10 +19,10 @@ def test_help_option(script_runner):
 
 def test_execution_tractometry(script_runner, monkeypatch):
     monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
-    in_mask = os.path.join(SCILPY_HOME, 'tractometry',
+    in_roi = os.path.join(SCILPY_HOME, 'tractometry',
                            'IFGWM.nii.gz')
     in_ref = os.path.join(SCILPY_HOME, 'tractometry',
                           'mni_masked.nii.gz')
     ret = script_runner.run('scil_volume_stats_in_ROI.py',
-                            in_mask, '--metrics', in_ref)
+                            in_roi, '--metrics', in_ref)
     assert ret.success

--- a/scripts/tests/test_volume_stats_in_ROI.py
+++ b/scripts/tests/test_volume_stats_in_ROI.py
@@ -20,9 +20,33 @@ def test_help_option(script_runner):
 def test_execution_tractometry(script_runner, monkeypatch):
     monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_roi = os.path.join(SCILPY_HOME, 'tractometry',
-                           'IFGWM.nii.gz')
+                          'IFGWM.nii.gz')
     in_ref = os.path.join(SCILPY_HOME, 'tractometry',
                           'mni_masked.nii.gz')
+
+    # Test with a single ROI input
     ret = script_runner.run('scil_volume_stats_in_ROI.py',
                             in_roi, '--metrics', in_ref)
+    assert ret.success
+
+    # Test with multiple ROIs input
+    ret = script_runner.run('scil_volume_stats_in_ROI.py',
+                            in_roi, in_roi, in_roi, '--metrics', in_ref)
+    assert ret.success
+
+    # Test with multiple metric input
+    ret = script_runner.run('scil_volume_stats_in_ROI.py',
+                            in_roi, '--metrics', in_ref, in_ref, in_ref)
+    assert ret.success
+
+    # Test with multiple metric and ROIs input
+    ret = script_runner.run('scil_volume_stats_in_ROI.py',
+                            in_roi, in_roi, '--metrics', in_ref, in_ref)
+    assert ret.success
+
+    # Test with a metric folder
+    metrics_dir = os.path.join(SCILPY_HOME, 'plot')
+    in_roi = os.path.join(SCILPY_HOME, 'plot', 'mask_wm.nii.gz')
+    ret = script_runner.run('scil_volume_stats_in_ROI.py',
+                            in_roi, '--metrics_dir', metrics_dir)
     assert ret.success

--- a/scripts/tests/test_volume_stats_in_labels.py
+++ b/scripts/tests/test_volume_stats_in_labels.py
@@ -17,9 +17,24 @@ def test_help_option(script_runner):
 
 def test_execution(script_runner, monkeypatch):
     monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
-    in_map = os.path.join(SCILPY_HOME, 'plot', 'fa.nii.gz')
+    in_metric = os.path.join(SCILPY_HOME, 'plot', 'fa.nii.gz')
     in_atlas = os.path.join(SCILPY_HOME, 'plot', 'atlas_brainnetome.nii.gz')
     atlas_lut = os.path.join(SCILPY_HOME, 'plot', 'atlas_brainnetome.json')
+
+    # Test with a single metric
     ret = script_runner.run('scil_volume_stats_in_labels.py',
-                            in_atlas, atlas_lut, "--metrics", in_map)
+                            in_atlas, atlas_lut, "--metrics", in_metric)
+    assert ret.success
+
+    # Test with multiple metrics
+    ret = script_runner.run('scil_volume_stats_in_labels.py',
+                            in_atlas, atlas_lut, "--metrics",
+                            in_metric, in_metric, in_metric)
+    assert ret.success
+
+    # Test with a metric folder
+    metrics_dir = os.path.join(SCILPY_HOME, 'plot')
+    ret = script_runner.run('scil_volume_stats_in_labels.py',
+                            in_atlas, atlas_lut, "--metrics_dir",
+                            metrics_dir)
     assert ret.success

--- a/scripts/tests/test_volume_stats_in_labels.py
+++ b/scripts/tests/test_volume_stats_in_labels.py
@@ -21,5 +21,5 @@ def test_execution(script_runner, monkeypatch):
     in_atlas = os.path.join(SCILPY_HOME, 'plot', 'atlas_brainnetome.nii.gz')
     atlas_lut = os.path.join(SCILPY_HOME, 'plot', 'atlas_brainnetome.json')
     ret = script_runner.run('scil_volume_stats_in_labels.py',
-                            in_atlas, atlas_lut, in_map)
+                            in_atlas, atlas_lut, "--metrics", in_map)
     assert ret.success


### PR DESCRIPTION
# Quick description

Add new input features to 

- scil_volume_stats_in_labels.py

  -  `in_map` was replaced by the argument group `Metrics input options`, allowing for a list of metric filenames or a metric folder;
  -  if the scripts as multiple input metrics, the output json file has a new top level dict `metric`;
  -  add `add_json_args` and corresponding formatting to the output json;
  - this PR changes the interface of the script, i.e. it will break other scripts using it.

- scil_volume_stats_in_ROI.py
  - change the positional argument `in_mask` to `in_rois`, allowing for multiple input mask.
  - if the scripts as multiple input ROIs, the output json file has a new top level dict `roi_name`;

...

## Type of change

Check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [X] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [X] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
