### PR TITLE
Fix Fury upcoming deprecation call

### DIFF
--- a/scilpy/io/fetcher.py
+++ b/scilpy/io/fetcher.py
@@ -5,9 +5,8 @@ import inspect
 import logging
 import os
 import pathlib
-import zipfile
-
 import requests
+import zipfile
 
 from scilpy import SCILPY_HOME
 

--- a/scilpy/viz/backends/fury.py
+++ b/scilpy/viz/backends/fury.py
@@ -148,7 +148,7 @@ def set_viewport(scene, orientation, slice_index, volume_shape, aspect_ratio):
         Ratio between viewport's width and height.
     """
 
-    scene.projection('parallel')
+    scene.projection(proj_type='parallel')
     camera = initialize_camera(
         orientation, slice_index, volume_shape, aspect_ratio)
     scene.set_camera(position=camera[CamParams.VIEW_POS],

--- a/scripts/tests/test_viz_volume_screenshot.py
+++ b/scripts/tests/test_viz_volume_screenshot.py
@@ -12,7 +12,8 @@ fetch_data(get_testing_files_dict(), keys=['bst.zip'])
 tmp_dir = tempfile.TemporaryDirectory()
 
 
-def test_screenshot(script_runner):
+def test_screenshot(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_fa = os.path.join(SCILPY_HOME, 'bst', 'fa.nii.gz')
 
     ret = script_runner.run("scil_viz_volume_screenshot.py", in_fa, 'fa.png')


### PR DESCRIPTION
# Quick description

Fix incomming deprecation fromFury. Also fixes some resource management problems by the test data fetcher. Closes scilus/scilpy#1059
...

## Type of change

Check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

pytest scripts/tests/test_viz_volume_screenshot.py

# Checklist

- [x] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [x] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
