### PR TITLE
[ENH] Allow extra option for topup and eddy

### DIFF
--- a/scilpy/io/utils.py
+++ b/scilpy/io/utils.py
@@ -1050,7 +1050,7 @@ def save_matrix_in_any_format(filepath, output_data):
         raise ValueError('Extension {} is not supported'.format(ext))
 
 
-def assert_fsl_options_exist(parser, options_args, command):
+def assert_fsl_options_exist(parser, options_args, command, overwrite=False):
     """
     Assert that all options for topup or eddy exist.
     If not, print parser's usage and exit.
@@ -1063,6 +1063,8 @@ def assert_fsl_options_exist(parser, options_args, command):
         Options for fsl command
     command: string
         Command used (eddy or topup).
+    overwrite: bool
+        If true, will only print a warning if an option is not valid.
     """
     if command == 'eddy':
         fsl_options = eddy_options
@@ -1078,8 +1080,13 @@ def assert_fsl_options_exist(parser, options_args, command):
 
     for nOption in res:
         if nOption not in fsl_options:
-            parser.error('--{} is not a valid option for '
-                         '{} command.'.format(nOption, command))
+            if overwrite:
+                logging.warning('--{} may not be a valid option for '
+                                '{} command depending '
+                                'of its version.'.format(nOption, command))
+            else:
+                parser.error('--{} is not a valid option for '
+                             '{} command.'.format(nOption, command))
 
 
 def parser_color_type(arg):

--- a/scripts/scil_dwi_prepare_eddy_command.py
+++ b/scripts/scil_dwi_prepare_eddy_command.py
@@ -131,7 +131,7 @@ def main():
     required_args = [args.in_dwi, args.in_bvals, args.in_bvecs, args.in_mask]
 
     assert_inputs_exist(parser, required_args)
-    assert_fsl_options_exist(parser, args.eddy_options, 'eddy')
+    assert_fsl_options_exist(parser, args.eddy_options, 'eddy', args.overwrite)
 
     if os.path.splitext(args.out_prefix)[1] != '':
         parser.error('The prefix must not contain any extension.')

--- a/scripts/scil_dwi_prepare_topup_command.py
+++ b/scripts/scil_dwi_prepare_topup_command.py
@@ -93,7 +93,8 @@ def main():
 
     assert_inputs_exist(parser, required_args)
     assert_outputs_exist(parser, args, [], args.out_b0s)
-    assert_fsl_options_exist(parser, args.topup_options, 'topup')
+    assert_fsl_options_exist(parser, args.topup_options, 'topup',
+                             overwrite=args.overwrite)
 
     if os.path.splitext(args.out_prefix)[1] != '':
         parser.error('The prefix must not contain any extension.')


### PR DESCRIPTION
# Quick description

New versions of topup and eddy allow news options.
This PR makes them available for every versions if used with -f
...

## Type of change

Check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

...

# Checklist

- [ ] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
