### PR TITLE
[FIX]: Return rejected streamlines with empty sft

### DIFF
--- a/scilpy/tractograms/streamline_operations.py
+++ b/scilpy/tractograms/streamline_operations.py
@@ -413,6 +413,7 @@ def filter_streamlines_by_length(sft, min_length=0., max_length=np.inf,
         filtered_sft = sft
 
     # Return to original space
+    sft.to_space(orig_space)
     filtered_sft.to_space(orig_space)
 
     if return_rejected:

--- a/scilpy/tractograms/streamline_operations.py
+++ b/scilpy/tractograms/streamline_operations.py
@@ -408,19 +408,15 @@ def filter_streamlines_by_length(sft, min_length=0., max_length=np.inf,
         valid_length_ids = np.logical_and(lengths >= min_length,
                                           lengths <= max_length)
         filtered_sft = sft[valid_length_ids]
-
-        if return_rejected:
-            rejected_sft = sft[~valid_length_ids]
     else:
-        valid_length_ids = []
+        valid_length_ids = np.array([], dtype=bool)
         filtered_sft = sft
 
     # Return to original space
-    sft.to_space(orig_space)
     filtered_sft.to_space(orig_space)
 
     if return_rejected:
-        rejected_sft.to_space(orig_space)
+        rejected_sft = sft[~valid_length_ids]
         return filtered_sft, valid_length_ids, rejected_sft
     else:
         return filtered_sft, valid_length_ids

--- a/scilpy/tractograms/tests/test_streamline_operations.py
+++ b/scilpy/tractograms/tests/test_streamline_operations.py
@@ -176,11 +176,11 @@ def test_filter_streamlines_by_length():
     assert np.all(lengths >= min_length) and np.all(lengths <= max_length)
 
     # === 4. Return rejected streamlines with empty sft ===
-    empty_sft = short_sft[[]] # Empty sft from short_sft (chosen arbitrarily)
-    filtered_sft, _, rejected = filter_streamlines_by_length(empty_sft,
-                                  min_length=min_length,
-                                  max_length=max_length,
-                                  return_rejected=True)
+    empty_sft = short_sft[[]]  # Empty sft from short_sft (chosen arbitrarily)
+    filtered_sft, _, rejected = \
+        filter_streamlines_by_length(empty_sft, min_length=min_length,
+                                     max_length=max_length,
+                                     return_rejected=True)
     assert isinstance(filtered_sft, StatefulTractogram)
     assert isinstance(rejected, StatefulTractogram)
     assert len(filtered_sft) == 0

--- a/scilpy/tractograms/tests/test_streamline_operations.py
+++ b/scilpy/tractograms/tests/test_streamline_operations.py
@@ -7,6 +7,7 @@ from numpy.testing import assert_array_almost_equal
 import pytest
 from dipy.io.streamline import load_tractogram
 from dipy.tracking.streamlinespeed import length
+from dipy.io.stateful_tractogram import StatefulTractogram
 
 from scilpy import SCILPY_HOME
 from scilpy.io.fetcher import fetch_data, get_testing_files_dict
@@ -173,6 +174,17 @@ def test_filter_streamlines_by_length():
     assert len(filtered_sft) < len(sft)
     # Test that streamlines shorter than 100 and longer than 120 were removed.
     assert np.all(lengths >= min_length) and np.all(lengths <= max_length)
+
+    # === 4. Return rejected streamlines with empty sft ===
+    empty_sft = short_sft[[]] # Empty sft from short_sft (chosen arbitrarily)
+    filtered_sft, _, rejected = filter_streamlines_by_length(empty_sft,
+                                  min_length=min_length,
+                                  max_length=max_length,
+                                  return_rejected=True)
+    assert isinstance(filtered_sft, StatefulTractogram)
+    assert isinstance(rejected, StatefulTractogram)
+    assert len(filtered_sft) == 0
+    assert len(rejected) == 0
 
 
 def test_filter_streamlines_by_total_length_per_dim():


### PR DESCRIPTION
# Quick description

As explained here: https://github.com/scilus/scilpy/issues/1073

## Type of change

Check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)
`pytest scilpy/tractograms/tests/test_streamline_operations.py -k 'test_filter_streamlines_by_length'`

# Checklist

- [x] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [x] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
