### PR TITLE
Change Crop Volume BBOX for a json

### DIFF
--- a/scilpy/io/fetcher.py
+++ b/scilpy/io/fetcher.py
@@ -56,7 +56,7 @@ def get_testing_files_dict():
         "plot.zip": "a1dc54cad7e1d17e55228c2518a1b34e",
         "others.zip": "82248b4888a63b0aeffc8070cc206995",
         "fodf_filtering.zip": "5985c0644321ecf81fd694fb91e2c898",
-        "processing.zip": "eece5cdbf437b8e4b5cb89c797872e28",
+        "processing.zip": "1ba6869c9d8b58a9b911ba71fdd50a07",
         "surface_vtk_fib.zip": "241f3afd6344c967d7176b43e4a99a41",
         "tractograms.zip": "1eb29085db974b5e58d32b13eb76fbe6",
         "mrds.zip": "5abe6092400e11e9bb2423e2c387e774"

--- a/scilpy/utils/spatial.py
+++ b/scilpy/utils/spatial.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
+
 from dipy.io.utils import get_reference_info
+import json
 import nibabel.orientations as ornt
 import numpy as np
-
 from numpy.lib.index_tricks import r_ as row
 
 
@@ -212,9 +213,46 @@ class WorldBoundingBox(object):
     """
 
     def __init__(self, minimums, maximums, voxel_size):
-        self.minimums = minimums
-        self.maximums = maximums
-        self.voxel_size = voxel_size
+        self.minimums = np.asarray(minimums)
+        self.maximums = np.asarray(maximums)
+        self.voxel_size = np.asarray(voxel_size)
+
+    def dump(self, filename):
+        """
+        Save the bounding box to a json file.
+
+        Parameters
+        ----------
+        filename: str
+            Path to the json file.
+        """
+        with open(filename, 'w+') as bbox_file:
+            json.dump({
+                "minimums": self.minimums.tolist(),
+                "maximums": self.maximums.tolist(),
+                "voxel_size": self.voxel_size.tolist()}, bbox_file)
+
+    @classmethod
+    def load(cls, filename):
+        """
+        Load a bounding box from a json file.
+
+        Parameters
+        ----------
+        filename: str
+            Path to the json file.
+
+        Returns
+        -------
+        WorldBoundingBox
+            The bounding box object.
+        """
+        with open(filename) as bbox_file:
+            values = json.load(bbox_file)
+            
+            return WorldBoundingBox(np.array(values['minimums']),
+                                    np.array(values['maximums']),
+                                    np.array(values['voxel_size']))
 
 
 def world_to_voxel(coord, affine):

--- a/scilpy/utils/spatial.py
+++ b/scilpy/utils/spatial.py
@@ -249,7 +249,7 @@ class WorldBoundingBox(object):
         """
         with open(filename) as bbox_file:
             values = json.load(bbox_file)
-            
+
             return WorldBoundingBox(np.array(values['minimums']),
                                     np.array(values['maximums']),
                                     np.array(values['voxel_size']))

--- a/scilpy/utils/spatial.py
+++ b/scilpy/utils/spatial.py
@@ -5,6 +5,7 @@ import json
 import nibabel.orientations as ornt
 import numpy as np
 from numpy.lib.index_tricks import r_ as row
+import pickle
 
 
 RAS_AXES_NAMES = ["sagittal", "coronal", "axial"]
@@ -217,7 +218,7 @@ class WorldBoundingBox(object):
         self.maximums = np.asarray(maximums)
         self.voxel_size = np.asarray(voxel_size)
 
-    def dump(self, filename):
+    def dump(self, filename, use_deprecated_pickle=False):
         """
         Save the bounding box to a json file.
 
@@ -227,13 +228,16 @@ class WorldBoundingBox(object):
             Path to the json file.
         """
         with open(filename, 'w+') as bbox_file:
-            json.dump({
-                "minimums": self.minimums.tolist(),
-                "maximums": self.maximums.tolist(),
-                "voxel_size": self.voxel_size.tolist()}, bbox_file)
+            if use_deprecated_pickle:
+                pickle.dump(self, bbox_file)
+            else:
+                json.dump({
+                    "minimums": self.minimums.tolist(),
+                    "maximums": self.maximums.tolist(),
+                    "voxel_size": self.voxel_size.tolist()}, bbox_file)
 
     @classmethod
-    def load(cls, filename):
+    def load(cls, filename, use_deprecated_pickle=False):
         """
         Load a bounding box from a json file.
 
@@ -248,8 +252,10 @@ class WorldBoundingBox(object):
             The bounding box object.
         """
         with open(filename) as bbox_file:
-            values = json.load(bbox_file)
+            if use_deprecated_pickle:
+                return pickle.load(bbox_file)
 
+            values = json.load(bbox_file)
             return WorldBoundingBox(np.array(values['minimums']),
                                     np.array(values['maximums']),
                                     np.array(values['voxel_size']))

--- a/scripts/scil_volume_crop.py
+++ b/scripts/scil_volume_crop.py
@@ -63,6 +63,8 @@ def _build_arg_parser():
     g1.add_argument('--output_bbox',
                     help='Path of the json file where to write the '
                          'computed bounding box.')
+    g1.add_argument('--use_deprecated_pickle', action='store_true',
+                    help='Enable to use .pkl bounding boxes instead of .json.')
 
     return p
 
@@ -77,7 +79,8 @@ def main():
 
     img = nib.load(args.in_image)
     if args.input_bbox:
-        wbbox = WorldBoundingBox.load(args.input_bbox)
+        wbbox = WorldBoundingBox.load(args.input_bbox,
+                                      args.use_deprecated_pickle)
         if not args.ignore_voxel_size:
             voxel_size = img.header.get_zooms()[0:3]
             if not np.allclose(voxel_size, wbbox.voxel_size[0:3], atol=1e-03):
@@ -87,7 +90,7 @@ def main():
     else:
         wbbox = compute_nifti_bounding_box(img)
         if args.output_bbox:
-            wbbox.dump(args.output_bbox)
+            wbbox.dump(args.output_bbox, args.use_deprecated_pickle)
 
     out_nifti_file = crop_volume(img, wbbox)
     nib.save(out_nifti_file, args.out_image)

--- a/scripts/tests/test_volume_crop.py
+++ b/scripts/tests/test_volume_crop.py
@@ -21,10 +21,10 @@ def test_execution_processing(script_runner, monkeypatch):
     monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_dwi = os.path.join(SCILPY_HOME, 'processing', 'dwi.nii.gz')
     ret = script_runner.run('scil_volume_crop.py', in_dwi, 'dwi_crop.nii.gz',
-                            '--output_bbox', 'bbox.pickle')
+                            '--output_bbox', 'bbox.json')
     assert ret.success
 
     # Then try to load back the same box
     ret = script_runner.run('scil_volume_crop.py', in_dwi, 'dwi_crop2.nii.gz',
-                            '--input_bbox', 'bbox.pickle')
+                            '--input_bbox', 'bbox.json')
     assert ret.success


### PR DESCRIPTION
# Quick description

Pickles are path bound and unsafe. A json file is way easier to use and doesn't pose code injection problems.

...

## Type of change

Check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

pytest scripts/tests/test_colume_crop.py

# Checklist

- [x] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [x] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
