### PR TITLE
Unit tests connectivity + FIX MAP_COORDINATES USAGE

### DIFF
--- a/scilpy/connectivity/connectivity.py
+++ b/scilpy/connectivity/connectivity.py
@@ -117,7 +117,7 @@ def compute_triu_connectivity_from_labels(tractogram, data_labels,
     return matrix, ordered_labels, start_labels, end_labels
 
 
-def load_node_nifti(directory, in_label, out_label, ref_img):
+def _load_node_nifti(directory, in_label, out_label, ref_img):
     in_filename = os.path.join(directory,
                                '{}_{}.nii.gz'.format(in_label, out_label))
 
@@ -252,8 +252,8 @@ def compute_connectivity_matrices_from_hdf5(
         measures_to_return['streamline_count'] = len(streamlines)
 
     if similarity_directory is not None:
-        density_sim = load_node_nifti(similarity_directory,
-                                      in_label, out_label, labels_img)
+        density_sim = _load_node_nifti(similarity_directory,
+                                       in_label, out_label, labels_img)
         if density_sim is None:
             ba_vox = 0
         else:

--- a/scilpy/connectivity/connectivity.py
+++ b/scilpy/connectivity/connectivity.py
@@ -5,7 +5,7 @@ import threading
 
 from dipy.io.stateful_tractogram import StatefulTractogram
 from dipy.io.utils import is_header_compatible, get_reference_info
-from dipy.tracking.streamlinespeed import length
+from dipy.tracking.streamlinespeed import length, set_number_of_points
 from dipy.tracking.vox2track import _streamlines_in_mask
 import h5py
 import nibabel as nib
@@ -38,7 +38,7 @@ def compute_triu_connectivity_from_labels(tractogram, data_labels,
         When using directly with a list of streamlines, streamlines must be in
         vox space, center origin.
     data_labels: np.ndarray
-        The loaded nifti image.
+        The loaded nifti image. Must be 3D.
     keep_background: Bool
         By default, the background (label 0) is not included in the matrix.
         If True, label 0 is kept.
@@ -66,25 +66,30 @@ def compute_triu_connectivity_from_labels(tractogram, data_labels,
         streamlines = sfs_2_pts.streamlines
 
     else:
-        streamlines = tractogram
+        # Using directly on streamlines, no SFT. Usually not recommended,
+        # useful for dwi_ml methods. Calling directly dipy's resampling.
+        streamlines = nib.streamlines.ArraySequence(tractogram)
+        streamlines = set_number_of_points(streamlines, 2)
 
     ordered_labels = list(np.sort(np.unique(data_labels)))
-    assert ordered_labels[0] >= 0, "Only accepting positive labels."
+    assert ordered_labels[0] >= 0, "Only accepting positive labels, or 0."
     nb_labels = len(ordered_labels)
     logging.debug("Computing connectivity matrix for {} labels."
                   .format(nb_labels))
 
     matrix = np.zeros((nb_labels, nb_labels), dtype=int)
-
-    labels = map_coordinates(data_labels, streamlines._data.T, order=0)
+    labels = map_coordinates(data_labels, streamlines._data.T, order=0,
+                             mode='nearest')
     start_labels = labels[0::2]
     end_labels = labels[1::2]
 
     # sort each pair of labels for start to be smaller than end
     start_labels, end_labels = zip(*[sorted(pair) for pair in
                                      zip(start_labels, end_labels)])
-
-    np.add.at(matrix, (start_labels, end_labels), 1)
+    ordered_labels = list(ordered_labels)
+    start_index = [ordered_labels.index(label) for label in start_labels]
+    end_index = [ordered_labels.index(label) for label in end_labels]
+    np.add.at(matrix, (start_index, end_index), 1)
     assert matrix.sum() == len(streamlines)
 
     # Rejecting background

--- a/scilpy/connectivity/matrix_tools.py
+++ b/scilpy/connectivity/matrix_tools.py
@@ -105,7 +105,8 @@ def evaluate_graph_measures(conn_matrix, len_matrix, avg_node_wise,
 
     Parameters
     ----------
-    conn_matrix: np.ndarray of shape ??
+    conn_matrix: np.ndarray
+        2D matrix of connectivity weights.
     len_matrix: np.ndarray of shape ??
     avg_node_wise: bool
         If true, return a single value for node-wise measures.

--- a/scilpy/connectivity/matrix_tools.py
+++ b/scilpy/connectivity/matrix_tools.py
@@ -43,27 +43,6 @@ def compute_olo(array):
     return perm
 
 
-def apply_olo(array, perm):
-    """
-    Apply the permutation from compute_RCM.
-
-    Parameters
-    ----------
-    array: ndarray (NxN)
-        Sparse connectivity matrix.
-    perm: ndarray (N,)
-        Permutations for rows and columns to be applied.
-
-    Returns
-    -------
-    ndarray (N,N)
-        Reordered array.
-    """
-    if array.ndim != 2:
-        raise ValueError('RCM can only be applied to 2D array.')
-    return array[perm].T[perm]
-
-
 def apply_reordering(array, ordering):
     """
     Apply a non-symmetric array ordering that support non-square output.
@@ -101,13 +80,12 @@ def apply_reordering(array, ordering):
 def evaluate_graph_measures(conn_matrix, len_matrix, avg_node_wise,
                             small_world):
     """
-    toDo Finish docstring
-
     Parameters
     ----------
     conn_matrix: np.ndarray
-        2D matrix of connectivity weights.
-    len_matrix: np.ndarray of shape ??
+        2D matrix of connectivity weights. Typicaly a streamline count matrix.
+    len_matrix: np.ndarray
+        2D matrix of bundle lengths.
     avg_node_wise: bool
         If true, return a single value for node-wise measures.
     small_world: bool

--- a/scilpy/connectivity/tests/test_connectivity.py
+++ b/scilpy/connectivity/tests/test_connectivity.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+import numpy as np
+
+from scilpy.connectivity.connectivity import \
+    compute_triu_connectivity_from_labels
+
+
+def test_compute_triu_connectivity_from_labels():
+    labels = np.asarray([[3, 4, 5, 6],
+                         [7, 8, 9, 10]])
+
+    # streamline 1 starts at label 4, ends at label 6
+    # streamline 2 starts at label 9, ends at label 7
+    # streamline 3 too, but not in the center (vox, corner)
+    tractogram = [np.asarray([[0, 1],
+                              [5, 6],
+                              [0, 3]]),
+                  np.asarray([[1, 2],
+                              [1, 0]]),
+                  np.asarray([[1.1, 2.2],
+                              [1.9, 0.5]])]
+    output, _, _, _ = compute_triu_connectivity_from_labels(
+        tractogram, labels)
+    assert np.array_equal(output.shape, [8, 8])
+    expected_out = np.zeros((8, 8))
+    expected_out[1, 3] = 1
+    expected_out[4, 6] = 2
+    assert np.array_equal(output, expected_out)
+
+
+def test_compute_connectivity_matrices_from_hdf5():
+    pass
+
+

--- a/scilpy/connectivity/tests/test_connectivity.py
+++ b/scilpy/connectivity/tests/test_connectivity.py
@@ -29,6 +29,7 @@ def test_compute_triu_connectivity_from_labels():
 
 
 def test_compute_connectivity_matrices_from_hdf5():
+    # ToDo. We will have to create a test hdf5.
     pass
 
 

--- a/scilpy/connectivity/tests/test_connectivity.py
+++ b/scilpy/connectivity/tests/test_connectivity.py
@@ -23,8 +23,8 @@ def test_compute_triu_connectivity_from_labels():
         tractogram, labels)
     assert np.array_equal(output.shape, [8, 8])
     expected_out = np.zeros((8, 8))
-    expected_out[1, 3] = 1
-    expected_out[4, 6] = 2
+    expected_out[1, 3] = 1  # This is labels (4, 6)
+    expected_out[4, 6] = 2  # This is labels (7, 9)
     assert np.array_equal(output, expected_out)
 
 

--- a/scilpy/connectivity/tests/test_connectivity.py
+++ b/scilpy/connectivity/tests/test_connectivity.py
@@ -7,29 +7,37 @@ from scilpy.connectivity.connectivity import \
 
 def test_compute_triu_connectivity_from_labels():
     labels = np.asarray([[3, 4, 5, 6],
-                         [7, 8, 9, 10]])
+                         [7, 8, 9, 10],
+                         [11, 12, 13, 14]])
+    labels = labels[:, :, None]
+    labels = np.concatenate([labels, labels, labels], axis=-1)
+    # Data shape: (3, 4, 3)
 
-    # streamline 1 starts at label 4, ends at label 6
-    # streamline 2 starts at label 9, ends at label 7
-    # streamline 3 too, but not in the center (vox, corner)
-    tractogram = [np.asarray([[0, 1],
-                              [5, 6],
-                              [0, 3]]),
-                  np.asarray([[1, 2],
-                              [1, 0]]),
-                  np.asarray([[1.1, 2.2],
-                              [1.9, 0.5]])]
+    # vox space, center origin
+    # streamline 1 : Easy (middle voxel).
+    #              starts at voxel (1, 1, 1) = label 8,
+    #              ends at voxel (1.1, 0.8, 1.1) = label 8.
+    # streamline 2: Border management, center of the voxel
+    #              starts at voxel (0, 1, 0) = label 4
+    #              ends at voxel (2, 0, 0) = label 11
+    # streamline 3: Idem, but not in the center  (vox, center)
+    tractogram = [np.asarray([[1.0, 1.0, 1.0],
+                              [5.0, 6.1, 10.1],
+                              [1.1, 0.8, 1.1]]),
+                  np.asarray([[0.0, 1.0, 0.0],
+                              [2.0, 0.0, 0.0]]),
+                  np.asarray([[-0.3, 0.8, -0.2],
+                              [2.1, 0.3, -0.2]])]
     output, _, _, _ = compute_triu_connectivity_from_labels(
         tractogram, labels)
-    assert np.array_equal(output.shape, [8, 8])
-    expected_out = np.zeros((8, 8))
-    expected_out[1, 3] = 1  # This is labels (4, 6)
-    expected_out[4, 6] = 2  # This is labels (7, 9)
+
+    assert np.array_equal(output.shape, [12, 12])  # 12 labels
+    expected_out = np.zeros((12, 12))
+    expected_out[5, 5] = 1  # One streamline with label (8, 8) => [5, 5]
+    expected_out[1, 8] = 2  # Two streamlines with label (4, 11) = [1, 8]
     assert np.array_equal(output, expected_out)
 
 
 def test_compute_connectivity_matrices_from_hdf5():
     # ToDo. We will have to create a test hdf5.
     pass
-
-

--- a/scilpy/connectivity/tests/test_matrix_tools.py
+++ b/scilpy/connectivity/tests/test_matrix_tools.py
@@ -9,10 +9,6 @@ def test_apply_olo():
     pass
 
 
-def test_parse_ordering():
-    pass
-
-
 def test_apply_reordering():
     pass
 

--- a/scilpy/connectivity/tests/test_matrix_tools.py
+++ b/scilpy/connectivity/tests/test_matrix_tools.py
@@ -5,10 +5,7 @@ from scilpy.connectivity.matrix_tools import apply_reordering
 
 
 def test_compute_olo():
-    pass
-
-
-def test_apply_olo():
+    # Simple and basically only using hierarchy's function. Not testing.
     pass
 
 

--- a/scilpy/connectivity/tests/test_matrix_tools.py
+++ b/scilpy/connectivity/tests/test_matrix_tools.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+import numpy as np
+
+from scilpy.connectivity.matrix_tools import apply_reordering
 
 
 def test_compute_olo():
@@ -10,8 +13,24 @@ def test_apply_olo():
 
 
 def test_apply_reordering():
-    pass
-
+    conn_matrix = np.asarray([[1, 2, 3, 4],
+                              [5, 6, 7, 8],
+                              [9, 10, 11, 12],
+                              [13, 14, 15, 16]])
+    output = apply_reordering(conn_matrix, [[0, 1, 3, 2],
+                                            [1, 2, 3, 0]])
+    # First changing rows 2 and 3
+    expected_out = np.asarray([[1, 2, 3, 4],
+                              [5, 6, 7, 8],
+                              [13, 14, 15, 16],
+                              [9, 10, 11, 12]])
+    # Permuting columns
+    expected_out = np.asarray([[2, 3, 4, 1],
+                              [6, 7, 8, 5],
+                              [14, 15, 16, 13],
+                              [10, 11, 12, 9]])
+    assert np.array_equal(output, expected_out)
+    
 
 def test_evaluate_graph_measures():
     pass

--- a/scilpy/connectivity/tests/test_matrix_tools.py
+++ b/scilpy/connectivity/tests/test_matrix_tools.py
@@ -16,18 +16,14 @@ def test_apply_reordering():
                               [13, 14, 15, 16]])
     output = apply_reordering(conn_matrix, [[0, 1, 3, 2],
                                             [1, 2, 3, 0]])
-    # First changing rows 2 and 3
-    expected_out = np.asarray([[1, 2, 3, 4],
-                              [5, 6, 7, 8],
-                              [13, 14, 15, 16],
-                              [9, 10, 11, 12]])
-    # Permuting columns
+
+    # Changing rows 2 and 3 + permuting columns
     expected_out = np.asarray([[2, 3, 4, 1],
                               [6, 7, 8, 5],
                               [14, 15, 16, 13],
                               [10, 11, 12, 9]])
     assert np.array_equal(output, expected_out)
-    
+
 
 def test_evaluate_graph_measures():
     pass

--- a/scilpy/tractograms/streamline_and_mask_operations.py
+++ b/scilpy/tractograms/streamline_and_mask_operations.py
@@ -600,9 +600,9 @@ def _intersects_two_rois(roi_data_1, roi_data_2, strl_indices,
 
     # Find all the points of the streamline that are in the ROIs
     roi_data_1_intersect = map_coordinates(
-        roi_data_1, strl_indices.T, order=0, mode='constant', cval=0)
+        roi_data_1, strl_indices.T, order=0, mode='nearest')
     roi_data_2_intersect = map_coordinates(
-        roi_data_2, strl_indices.T, order=0, mode='constant', cval=0)
+        roi_data_2, strl_indices.T, order=0, mode='nearest')
 
     # Get the indices of the voxels intersecting with the ROIs
     in_strl_indices = np.argwhere(roi_data_1_intersect).squeeze(-1)

--- a/scripts/scil_bundle_diameter.py
+++ b/scripts/scil_bundle_diameter.py
@@ -269,7 +269,7 @@ def main():
         labels_dict = {label: ([], []) for label in unique_labels}
         pts_labels = map_coordinates(data_labels,
                                      sft.streamlines._data.T-0.5,
-                                     order=0)
+                                     order=0, mode='nearest')
         # For each label, all positions and directions are needed to get
         # a tube estimation per label.
         for streamline in sft.streamlines:

--- a/scripts/scil_bundle_label_map.py
+++ b/scripts/scil_bundle_label_map.py
@@ -357,7 +357,8 @@ def main():
 
             if len(cut_sft):
                 tmp_data = ndi.map_coordinates(
-                    map, cut_sft.streamlines._data.T - 0.5, order=0)
+                    map, cut_sft.streamlines._data.T - 0.5, order=0,
+                    mode='nearest')
 
                 if basename == 'labels':
                     max_val = args.nb_pts

--- a/scripts/scil_tractogram_assign_custom_color.py
+++ b/scripts/scil_tractogram_assign_custom_color.py
@@ -214,7 +214,8 @@ def main():
                              'but got {}'.format(expected_shape, len(data)))
         else:  # args.from_anatomy:
             data = nib.load(args.from_anatomy).get_fdata()
-            data = map_coordinates(data, concat_points, order=0)
+            data = map_coordinates(data, concat_points, order=0,
+                                   mode='nearest')
     elif args.along_profile:
         data = get_streamlines_as_linspaces(sft)
         data = np.hstack(data)


### PR DESCRIPTION
Adding unit tests for connectivity methods

- Deleted method `apply_olo`. Not used anywhere inside scilpy.
- Fixed `compute_triu_connectivity_from_labels`:
    - Was putting the streamline count at the row / column of the matrix for the label's id, not the index of that label in the matrix.
    - Was not using correctly map_coordinates.
 
Led to correcting map_coordinates a bit everywhere. **Explanation:**

Without `mode='nearest'`  (meaning, pad to nearest value when out of range), the default is to pad to 0 when outside the volume. The issue is that the first half of the voxels at the limit is considered out of range, as per following picture (thanks @AntoineTheb ): 

<img width="932" height="502" alt="image" src="https://github.com/user-attachments/assets/d3d9d121-30a5-4cc9-89c4-42f4344b262b" />
