### PR TITLE
Update script scil_viz_gradients_screenshot

### DIFF
--- a/scripts/scil_viz_gradients_screenshot.py
+++ b/scripts/scil_viz_gradients_screenshot.py
@@ -121,14 +121,14 @@ def main():
         if len(args.in_gradient_scheme) == 2:
             in_gradient_schemes = args.in_gradient_scheme
             in_gradient_schemes.sort()  # [bval, bvec]
-            bvals, points = read_bvals_bvecs(in_gradient_schemes[0],
-                                             in_gradient_schemes[1])
+            bvals, bvecs = read_bvals_bvecs(in_gradient_schemes[0],
+                                            in_gradient_schemes[1])
             centroids, shell_idx = identify_shells(bvals)
         else:
             # MRtrix format X, Y, Z, b
             in_gradient_scheme = args.in_gradient_scheme[0]
             tmp = np.genfromtxt(in_gradient_scheme, delimiter=' ')
-            points = tmp[:, :3]
+            bvecs = tmp[:, :3]
             bvals = tmp[:, 3]
             centroids, shell_idx = identify_shells(bvals)
 
@@ -159,7 +159,7 @@ def main():
             for idx, val in enumerate(shell_idx):
                 if val != 0 and val != -1:
                     shell_idx[idx] -= len(np.where(indexes < val)[0])
-        ms = build_ms_from_shell_idx(points, shell_idx)
+        ms = build_ms_from_shell_idx(bvecs, shell_idx)
 
     else:
         ms = [get_sphere(args.dipy_sphere).vertices]

--- a/scripts/scil_viz_gradients_screenshot.py
+++ b/scripts/scil_viz_gradients_screenshot.py
@@ -12,6 +12,7 @@ import numpy as np
 import os
 
 from dipy.data import get_sphere
+from dipy.io.gradients import read_bvals_bvecs
 
 from scilpy.gradients.bvec_bval_tools import identify_shells
 from scilpy.io.utils import (add_overwrite_arg,
@@ -120,11 +121,8 @@ def main():
         if len(args.in_gradient_scheme) == 2:
             in_gradient_schemes = args.in_gradient_scheme
             in_gradient_schemes.sort()  # [bval, bvec]
-            # bvecs/bvals (FSL) format, X Y Z AND b (or transpose)
-            points = np.genfromtxt(in_gradient_schemes[1])
-            if points.shape[0] == 3:
-                points = points.T
-            bvals = np.genfromtxt(in_gradient_schemes[0])
+            bvals, points = read_bvals_bvecs(in_gradient_schemes[0],
+                                             in_gradient_schemes[1])
             centroids, shell_idx = identify_shells(bvals)
         else:
             # MRtrix format X, Y, Z, b

--- a/scripts/scil_viz_gradients_screenshot.py
+++ b/scripts/scil_viz_gradients_screenshot.py
@@ -89,7 +89,7 @@ def main():
 
         if len(args.in_gradient_scheme) == 2:
             assert_gradients_filenames_valid(parser, args.in_gradient_scheme,
-                                             'fsl')
+                                             True)
         elif len(args.in_gradient_scheme) == 1:
             basename, ext = os.path.splitext(args.in_gradient_scheme[0])
             if ext in ['.bvec', '.bvecs', '.bvals', '.bval']:
@@ -98,7 +98,7 @@ def main():
             else:
                 assert_gradients_filenames_valid(parser,
                                                  args.in_gradient_scheme,
-                                                 'mrtrix')
+                                                 False)
         else:
             parser.error('Depending on the gradient format you should have '
                          'two files for FSL format and one file for MRtrix')


### PR DESCRIPTION
# Quick description

The reading of .bvals and .bvecs files was outdated in `scil_viz_gradients_screenshot.py`. I used read_bvals_bvecs instead. Also, I changed the last argument given to `assert_gradients_filenames_valid`, which was not working at all. (supposed to be a bool but was 'fsl' or 'mrtrix')

...

## Type of change

Check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [ ] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
