### PR TITLE
DOC - renamed the uncompress fct to streamlines_to_voxel_coordinates

### DIFF
--- a/docs/source/fake_files/uncompress.py
+++ b/docs/source/fake_files/uncompress.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
 
 
-def uncompress():
+def streamlines_to_voxel_coordinates():
     pass

--- a/scilpy/tractanalysis/connectivity_segmentation.py
+++ b/scilpy/tractanalysis/connectivity_segmentation.py
@@ -96,7 +96,8 @@ def compute_connectivity(indices, atlas_data, real_labels, segmenting_func):
     ----------
     indices: ArraySequence
         The list of 3D indices [i, j, k] of all voxels traversed by all
-        streamlines. This is the output of our uncompress function.
+        streamlines. This is the output of the
+        streamlines_to_voxel_coordinates function.
     atlas_data: np.ndarray
         The loaded image containing the labels.
     real_labels: np.ndarray
@@ -155,9 +156,9 @@ def construct_hdf5_from_connectivity(
     sft: StatefulTractogram
         The tractogram.
     indices: ArraySequence
-        Results from uncompress.
+        Results from streamlines_to_voxel_coordinates.
     points_to_idx: ArraySequence
-        Results from uncompress.
+        Results from streamlines_to_voxel_coordinates.
     real_labels: np.ndarray
         The labels.
     con_info: dict

--- a/scilpy/tractanalysis/fibertube_scoring.py
+++ b/scilpy/tractanalysis/fibertube_scoring.py
@@ -12,7 +12,7 @@ from scilpy.tracking.fibertube_utils import (streamlines_to_segments,
                                              dist_segment_segment,
                                              dist_point_segment)
 from scilpy.tracking.utils import tqdm_if_verbose
-from scilpy.tractograms.uncompress import uncompress
+from scilpy.tractograms.uncompress import streamlines_to_voxel_coordinates
 
 
 def fibertube_density(sft, samples_per_voxel_axis, verbose=False):
@@ -61,10 +61,10 @@ def fibertube_density(sft, samples_per_voxel_axis, verbose=False):
                            len(sft.streamlines))
     max_diameter = np.max(diameters)
 
-    # Everything will be in vox and corner for uncompress.
+    # Everything will be in vox and corner for streamlines_to_voxel_coordinates.
     sft.to_vox()
     sft.to_corner()
-    vox_idx_for_streamline = uncompress(sft.streamlines)
+    vox_idx_for_streamline = streamlines_to_voxel_coordinates(sft.streamlines)
     mask_idx = np.concatenate(vox_idx_for_streamline)
     mask = np.zeros((sft.dimensions), dtype=np.uint8)
     # Numpy array indexing in 3D works like this
@@ -222,7 +222,7 @@ def min_external_distance(sft, verbose):
                 min_external_distance = external_distance
                 min_external_distance_vec = (
                     get_external_vector_from_centerline_vector(vector, rp, rq)
-                    )
+                )
 
     return min_external_distance, min_external_distance_vec
 

--- a/scilpy/tractograms/tests/test_streamline_and_mask_operations.py
+++ b/scilpy/tractograms/tests/test_streamline_and_mask_operations.py
@@ -343,7 +343,7 @@ def test_compute_streamline_segment():
 
     # Split head and tail from mask
     roi_data_1, roi_data_2 = split_mask_blobs_kmeans(
-        head_tail_offset_rois, 
+        head_tail_offset_rois,
         nb_clusters=2
     )
 

--- a/scilpy/tractograms/tests/test_streamline_and_mask_operations.py
+++ b/scilpy/tractograms/tests/test_streamline_and_mask_operations.py
@@ -21,7 +21,7 @@ from scilpy.tractograms.streamline_and_mask_operations import (
     get_head_tail_density_maps,
     CuttingStyle)
 from scilpy.image.labels import get_labels_from_mask
-from scilpy.tractograms.uncompress import uncompress
+from scilpy.tractograms.uncompress import streamlines_to_voxel_coordinates
 
 
 fetch_data(get_testing_files_dict(), keys=['tractograms.zip'])
@@ -147,12 +147,15 @@ def test_trim_streamline_in_mask():
     sft.to_vox()
     sft.to_corner()
 
-    idices, points_to_idx = uncompress(sft.streamlines, return_mapping=True)
-    strl_indices = idices[0]
-    points_to_idices = points_to_idx[0]
+    indices, points_to_idx = streamlines_to_voxel_coordinates(
+        sft.streamlines,
+        return_mapping=True
+    )
+    strl_indices = indices[0]
+    points_to_indices = points_to_idx[0]
 
     cut = _trim_streamline_in_mask(
-        strl_indices, sft.streamlines[0], points_to_idices, center_roi)
+        strl_indices, sft.streamlines[0], points_to_indices, center_roi)
 
     in_result = os.path.join(SCILPY_HOME, 'tractograms',
                              'streamline_and_mask_operations',
@@ -200,12 +203,15 @@ def test_trim_streamline_in_mask_keep_longest():
     sft.to_vox()
     sft.to_corner()
 
-    idices, points_to_idx = uncompress(sft.streamlines, return_mapping=True)
-    strl_indices = idices[0]
-    points_to_idices = points_to_idx[0]
+    indices, points_to_idx = streamlines_to_voxel_coordinates(
+        sft.streamlines,
+        return_mapping=True
+    )
+    strl_indices = indices[0]
+    points_to_indices = points_to_idx[0]
 
     cut = _trim_streamline_in_mask_keep_longest(
-        strl_indices, sft.streamlines[0], points_to_idices, center_roi)
+        strl_indices, sft.streamlines[0], points_to_indices, center_roi)
 
     in_result = os.path.join(SCILPY_HOME, 'tractograms',
                              'streamline_and_mask_operations',
@@ -250,12 +256,15 @@ def test_trim_streamline_endpoints_in_mask():
     sft.to_vox()
     sft.to_corner()
 
-    idices, points_to_idx = uncompress(sft.streamlines, return_mapping=True)
-    strl_indices = idices[0]
-    points_to_idices = points_to_idx[0]
+    indices, points_to_idx = streamlines_to_voxel_coordinates(
+        sft.streamlines,
+        return_mapping=True
+    )
+    strl_indices = indices[0]
+    points_to_indices = points_to_idx[0]
 
     cut = _trim_streamline_endpoints_in_mask(
-        strl_indices, sft.streamlines[0], points_to_idices,
+        strl_indices, sft.streamlines[0], points_to_indices,
         head_tail_offset_rois)
 
     in_result = os.path.join(SCILPY_HOME, 'tractograms',
@@ -334,10 +343,14 @@ def test_compute_streamline_segment():
 
     # Split head and tail from mask
     roi_data_1, roi_data_2 = split_mask_blobs_kmeans(
-        head_tail_offset_rois, nb_clusters=2)
+        head_tail_offset_rois, 
+        nb_clusters=2
+    )
 
-    (indices, points_to_idx) = uncompress(one_sft.streamlines,
-                                          return_mapping=True)
+    (indices, points_to_idx) = streamlines_to_voxel_coordinates(
+        one_sft.streamlines,
+        return_mapping=True
+    )
 
     strl_indices = indices[0]
     # Find the first and last "voxels" of the streamline that are in the

--- a/scilpy/tractograms/uncompress.pyx
+++ b/scilpy/tractograms/uncompress.pyx
@@ -32,7 +32,7 @@ cdef struct Pointers:
 
 @cython.boundscheck(False)
 @cython.cdivision(True)
-def uncompress(streamlines, return_mapping=False):
+def streamlines_to_voxel_coordinates(streamlines, return_mapping=False):
     """
     Get the indices of the voxels traversed by each streamline; then returns
     an ArraySequence of indices, i.e. [i, j, k] coordinates.
@@ -102,7 +102,9 @@ def uncompress(streamlines, return_mapping=False):
     pointers.points_to_index_out = &points_to_index_view_out[0]
 
     while 1:
-        at_point = _uncompress(&pointers, at_point, max_points - 1)
+        at_point = _streamlines_to_voxel_coordinates(&pointers, 
+                                                     at_point, 
+                                                     max_points - 1)
         if pointers.lengths_in == pointers.lengths_in_end:
             # Job finished, we can return the streamlines
             break
@@ -147,7 +149,7 @@ cdef inline void c_get_closest_edge(double *p,
 
 @cython.boundscheck(False)
 @cython.cdivision(True)
-cdef cnp.npy_intp _uncompress(
+cdef cnp.npy_intp _streamlines_to_voxel_coordinates(
         Pointers* pointers,
         cnp.npy_intp at_point,
         cnp.npy_intp max_points) nogil:

--- a/scripts/scil_tractogram_segment_connections_from_labels.py
+++ b/scripts/scil_tractogram_segment_connections_from_labels.py
@@ -84,7 +84,7 @@ from scilpy.tractanalysis.connectivity_segmentation import (
     compute_connectivity,
     construct_hdf5_from_connectivity,
     extract_longest_segments_from_profile)
-from scilpy.tractograms.uncompress import uncompress
+from scilpy.tractograms.uncompress import streamlines_to_voxel_coordinates
 
 
 def _get_output_paths(args):
@@ -285,7 +285,10 @@ def main():
     # Get the indices of the voxels traversed by each streamline
     logging.info('*** Computing voxels traversed by each streamline ***')
     time1 = time.time()
-    indices, points_to_idx = uncompress(sft.streamlines, return_mapping=True)
+    indices, points_to_idx = streamlines_to_voxel_coordinates(
+        sft.streamlines,
+        return_mapping=True
+    )
     time2 = time.time()
     logging.info('    Streamlines intersection took {} sec.'.format(
         round(time2 - time1, 2)))


### PR DESCRIPTION
# Quick description

For clarity, the `uncompress(.)` function was renamed `streamlines_to_voxel_coordinates`.

The module remains named `scilpy.tractogram.uncompress`.

...

## Type of change

Check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [X] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
