### PR TITLE
Adding support for list of lists of paths in assert_inputs_exist

### DIFF
--- a/scilpy/io/utils.py
+++ b/scilpy/io/utils.py
@@ -716,9 +716,9 @@ def assert_inputs_exist(parser, required, optional=None):
     ----------
     parser: argparse.ArgumentParser object
         Parser.
-    required: string or list of paths
+    required: string or list of paths or list of lists of paths
         Required paths to be checked.
-    optional: string or list of paths
+    optional: string or list of paths or list of lists of paths
         Optional paths to be checked.
     """
 
@@ -733,10 +733,18 @@ def assert_inputs_exist(parser, required, optional=None):
         optional = [optional]
 
     for required_file in required:
-        check(required_file)
+        if isinstance(required_file, str):
+            check(required_file)
+        else:
+            for file in required_file:
+                check(file)
     for optional_file in optional or []:
         if optional_file is not None:
-            check(optional_file)
+            if isinstance(optional_file, str):
+                check(optional_file)
+            else:
+                for file in optional_file:
+                    check(file)
 
 
 def assert_inputs_dirs_exist(parser, required, optional=None):


### PR DESCRIPTION
# Quick description

I added support for a list of lists of paths in `scil_assert_inputs_exist.py`. This arises when you mix `nargs='+'` with `action='append'`.

Closes #1067 

...

## Type of change

Check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [ ] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
