### PR TITLE
FIX: Filter streamlines by length, use the "save rejection" argument.

### DIFF
--- a/scripts/scil_tractogram_filter_by_length.py
+++ b/scripts/scil_tractogram_filter_by_length.py
@@ -48,8 +48,8 @@ def _build_arg_parser():
                    help='Do not write file if there is no streamline.')
     p.add_argument('--display_counts', action='store_true',
                    help='Print streamline count before and after filtering')
-    p.add_argument('--save_rejected', action='store_true',
-                   help='Save rejected streamlines to output tractogram.')
+    p.add_argument('--out_rejected',
+                   help='If specified, save rejected streamlines to this file.')
     add_json_args(p)
     add_reference_arg(p)
     add_verbose_arg(p)
@@ -75,8 +75,17 @@ def main():
     sft = load_tractogram_with_reference(parser, args, args.in_tractogram)
 
     # Processing
-    new_sft, _, outliers_sft = filter_streamlines_by_length(
-        sft, args.minL, args.maxL, return_rejected=True)
+    return_rejected = args.out_rejected is not None
+
+    # Returns (new_sft, _, [rejected_sft]) in filtered_result
+    filtered_result = filter_streamlines_by_length(
+        sft, args.minL, args.maxL, return_rejected=return_rejected)
+
+    new_sft = filtered_result[0]
+    
+    if return_rejected:
+        rejected_sft = filtered_result[2]
+        save_tractogram(rejected_sft, args.out_rejected, args.no_empty)
 
     if args.display_counts:
         sc_bf = len(sft.streamlines)

--- a/scripts/scil_tractogram_filter_by_length.py
+++ b/scripts/scil_tractogram_filter_by_length.py
@@ -49,7 +49,8 @@ def _build_arg_parser():
     p.add_argument('--display_counts', action='store_true',
                    help='Print streamline count before and after filtering')
     p.add_argument('--out_rejected',
-                   help='If specified, save rejected streamlines to this file.')
+                   help='If specified, save rejected streamlines to this '
+                   'file.')
     add_json_args(p)
     add_reference_arg(p)
     add_verbose_arg(p)
@@ -82,7 +83,7 @@ def main():
         sft, args.minL, args.maxL, return_rejected=return_rejected)
 
     new_sft = filtered_result[0]
-    
+
     if return_rejected:
         rejected_sft = filtered_result[2]
         save_tractogram(rejected_sft, args.out_rejected, args.no_empty)

--- a/scripts/tests/test_tractogram_filter_by_length.py
+++ b/scripts/tests/test_tractogram_filter_by_length.py
@@ -6,6 +6,7 @@ import tempfile
 
 from scilpy import SCILPY_HOME
 from scilpy.io.fetcher import fetch_data, get_testing_files_dict
+from scilpy.io.streamlines import load_tractogram
 
 # If they already exist, this only takes 5 seconds (check md5sum)
 fetch_data(get_testing_files_dict(), keys=['filtering.zip'])
@@ -20,9 +21,53 @@ def test_help_option(script_runner):
 
 def test_execution_filtering(script_runner, monkeypatch):
     monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+    # Effectively, this doesn't filter anything, since bundle_4.trk has
+    # all streamlines with lengths of 130mm. This is just to test the
+    # script execution.
     in_bundle = os.path.join(SCILPY_HOME, 'filtering',
                              'bundle_4.trk')
     ret = script_runner.run('scil_tractogram_filter_by_length.py',
                             in_bundle,  'bundle_4_filtered.trk',
                             '--minL', '125', '--maxL', '130')
+    
+    sft = load_tractogram('bundle_4_filtered.trk', 'same')
+    assert len(sft) == 52
+
     assert ret.success
+
+def test_rejected_filtering(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+    in_bundle = os.path.join(SCILPY_HOME, 'filtering',
+                             'bundle_all_1mm.trk')
+    ret = script_runner.run('scil_tractogram_filter_by_length.py',
+                            in_bundle,  'bundle_all_1mm_filtered.trk',
+                            '--minL', '125', '--maxL', '130',
+                            '--out_rejected', 'bundle_all_1mm_rejected.trk')
+    assert ret.success
+    assert os.path.exists('bundle_all_1mm_rejected.trk')
+    assert os.path.exists('bundle_all_1mm_rejected.trk')
+
+    sft = load_tractogram('bundle_all_1mm_filtered.trk', 'same')
+    rejected_sft = load_tractogram('bundle_all_1mm_rejected.trk', 'same')
+    
+    assert len(sft) == 266
+    assert len(rejected_sft) == 2824
+
+def test_rejected_filtering_no_rejection(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+    in_bundle = os.path.join(SCILPY_HOME, 'filtering',
+                             'bundle_4.trk')
+    ret = script_runner.run('scil_tractogram_filter_by_length.py',
+                            in_bundle,  'bundle_4_filtered.trk',
+                            '--minL', '125', '--maxL', '130',
+                            '--out_rejected', 'bundle_4_rejected.trk')
+    assert ret.success
+    
+    # File should be created even though there are no rejected streamlines
+    assert os.path.exists('bundle_4_rejected.trk')
+
+    sft = load_tractogram('bundle_4_filtered.trk', 'same')
+    rejected_sft = load_tractogram('bundle_4_rejected.trk', 'same')
+    
+    assert len(sft) == 52
+    assert len(rejected_sft) == 0

--- a/scripts/tests/test_tractogram_filter_by_length.py
+++ b/scripts/tests/test_tractogram_filter_by_length.py
@@ -29,11 +29,12 @@ def test_execution_filtering(script_runner, monkeypatch):
     ret = script_runner.run('scil_tractogram_filter_by_length.py',
                             in_bundle,  'bundle_4_filtered.trk',
                             '--minL', '125', '--maxL', '130')
-    
+
     sft = load_tractogram('bundle_4_filtered.trk', 'same')
     assert len(sft) == 52
 
     assert ret.success
+
 
 def test_rejected_filtering(script_runner, monkeypatch):
     monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
@@ -49,9 +50,10 @@ def test_rejected_filtering(script_runner, monkeypatch):
 
     sft = load_tractogram('bundle_all_1mm_filtered.trk', 'same')
     rejected_sft = load_tractogram('bundle_all_1mm_rejected.trk', 'same')
-    
+
     assert len(sft) == 266
     assert len(rejected_sft) == 2824
+
 
 def test_rejected_filtering_no_rejection(script_runner, monkeypatch):
     monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
@@ -62,12 +64,12 @@ def test_rejected_filtering_no_rejection(script_runner, monkeypatch):
                             '--minL', '125', '--maxL', '130',
                             '--out_rejected', 'bundle_4_rejected.trk')
     assert ret.success
-    
+
     # File should be created even though there are no rejected streamlines
     assert os.path.exists('bundle_4_rejected.trk')
 
     sft = load_tractogram('bundle_4_filtered.trk', 'same')
     rejected_sft = load_tractogram('bundle_4_rejected.trk', 'same')
-    
+
     assert len(sft) == 52
     assert len(rejected_sft) == 0

--- a/scripts/tests/test_tractogram_filter_by_length.py
+++ b/scripts/tests/test_tractogram_filter_by_length.py
@@ -60,7 +60,7 @@ def test_rejected_filtering_no_rejection(script_runner, monkeypatch):
     in_bundle = os.path.join(SCILPY_HOME, 'filtering',
                              'bundle_4.trk')
     ret = script_runner.run('scil_tractogram_filter_by_length.py',
-                            in_bundle,  'bundle_4_filtered.trk',
+                            in_bundle,  'bundle_4_filtered_no_rejection.trk',
                             '--minL', '125', '--maxL', '130',
                             '--out_rejected', 'bundle_4_rejected.trk')
     assert ret.success
@@ -68,7 +68,7 @@ def test_rejected_filtering_no_rejection(script_runner, monkeypatch):
     # File should be created even though there are no rejected streamlines
     assert os.path.exists('bundle_4_rejected.trk')
 
-    sft = load_tractogram('bundle_4_filtered.trk', 'same')
+    sft = load_tractogram('bundle_4_filtered_no_rejection.trk', 'same')
     rejected_sft = load_tractogram('bundle_4_rejected.trk', 'same')
 
     assert len(sft) == 52


### PR DESCRIPTION
# Quick description

Closes https://github.com/scilus/scilpy/issues/1007.

As the script's argument was unused in the code, it's unlikely to be break someone's code as specifying this argument wasn't doing anything. I renamed it to specify the output file path for the rejected streamlines instead of just specifying the flag so that the script user can control where the saved TRK goes.

...

## Type of change

Check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (not sure)

## Provide data, screenshots, command line to test (if relevant)
`pytest scripts/tests/test_tractogram_filter_by_length.py -k 'test_rejected_filtering`

# Checklist

- [x] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [x] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
