### PR TITLE
ENH: remove `sft._data` usage part 1

### DIFF
--- a/scilpy/viz/color.py
+++ b/scilpy/viz/color.py
@@ -102,7 +102,7 @@ def get_lookup_table(name):
         name_list = name.split('-')
         colors_list = [mcolors.to_rgba(color)[0:3] for color in name_list]
         cmap = mcolors.LinearSegmentedColormap.from_list('CustomCmap',
-                                                        colors_list)
+                                                         colors_list)
         return cmap
 
     return plt.colormaps.get_cmap(name)
@@ -283,10 +283,10 @@ def prepare_colorbar_figure(cmap, lbound, ubound, nb_values=255, nb_ticks=10,
     return fig
 
 
-def ambiant_occlusion(sft, colors, factor=4):
+def ambient_occlusion(sft, colors, factor=4):
     """
     Apply ambiant occlusion to a set of colors based on point density
-    around each points. 
+    around each points.
 
     Parameters
     ----------
@@ -296,14 +296,14 @@ def ambiant_occlusion(sft, colors, factor=4):
         The original colors to modify.
     factor : float
         The factor of occlusion (how density will affect the saturation).
-    
+
     Returns
     -------
     np.ndarray
         The modified colors.
     """
 
-    pts = sft.streamlines._data
+    pts = sft.streamlines.get_data()
     hsv = mcolors.rgb_to_hsv(colors)
 
     tree = KDTree(pts)
@@ -323,6 +323,7 @@ def ambiant_occlusion(sft, colors, factor=4):
     hsv[:, 2] = np.clip(hsv[:, 2], 0, 255)
 
     return mcolors.hsv_to_rgb(hsv)
+
 
 def generate_local_coloring(sft):
     """

--- a/scripts/scil_tractogram_remove_invalid.py
+++ b/scripts/scil_tractogram_remove_invalid.py
@@ -77,7 +77,7 @@ def main():
 
     # Processing
     ori_len = len(sft)
-    ori_len_pts = len(sft.streamlines._data)
+    ori_len_pts = sft._get_point_count()
     if args.cut_invalid:
         sft, cutting_counter = cut_invalid_streamlines(sft,
                                                        epsilon=args.threshold)
@@ -92,7 +92,7 @@ def main():
         sft = remove_overlapping_points_streamlines(sft, args.threshold)
         logging.warning("data_per_point will be discarded.")
         logging.warning('Removed {} overlapping points from tractogram.'.format(
-            ori_len_pts - len(sft.streamlines._data)))
+            ori_len_pts - sft._get_point_count()))
 
     logging.warning('Removed {} invalid streamlines.'.format(
         ori_len - len(sft)))


### PR DESCRIPTION
# Quick description

As per #891, although does not fix it completely.

## Type of change

Check the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

No

# Checklist

- [x] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
