### PR TITLE
[BF] NODDI map catch error

### DIFF
--- a/scripts/scil_NODDI_maps.py
+++ b/scripts/scil_NODDI_maps.py
@@ -113,7 +113,7 @@ def main():
 
     assert_output_dirs_exist_and_empty(parser, args, args.out_dir,
                                        optional=args.save_kernels)
-    
+
     assert_headers_compatible(parser, args.in_dwi, optional=args.mask)
 
     # Generate a scheme file from the bvals and bvecs files

--- a/scripts/scil_NODDI_maps.py
+++ b/scripts/scil_NODDI_maps.py
@@ -26,6 +26,7 @@ from scilpy.io.utils import (add_overwrite_arg,
                              add_verbose_arg,
                              assert_inputs_exist,
                              assert_output_dirs_exist_and_empty,
+                             assert_headers_compatible,
                              redirect_stdout_c, add_tolerance_arg,
                              add_skip_b0_check_arg)
 from scilpy.gradients.bvec_bval_tools import (check_b0_threshold,
@@ -112,6 +113,8 @@ def main():
 
     assert_output_dirs_exist_and_empty(parser, args, args.out_dir,
                                        optional=args.save_kernels)
+    
+    assert_headers_compatible(parser, args.in_dwi, optional=args.mask)
 
     # Generate a scheme file from the bvals and bvecs files
     bvals, _ = read_bvals_bvecs(args.in_bval, args.in_bvec)


### PR DESCRIPTION
# Quick description

Script was not able to catch the error when mask and dwi don't have the same header

...

## Type of change

Check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [ ] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
