### PR TITLE
Do not ignore legacy

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -37,4 +37,3 @@ addopts =
     --cov
     --cov-report html
     --cov-report xml
-    --ignore=scripts/legacy/

--- a/scripts/legacy/tests/test_legacy_scripts.py
+++ b/scripts/legacy/tests/test_legacy_scripts.py
@@ -102,7 +102,6 @@ legacy_scripts_list_tag_1_6_0 = [
     "scil_filter_tractogram_anatomically.py",
     "scil_filter_tractogram.py",
     "scil_fit_bingham_to_fodf.py",
-    "scil_fix_dsi_studio_trk.py",
     "scil_flip_gradients.py",
     "scil_flip_streamlines.py",
     "scil_flip_surface.py",


### PR DESCRIPTION
Legagcy flies currently ignored from pytest (generated too many warnings, Arnaud got tired).

Adding back to supervise any error.

Legacy scripts will be deleted in a few versions, but meanwhile, checking that they work.
