### PR TITLE
Fixing bug in gradients_generate_sampling

### DIFF
--- a/scripts/scil_gradients_generate_sampling.py
+++ b/scripts/scil_gradients_generate_sampling.py
@@ -62,7 +62,7 @@ def _build_arg_parser():
                              "Default if you add no option is to have a b0 "
                              "at the start.")
     gg = g.add_mutually_exclusive_group()
-    gg.add_argument('--no_b0_start',
+    gg.add_argument('--no_b0_start', action='store_true',
                     help="If set, do not add a b0 at the beginning. ")
     gg.add_argument('--b0_every', type=int,
                     help='Interleave a b0 every n=b0_every values. Starts '


### PR DESCRIPTION
# Quick description

There was a small bug with the argument `--no_b0_start`, it was missing `action='store_true` and was just doing nothing.

...

## Type of change

Check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [ ] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
