### PR TITLE
Add Fibertube_tracking.rst to the read-the-docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -17,4 +17,5 @@ Welcome to the scilpy documentation!
     documentation/construct_participants_tsv_file
     documentation/create_overlapping_slice_mosaics
     documentation/devcontainer
+    documentation/fibertube_tracking
     documentation/tractogram_registration


### PR DESCRIPTION
# Quick description

Add @VincentBeaud's Fibertube tracking tutorial to the scil documentation read-the-docs website (simply add to index.rst).

## Type of change

Check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

# Checklist

- [ ] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
