### PR TITLE
Add Sciply version - part 3

### DIFF
--- a/scripts/scil_NODDI_maps.py
+++ b/scripts/scil_NODDI_maps.py
@@ -45,7 +45,6 @@ def _build_arg_parser():
     p = argparse.ArgumentParser(description=__doc__,
                                 formatter_class=argparse.RawTextHelpFormatter,
                                 epilog=version_string)
-
     p.add_argument('in_dwi',
                    help='DWI file acquired with a NODDI compatible protocol '
                         '(single-shell data not suited).')

--- a/scripts/scil_NODDI_maps.py
+++ b/scripts/scil_NODDI_maps.py
@@ -45,6 +45,7 @@ def _build_arg_parser():
     p = argparse.ArgumentParser(description=__doc__,
                                 formatter_class=argparse.RawTextHelpFormatter,
                                 epilog=version_string)
+
     p.add_argument('in_dwi',
                    help='DWI file acquired with a NODDI compatible protocol '
                         '(single-shell data not suited).')

--- a/scripts/scil_gradients_validate_sampling.py
+++ b/scripts/scil_gradients_validate_sampling.py
@@ -24,6 +24,13 @@ single shell. The --viz_and_save option first displays both the inputed and
 optimal b-vectors on a single shell and then saves them as png. Use one or the
 other, not both. For more options on visualization, please use
 scil_viz_gradients_screenshot.py.
+------------------------------------------------------------------------------
+Reference:
+[1] Emmanuel Caruyer, Christophe Lenglet, Guillermo Sapiro,
+    Rachid Deriche. Design of multishell gradient sampling with uniform coverage
+    in diffusion MRI. Magnetic Resonance in Medicine, Wiley, 2013, 69 (6),
+    pp. 1534-1540. <http://dx.doi.org/10.1002/mrm.24736>
+------------------------------------------------------------------------------
 """
 
 import argparse
@@ -45,21 +52,14 @@ from scilpy.gradients.bvec_bval_tools import (is_normalized_bvecs,
 from scilpy.gradients.gen_gradient_sampling import (generate_gradient_sampling,
                                                     energy_comparison)
 from scilpy.viz.gradients import (plot_proj_shell, build_ms_from_shell_idx)
-
-
-EPILOG = """
-References: [1] Emmanuel Caruyer, Christophe Lenglet, Guillermo Sapiro,
-Rachid Deriche. Design of multishell gradient sampling with uniform coverage
-in diffusion MRI. Magnetic Resonance in Medicine, Wiley, 2013, 69 (6),
-pp. 1534-1540. <http://dx.doi.org/10.1002/mrm.24736>
-    """
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(
-        formatter_class=argparse.RawTextHelpFormatter,
-        description=__doc__,
-        epilog=EPILOG)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
+
     p.add_argument('in_gradients', nargs='+',
                    help='Path(s) to the gradient file(s). Either FSL '
                         '(.bval, .bvec) or MRtrix (.b).')

--- a/scripts/scil_plot_stats_per_point.py
+++ b/scripts/scil_plot_stats_per_point.py
@@ -22,11 +22,14 @@ from scilpy.io.utils import (add_overwrite_arg, assert_inputs_exist,
                              assert_output_dirs_exist_and_empty,
                              add_verbose_arg)
 from scilpy.viz.plot import plot_metrics_stats
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
     p = argparse.ArgumentParser(description=__doc__,
-                                formatter_class=argparse.RawTextHelpFormatter)
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
+
     p.add_argument('in_json',
                    help='JSON file containing the mean/std per point. For '
                         'example, can be created using '

--- a/scripts/scil_qball_metrics.py
+++ b/scripts/scil_qball_metrics.py
@@ -39,14 +39,17 @@ from scilpy.io.utils import (add_b0_thresh_arg, add_overwrite_arg,
                              assert_inputs_exist, assert_outputs_exist,
                              parse_sh_basis_arg, validate_nbr_processes,
                              assert_headers_compatible)
+from scilpy.version import version_string
 
 
 DEFAULT_SMOOTH = 0.006
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
+
     p.add_argument('in_dwi',
                    help='Path of the input diffusion volume.')
     p.add_argument('in_bval',

--- a/scripts/scil_rgb_convert.py
+++ b/scripts/scil_rgb_convert.py
@@ -30,12 +30,13 @@ import numpy as np
 
 from scilpy.io.utils import (add_overwrite_arg, assert_inputs_exist,
                              assert_outputs_exist, add_verbose_arg)
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(
-        formatter_class=argparse.RawTextHelpFormatter,
-        description=__doc__)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('in_image',
                    help='name of input RGB image.\n' +

--- a/scripts/scil_search_keywords.py
+++ b/scripts/scil_search_keywords.py
@@ -64,11 +64,13 @@ from scilpy.utils.scilpy_bot import (
 )
 from scilpy.utils.scilpy_bot import SPACING_LEN, VOCAB_FILE_PATH
 from scilpy.io.utils import add_verbose_arg
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
     p = argparse.ArgumentParser(description=__doc__,
-                                formatter_class=argparse.RawTextHelpFormatter)
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('expressions', nargs='+',
                    help='Search the provided list of expressions.\n'

--- a/scripts/scil_sh_convert.py
+++ b/scripts/scil_sh_convert.py
@@ -23,11 +23,13 @@ from scilpy.io.utils import (add_overwrite_arg, add_sh_basis_args,
                              add_processes_arg, add_verbose_arg,
                              assert_inputs_exist, assert_outputs_exist,
                              parse_sh_basis_arg)
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
-                                description=__doc__)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('in_sh',
                    help='Input SH filename. (nii or nii.gz)')

--- a/scripts/scil_sh_fusion.py
+++ b/scripts/scil_sh_fusion.py
@@ -12,6 +12,18 @@ conserving the most relevant information.
 Based on [1] and [2].
 
 Formerly: scil_merge_sh.py
+---------------------------------------------------------------------------------
+References:
+[1] Garyfallidis, E., Zucchelli, M., Houde, J-C., Descoteaux, M.
+    How to perform best ODF reconstruction from the Human Connectome
+    Project sampling scheme?
+    ISMRM 2014.
+
+[2] Khachaturian, M. H., Wisco, J. J., & Tuch, D. S. (2007). Boosting the
+    sampling efficiency of q‐ball imaging using multiple wavevector fusion.
+    Magnetic Resonance in Medicine: An Official Journal of the International
+    Society for Magnetic Resonance in Medicine, 57(2), 289-296.
+---------------------------------------------------------------------------------
 """
 
 import argparse
@@ -23,25 +35,13 @@ import numpy as np
 from scilpy.io.image import assert_same_resolution
 from scilpy.io.utils import (add_overwrite_arg, assert_inputs_exist,
                              assert_outputs_exist, add_verbose_arg)
-
-
-EPILOG = """
-Reference:
-[1] Garyfallidis, E., Zucchelli, M., Houde, J-C., Descoteaux, M.
-    How to perform best ODF reconstruction from the Human Connectome
-    Project sampling scheme?
-    ISMRM 2014.
-
-[2] Khachaturian, M. H., Wisco, J. J., & Tuch, D. S. (2007). Boosting the
-    sampling efficiency of q‐ball imaging using multiple wavevector fusion.
-    Magnetic Resonance in Medicine: An Official Journal of the International
-    Society for Magnetic Resonance in Medicine, 57(2), 289-296.
-"""
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
-                                description=__doc__, epilog=EPILOG)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('in_shs', nargs="+",
                    help='List of SH files.')

--- a/scripts/scil_sh_to_aodf.py
+++ b/scripts/scil_sh_to_aodf.py
@@ -13,6 +13,16 @@ Unified filtering can be accelerated using OpenCL with the option --use_opencl.
 Make sure you have pyopencl installed before using this option. By default, the
 OpenCL program will run on the cpu. To use a gpu instead, also specify the
 option --device gpu.
+----------------------------------------------------------------------------------
+References:
+[1] Poirier and Descoteaux, 2024, "A Unified Filtering Method for Estimating
+    Asymmetric Orientation Distribution Functions", Neuroimage, vol. 287,
+    https://doi.org/10.1016/j.neuroimage.2024.120516
+
+[2] Poirier et al, 2021, "Investigating the Occurrence of Asymmetric Patterns
+    in White Matter Fiber Orientation Distribution Functions", ISMRM 2021
+    (abstract 0865)
+---------------------------------------------------------------------------------
 """
 
 import argparse
@@ -28,22 +38,13 @@ from scilpy.io.utils import (add_overwrite_arg, add_verbose_arg,
                              assert_inputs_exist, add_sh_basis_args,
                              assert_outputs_exist, parse_sh_basis_arg)
 from scilpy.denoise.asym_filtering import (cosine_filtering, unified_filtering)
-
-
-EPILOG = """
-[1] Poirier and Descoteaux, 2024, "A Unified Filtering Method for Estimating
-    Asymmetric Orientation Distribution Functions", Neuroimage, vol. 287,
-    https://doi.org/10.1016/j.neuroimage.2024.120516
-
-[2] Poirier et al, 2021, "Investigating the Occurrence of Asymmetric Patterns
-    in White Matter Fiber Orientation Distribution Functions", ISMRM 2021
-    (abstract 0865)
-"""
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(description=__doc__, epilog=EPILOG,
-                                formatter_class=argparse.RawTextHelpFormatter)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
     p.add_argument('in_sh',
                    help='Path to the input file.')
 

--- a/scripts/scil_sh_to_aodf.py
+++ b/scripts/scil_sh_to_aodf.py
@@ -45,6 +45,7 @@ def _build_arg_parser():
     p = argparse.ArgumentParser(description=__doc__,
                                 formatter_class=argparse.RawTextHelpFormatter,
                                 epilog=version_string)
+
     p.add_argument('in_sh',
                    help='Path to the input file.')
 

--- a/scripts/scil_sh_to_rish.py
+++ b/scripts/scil_sh_to_rish.py
@@ -13,11 +13,13 @@ any SH order.
 
 Each RISH feature will be saved as a separate file.
 
-[1] Mirzaalian, Hengameh, et al. "Harmonizing diffusion MRI data across
-multiple sites and scanners." MICCAI 2015.
-https://scholar.harvard.edu/files/hengameh/files/miccai2015.pdf
-
 Formerly: scil_compute_rish_from_sh.py
+-----------------------------------------------------------------------
+Reference:
+[1] Mirzaalian, Hengameh, et al. "Harmonizing diffusion MRI data across
+    multiple sites and scanners." MICCAI 2015.
+    https://scholar.harvard.edu/files/hengameh/files/miccai2015.pdf
+-----------------------------------------------------------------------
 """
 import argparse
 import logging
@@ -31,11 +33,14 @@ from scilpy.io.utils import (add_overwrite_arg, assert_inputs_exist,
                              assert_outputs_exist, add_verbose_arg,
                              assert_headers_compatible)
 from scilpy.reconst.sh import compute_rish
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
+
     p.add_argument('in_sh',
                    help='Path of the sh image. They can be formatted in any '
                         'sh basis, but we \nexpect it to be a symmetrical '

--- a/scripts/scil_sh_to_sf.py
+++ b/scripts/scil_sh_to_sf.py
@@ -29,11 +29,14 @@ from scilpy.io.utils import (add_overwrite_arg, add_processes_arg,
                              assert_inputs_exist, assert_outputs_exist,
                              parse_sh_basis_arg, validate_nbr_processes)
 from scilpy.reconst.sh import convert_sh_to_sf
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
+
     p.add_argument('in_sh',
                    help='Path of the SH volume.')
     p.add_argument('out_sf',

--- a/scripts/scil_stats_group_comparison.py
+++ b/scripts/scil_stats_group_comparison.py
@@ -56,12 +56,13 @@ from scilpy.stats.utils import (data_for_stat,
                                 get_group_data_sample,
                                 visualise_distribution,
                                 write_current_dictionnary)
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-
-    p = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('in_json', metavar='IN_JSON',
                    help='Input JSON file from tractometry nextflow pipeline'

--- a/scripts/scil_surface_apply_transform.py
+++ b/scripts/scil_surface_apply_transform.py
@@ -18,6 +18,10 @@ The resulting surface will be in *b0 world LPS* coordinates
 (aligned over the b0 in MI-Brain).
 
 Formerly: scil_apply_transform_to_surface.py.
+-------------------------------------------------------------------------------------------
+Reference:
+[1] St-Onge, E., Daducci, A., Girard, G. and Descoteaux, M. 2018.
+    Surface-enhanced tractography (SET). NeuroImage.
 """
 
 import argparse
@@ -33,18 +37,13 @@ from scilpy.io.utils import (add_overwrite_arg,
                              assert_outputs_exist,
                              load_matrix_in_any_format)
 from scilpy.surfaces.surface_operations import apply_transform
-
-
-EPILOG = """
-References:
-[1] St-Onge, E., Daducci, A., Girard, G. and Descoteaux, M. 2018.
-    Surface-enhanced tractography (SET). NeuroImage.
-"""
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(description=__doc__, epilog=EPILOG,
-                                formatter_class=argparse.RawTextHelpFormatter)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('in_moving_surface',
                    help='Input surface (.vtk).')

--- a/scripts/scil_surface_apply_transform.py
+++ b/scripts/scil_surface_apply_transform.py
@@ -18,10 +18,11 @@ The resulting surface will be in *b0 world LPS* coordinates
 (aligned over the b0 in MI-Brain).
 
 Formerly: scil_apply_transform_to_surface.py.
--------------------------------------------------------------------------------------------
+-------------------------------------------------------------------
 Reference:
 [1] St-Onge, E., Daducci, A., Girard, G. and Descoteaux, M. 2018.
     Surface-enhanced tractography (SET). NeuroImage.
+-------------------------------------------------------------------
 """
 
 import argparse

--- a/scripts/scil_surface_convert.py
+++ b/scripts/scil_surface_convert.py
@@ -11,6 +11,11 @@ Supported formats:
 > scil_surface_convert.py surf.vtk converted_surf.ply
 
 Formerly: scil_convert_surface.py
+-----------------------------------------------------------------
+Reference:
+[1] St-Onge, E., Daducci, A., Girard, G. and Descoteaux, M. 2018.
+    Surface-enhanced tractography (SET). NeuroImage.
+-----------------------------------------------------------------
 """
 import argparse
 import logging
@@ -26,17 +31,13 @@ from scilpy.io.utils import (add_overwrite_arg,
                              add_verbose_arg,
                              assert_inputs_exist,
                              assert_outputs_exist)
-
-EPILOG = """
-References:
-[1] St-Onge, E., Daducci, A., Girard, G. and Descoteaux, M. 2018.
-    Surface-enhanced tractography (SET). NeuroImage.
-"""
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(description=__doc__, epilog=EPILOG,
-                                formatter_class=argparse.RawTextHelpFormatter)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('in_surface',
                    help='Input a surface (FreeSurfer or supported by VTK).')

--- a/scripts/scil_surface_create.py
+++ b/scripts/scil_surface_create.py
@@ -10,6 +10,11 @@ Example : use wmparc.a2009s.nii.gz with some aseg.stats indices
 scil_surface_create.py out_surface.vtk \\
     --in_labels s1a1/mask/S1-A1_wmparc.a2009s.nii.gz\\
     --list_indices 16:32 --opening 2 --smooth 2 -v
+-----------------------------------------------------------------
+Reference:
+[1] St-Onge, E., Daducci, A., Girard, G. and Descoteaux, M. 2018.
+    Surface-enhanced tractography (SET). NeuroImage.
+-----------------------------------------------------------------
 """
 
 import argparse
@@ -35,17 +40,13 @@ from scilpy.io.utils import (add_overwrite_arg,
                              assert_inputs_exist,
                              assert_outputs_exist,
                              ranged_type)
-
-EPILOG = """
-References:
-[1] St-Onge, E., Daducci, A., Girard, G. and Descoteaux, M. 2018.
-    Surface-enhanced tractography (SET). NeuroImage.
-"""
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(description=__doc__, epilog=EPILOG,
-                                formatter_class=argparse.RawTextHelpFormatter)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     g1 = p.add_argument_group("Input (Labels or Mask)")
     mxg = g1.add_mutually_exclusive_group(required=True)

--- a/scripts/scil_surface_flip.py
+++ b/scripts/scil_surface_flip.py
@@ -8,6 +8,11 @@ Can flip surface coordinates around a single or multiple axes
 Can also be used to reverse the orientation of the surface normals.
 
 Formerly: scil_flip_surface.py
+-----------------------------------------------------------------
+Reference:
+[1] St-Onge, E., Daducci, A., Girard, G. and Descoteaux, M. 2018.
+    Surface-enhanced tractography (SET). NeuroImage.
+-----------------------------------------------------------------
 """
 
 import argparse
@@ -20,17 +25,13 @@ from scilpy.io.utils import (add_overwrite_arg,
                              assert_inputs_exist,
                              assert_outputs_exist)
 from scilpy.surfaces.surface_operations import flip
-
-EPILOG = """
-References:
-[1] St-Onge, E., Daducci, A., Girard, G. and Descoteaux, M. 2018.
-    Surface-enhanced tractography (SET). NeuroImage.
-"""
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(description=__doc__, epilog=EPILOG,
-                                formatter_class=argparse.RawTextHelpFormatter)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('in_surface',
                    help='Input surface (.vtk).')

--- a/scripts/scil_surface_smooth.py
+++ b/scripts/scil_surface_smooth.py
@@ -13,6 +13,11 @@ Smoothing time = step_size * nb_steps
     large amount of smoothing [step_size 100, nb_steps 1000]
 
 Formerly: scil_smooth_surface.py
+-----------------------------------------------------------------
+Reference:
+[1] St-Onge, E., Daducci, A., Girard, G. and Descoteaux, M. 2018.
+    Surface-enhanced tractography (SET). NeuroImage.
+-----------------------------------------------------------------
 """
 
 import argparse
@@ -25,18 +30,13 @@ from scilpy.io.utils import (add_overwrite_arg,
                              add_verbose_arg,
                              assert_inputs_exist,
                              assert_outputs_exist)
-
-
-EPILOG = """
-References:
-[1] St-Onge, E., Daducci, A., Girard, G. and Descoteaux, M. 2018.
-    Surface-enhanced tractography (SET). NeuroImage.
-"""
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(description=__doc__, epilog=EPILOG,
-                                formatter_class=argparse.RawTextHelpFormatter)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('in_surface',
                    help='Input surface (.vtk).')

--- a/scripts/scil_tracking_local.py
+++ b/scripts/scil_tracking_local.py
@@ -47,7 +47,7 @@ All the input nifti files must be in isotropic resolution.
 
 Formerly: scil_compute_local_tracking.py
 --------------------------------------------------------------------------------
-References
+References:
 [1] Garyfallidis, E. (2012). Towards an accurate brain tractography
     [PhD thesis]. University of Cambridge. United Kingdom.
 

--- a/scripts/scil_tracking_local.py
+++ b/scripts/scil_tracking_local.py
@@ -45,16 +45,15 @@ implementations:
 
 All the input nifti files must be in isotropic resolution.
 
-
-References
-----------
-[1]: Garyfallidis, E. (2012). Towards an accurate brain tractography
-[PhD thesis]. University of Cambridge. United Kingdom.
-
-[2]: Aydogan, D. B., & Shi, Y. (2020). Parallel transport tractography.
-IEEE transactions on medical imaging, 40(2), 635-647.
-
 Formerly: scil_compute_local_tracking.py
+--------------------------------------------------------------------------------
+References
+[1] Garyfallidis, E. (2012). Towards an accurate brain tractography
+    [PhD thesis]. University of Cambridge. United Kingdom.
+
+[2] Aydogan, D. B., & Shi, Y. (2020). Parallel transport tractography.
+    IEEE transactions on medical imaging, 40(2), 635-647.
+--------------------------------------------------------------------------------
 """
 
 import argparse
@@ -82,6 +81,7 @@ from scilpy.tracking.utils import (add_mandatory_options_tracking,
                                    get_direction_getter, get_theta,
                                    save_tractogram, verify_seed_options,
                                    verify_streamline_length_options)
+from scilpy.version import version_string
 
 # GPU tracking arguments default values
 DEFAULT_BATCH_SIZE = 10000
@@ -91,9 +91,9 @@ DEFAULT_GPU_SPHERE = 'repulsion724'
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(
-        description=__doc__,
-        formatter_class=argparse.RawTextHelpFormatter)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     # Options that are the same in this script and scil_tracking_local_dev:
     add_mandatory_options_tracking(p)

--- a/scripts/scil_tracking_local_dev.py
+++ b/scripts/scil_tracking_local_dev.py
@@ -40,7 +40,7 @@ A few notes on Runge-Kutta integration.
 
 Formerly: scil_compute_local_tracking_dev.py
 -------------------------------------------------------------------------------
-References: 
+Reference: 
 [1] Girard, G., Whittingstall K., Deriche, R., and Descoteaux, M. (2014). 
     Towards quantitative connectivity analysis:reducing tractography biases. 
     Neuroimage, 98, 266-278.

--- a/scripts/scil_tracking_local_dev.py
+++ b/scripts/scil_tracking_local_dev.py
@@ -38,11 +38,13 @@ A few notes on Runge-Kutta integration.
     2. As a rule of thumb, doubling the rk_order will double the computation
        time in the worst case.
 
-References: [1] Girard, G., Whittingstall K., Deriche, R., and
-            Descoteaux, M. (2014). Towards quantitative connectivity analysis:
-            reducing tractography biases. Neuroimage, 98, 266-278.
-
 Formerly: scil_compute_local_tracking_dev.py
+-------------------------------------------------------------------------------
+References: 
+[1] Girard, G., Whittingstall K., Deriche, R., and Descoteaux, M. (2014). 
+    Towards quantitative connectivity analysis:reducing tractography biases. 
+    Neuroimage, 98, 266-278.
+-------------------------------------------------------------------------------
 """
 import argparse
 import logging
@@ -73,12 +75,13 @@ from scilpy.tracking.utils import (add_mandatory_options_tracking,
                                    get_theta,
                                    verify_streamline_length_options,
                                    verify_seed_options)
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(
-        formatter_class=argparse.RawTextHelpFormatter,
-        description=__doc__)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     # Options common to both scripts
     add_mandatory_options_tracking(p)

--- a/scripts/scil_tracking_pft.py
+++ b/scripts/scil_tracking_pft.py
@@ -26,6 +26,12 @@ deterministic algorithm and 0.2mm for probabilitic algorithm.
 All the input nifti files must be in isotropic resolution.
 
 Formerly: scil_compute_pft.py
+-----------------------------------------------------------------------------
+Reference:
+[1]Girard, G., Whittingstall K., Deriche, R., and Descoteaux, M. (2014). 
+Towards quantitative connectivity analysis: reducing tractographybiases. 
+Neuroimage.
+-----------------------------------------------------------------------------
 """
 
 import argparse
@@ -52,15 +58,13 @@ from scilpy.io.utils import (add_overwrite_arg, add_sh_basis_args,
                              assert_headers_compatible, add_compression_arg,
                              verify_compression_th)
 from scilpy.tracking.utils import get_theta
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawTextHelpFormatter,
-        epilog='References: [1] Girard, G., Whittingstall K., Deriche, R., '
-               'and Descoteaux, M. (2014). Towards quantitative connectivity '
-               'analysis: reducing tractography biases. Neuroimage, 98, '
-               '266-278.')
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
     p._optionals.title = 'Generic options'
 
     p.add_argument('in_sh',

--- a/scripts/scil_tracking_pft.py
+++ b/scripts/scil_tracking_pft.py
@@ -28,9 +28,9 @@ All the input nifti files must be in isotropic resolution.
 Formerly: scil_compute_pft.py
 -----------------------------------------------------------------------------
 Reference:
-[1]Girard, G., Whittingstall K., Deriche, R., and Descoteaux, M. (2014). 
-Towards quantitative connectivity analysis: reducing tractographybiases. 
-Neuroimage.
+[1] Girard, G., Whittingstall K., Deriche, R., and Descoteaux, M. (2014). 
+    Towards quantitative connectivity analysis: reducing tractographybiases. 
+    Neuroimage.
 -----------------------------------------------------------------------------
 """
 
@@ -65,6 +65,7 @@ def _build_arg_parser():
     p = argparse.ArgumentParser(description=__doc__,
                                 formatter_class=argparse.RawTextHelpFormatter,
                                 epilog=version_string)
+
     p._optionals.title = 'Generic options'
 
     p.add_argument('in_sh',

--- a/scripts/scil_tracking_pft_maps.py
+++ b/scripts/scil_tracking_pft_maps.py
@@ -11,6 +11,12 @@ References: Girard, G., Whittingstall K., Deriche, R., and Descoteaux, M.
 biases. Neuroimage.
 
 Formerly: scil_compute_maps_for_particle_filter_tracking.py
+-----------------------------------------------------------------------------
+Reference:
+[1]Girard, G., Whittingstall K., Deriche, R., and Descoteaux, M. (2014). 
+Towards quantitative connectivity analysis: reducing tractographybiases. 
+Neuroimage.
+-----------------------------------------------------------------------------
 """
 
 import argparse
@@ -23,11 +29,14 @@ from scilpy.io.utils import (add_overwrite_arg,
                              assert_inputs_exist,
                              assert_outputs_exist,
                              add_verbose_arg)
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
+
     p.add_argument('in_wm',
                    help='White matter PVE map (nifti). From normal FAST '
                         'output, has a PVE_2 name suffix.')

--- a/scripts/scil_tracking_pft_maps.py
+++ b/scripts/scil_tracking_pft_maps.py
@@ -13,9 +13,9 @@ biases. Neuroimage.
 Formerly: scil_compute_maps_for_particle_filter_tracking.py
 -----------------------------------------------------------------------------
 Reference:
-[1]Girard, G., Whittingstall K., Deriche, R., and Descoteaux, M. (2014). 
-Towards quantitative connectivity analysis: reducing tractographybiases. 
-Neuroimage.
+[1] Girard, G., Whittingstall K., Deriche, R., and Descoteaux, M. (2014). 
+    Towards quantitative connectivity analysis: reducing tractographybiases. 
+    Neuroimage.
 -----------------------------------------------------------------------------
 """
 

--- a/scripts/scil_tracking_pft_maps_edit.py
+++ b/scripts/scil_tracking_pft_maps_edit.py
@@ -17,27 +17,29 @@ from scilpy.io.image import get_data_as_mask
 from scilpy.io.utils import (add_overwrite_arg, add_verbose_arg,
                              assert_inputs_exist, assert_outputs_exist,
                              assert_headers_compatible)
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    parser = argparse.ArgumentParser(
-        description=__doc__,
-        formatter_class=argparse.RawTextHelpFormatter)
-    parser.add_argument('map_include',
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
+
+    p.add_argument('map_include',
                         help='PFT map include.')
-    parser.add_argument('map_exclude',
+    p.add_argument('map_exclude',
                         help='PFT map exclude.')
-    parser.add_argument('additional_mask',
+    p.add_argument('additional_mask',
                         help='Allow PFT tracking in this mask.')
-    parser.add_argument('map_include_corr',
+    p.add_argument('map_include_corr',
                         help='Corrected PFT map include output file name.')
-    parser.add_argument('map_exclude_corr',
+    p.add_argument('map_exclude_corr',
                         help='Corrected PFT map exclude output file name.')
 
-    add_verbose_arg(parser)
-    add_overwrite_arg(parser)
+    add_verbose_arg(p)
+    add_overwrite_arg(p)
 
-    return parser
+    return p
 
 
 def main():

--- a/scripts/scil_tractogram_apply_transform.py
+++ b/scripts/scil_tractogram_apply_transform.py
@@ -54,11 +54,13 @@ from scilpy.io.utils import (add_overwrite_arg,
                              assert_outputs_exist,
                              load_matrix_in_any_format)
 from scilpy.tractograms.tractogram_operations import transform_warp_sft
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
-                                description=__doc__)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('in_moving_tractogram',
                    help='Path of the tractogram to be transformed.\n'

--- a/scripts/scil_tractogram_apply_transform_to_hdf5.py
+++ b/scripts/scil_tractogram_apply_transform_to_hdf5.py
@@ -33,11 +33,13 @@ from scilpy.io.utils import (add_overwrite_arg,
                              assert_outputs_exist,
                              load_matrix_in_any_format)
 from scilpy.tractograms.tractogram_operations import transform_warp_sft
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
-                                description=__doc__)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('in_hdf5',
                    help='Path of the hdf5 containing the moving tractogram, '

--- a/scripts/scil_tractogram_assign_custom_color.py
+++ b/scripts/scil_tractogram_assign_custom_color.py
@@ -69,12 +69,13 @@ from scilpy.tractograms.streamline_operations import (
 from scilpy.viz.color import (
     get_lookup_table, prepare_colorbar_figure, ambiant_occlusion,
     generate_local_coloring)
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(
-        description=__doc__,
-        formatter_class=argparse.RawTextHelpFormatter)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('in_tractogram',
                    help='Input tractogram (.trk or .tck).')

--- a/scripts/scil_tractogram_assign_uniform_color.py
+++ b/scripts/scil_tractogram_assign_uniform_color.py
@@ -31,12 +31,13 @@ from scilpy.io.utils import (assert_inputs_exist,
                              add_verbose_arg,
                              add_reference_arg, assert_headers_compatible)
 from scilpy.viz.color import format_hexadecimal_color_to_rgb, ambiant_occlusion
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(
-        description=__doc__,
-        formatter_class=argparse.RawTextHelpFormatter)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('in_tractograms', nargs='+',
                    help='Input tractograms (.trk or .tck).')

--- a/scripts/scil_tractogram_commit.py
+++ b/scripts/scil_tractogram_commit.py
@@ -71,6 +71,15 @@ When tunning parameters, such as --iso_diff, --para_diff, --perp_diff or
     - Compare the density map before and after (essential tractogram)
 
 Formerly: scil_run_commit.py
+--------------------------------------------------------------------------------
+References:
+[1] Daducci, Alessandro, et al. "COMMIT: convex optimization modeling for
+    microstructure informed tractography." IEEE transactions on medical
+    imaging 34.1 (2014): 246-257.
+[2] Schiavi, Simona, et al. "A new method for accurate in vivo mapping of
+    human brain connections using microstructural and anatomical information."
+    Science advances 6.31 (2020): eaba8245.
+--------------------------------------------------------------------------------
 """
 
 import argparse
@@ -107,21 +116,13 @@ from scilpy.io.utils import (add_overwrite_arg,
                              add_reference_arg)
 from scilpy.gradients.bvec_bval_tools import identify_shells, \
     check_b0_threshold
-
-EPILOG = """
-References:
-[1] Daducci, Alessandro, et al. "COMMIT: convex optimization modeling for
-    microstructure informed tractography." IEEE transactions on medical
-    imaging 34.1 (2014): 246-257.
-[2] Schiavi, Simona, et al. "A new method for accurate in vivo mapping of
-    human brain connections using microstructural and anatomical information."
-    Science advances 6.31 (2020): eaba8245.
-"""
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(description=__doc__, epilog=EPILOG,
-                                formatter_class=argparse.RawTextHelpFormatter)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('in_tractogram',
                    help='Input tractogram (.trk or .tck or .h5).')

--- a/scripts/scil_tractogram_commit.py
+++ b/scripts/scil_tractogram_commit.py
@@ -76,6 +76,7 @@ References:
 [1] Daducci, Alessandro, et al. "COMMIT: convex optimization modeling for
     microstructure informed tractography." IEEE transactions on medical
     imaging 34.1 (2014): 246-257.
+
 [2] Schiavi, Simona, et al. "A new method for accurate in vivo mapping of
     human brain connections using microstructural and anatomical information."
     Science advances 6.31 (2020): eaba8245.

--- a/scripts/scil_tractogram_compress.py
+++ b/scripts/scil_tractogram_compress.py
@@ -23,11 +23,14 @@ from scilpy.tractograms.tractogram_operations import \
 from scilpy.io.utils import (add_overwrite_arg, add_verbose_arg,
                              assert_inputs_exist, assert_outputs_exist,
                              verify_compression_th)
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
+
     p.add_argument('in_tractogram',
                    help='Path of the input tractogram file (trk or tck).')
     p.add_argument('out_tractogram',

--- a/scripts/scil_tractogram_compute_TODI.py
+++ b/scripts/scil_tractogram_compute_TODI.py
@@ -10,6 +10,12 @@ This script can afterwards output a Track Density Image (TDI) or a TODI with SF
 or SH representation, based on streamlines' segments.
 
 Formerly: scil_compute_todi.py
+------------------------------------------------------------------------------------
+Reference:
+[1] Dhollander T, Emsell L, Van Hecke W, Maes F, Sunaert S, Suetens P. 
+    Track orientation density imaging (TODI) and track orientation distribution (TOD) 
+    based tractography. NeuroImage. 2014 Jul 1;94:312-36.
+------------------------------------------------------------------------------------
 """
 
 import argparse
@@ -25,20 +31,13 @@ from scilpy.io.utils import (add_overwrite_arg, add_reference_arg,
                              assert_inputs_exist, assert_outputs_exist,
                              parse_sh_basis_arg, assert_headers_compatible)
 from scilpy.tractanalysis.todi import TrackOrientationDensityImaging
-
-
-EPILOG = """
-References:
-    [1] Dhollander T, Emsell L, Van Hecke W, Maes F, Sunaert S, Suetens P.
-        Track orientation density imaging (TODI) and
-        track orientation distribution (TOD) based tractography.
-        NeuroImage. 2014 Jul 1;94:312-36.
-"""
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(description=__doc__, epilog=EPILOG,
-                                formatter_class=argparse.RawTextHelpFormatter)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('in_tractogram',
                    help='Input streamlines file.')

--- a/scripts/scil_tractogram_compute_density_map.py
+++ b/scripts/scil_tractogram_compute_density_map.py
@@ -19,11 +19,14 @@ from scilpy.io.utils import (add_overwrite_arg, add_reference_arg,
                              assert_inputs_exist, add_verbose_arg, 
                              assert_outputs_exist)
 from scilpy.tractanalysis.streamlines_metrics import compute_tract_counts_map
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
+
     p.add_argument('in_bundle',
                    help='Tractogram filename.')
     p.add_argument('out_img',

--- a/scripts/scil_tractogram_convert.py
+++ b/scripts/scil_tractogram_convert.py
@@ -21,11 +21,13 @@ from scilpy.io.utils import (add_bbox_arg, add_overwrite_arg,
                              add_reference_arg, assert_inputs_exist,
                              assert_outputs_exist, add_verbose_arg)
 from trimeshpy.vtk_util import lines_to_vtk_polydata, save_polydata
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
     p = argparse.ArgumentParser(description=__doc__,
-                                formatter_class=argparse.RawTextHelpFormatter)
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('in_tractogram',
                    help='Tractogram filename. Format must be one of \n'

--- a/scripts/scil_tractogram_convert_hdf5_to_trk.py
+++ b/scripts/scil_tractogram_convert_hdf5_to_trk.py
@@ -45,6 +45,7 @@ def _build_arg_parser():
     p = argparse.ArgumentParser(description=__doc__,
                                 formatter_class=argparse.RawTextHelpFormatter,
                                 epilog=version_string)
+
     p.add_argument('in_hdf5',
                    help='HDF5 filename (.h5) containing decomposed '
                         'connections.')

--- a/scripts/scil_tractogram_convert_hdf5_to_trk.py
+++ b/scripts/scil_tractogram_convert_hdf5_to_trk.py
@@ -38,11 +38,13 @@ from scilpy.io.hdf5 import reconstruct_sft_from_hdf5
 from scilpy.io.utils import (add_overwrite_arg, add_verbose_arg,
                              assert_inputs_exist,
                              assert_output_dirs_exist_and_empty)
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
     p.add_argument('in_hdf5',
                    help='HDF5 filename (.h5) containing decomposed '
                         'connections.')

--- a/scripts/scil_tractogram_convert_trk_to_hdf5.py
+++ b/scripts/scil_tractogram_convert_trk_to_hdf5.py
@@ -46,6 +46,7 @@ def _build_arg_parser():
     p = argparse.ArgumentParser(description=__doc__,
                                 formatter_class=argparse.RawTextHelpFormatter,
                                 epilog=version_string)
+
     p.add_argument('in_bundles', nargs='+',
                    help='Path of the input connection(s) or bundle(s).')
     p.add_argument('out_hdf5',

--- a/scripts/scil_tractogram_convert_trk_to_hdf5.py
+++ b/scripts/scil_tractogram_convert_trk_to_hdf5.py
@@ -39,11 +39,13 @@ from scilpy.io.streamlines import load_tractogram_with_reference
 from scilpy.io.utils import (add_overwrite_arg, add_verbose_arg,
                              assert_inputs_exist,
                              assert_outputs_exist)
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
     p.add_argument('in_bundles', nargs='+',
                    help='Path of the input connection(s) or bundle(s).')
     p.add_argument('out_hdf5',

--- a/scripts/scil_tractogram_count_streamlines.py
+++ b/scripts/scil_tractogram_count_streamlines.py
@@ -25,6 +25,7 @@ def _build_arg_parser():
     p = argparse.ArgumentParser(description=__doc__,
                                 formatter_class=argparse.RawTextHelpFormatter,
                                 epilog=version_string)
+
     p.add_argument('in_tractogram',
                    help='Path of the input tractogram file.')
     p.add_argument('--print_count_alone', action='store_true',

--- a/scripts/scil_tractogram_count_streamlines.py
+++ b/scripts/scil_tractogram_count_streamlines.py
@@ -18,11 +18,13 @@ from scilpy.io.utils import (add_json_args,
                              assert_inputs_exist)
 from scilpy.tractograms.lazy_tractogram_operations import \
     lazy_streamlines_count
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
     p = argparse.ArgumentParser(description=__doc__,
-                                formatter_class=argparse.RawTextHelpFormatter)
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
     p.add_argument('in_tractogram',
                    help='Path of the input tractogram file.')
     p.add_argument('--print_count_alone', action='store_true',

--- a/scripts/scil_tractogram_cut_streamlines.py
+++ b/scripts/scil_tractogram_cut_streamlines.py
@@ -52,6 +52,8 @@ from scilpy.tractograms.streamline_and_mask_operations import \
     CuttingStyle
 from scilpy.tractograms.streamline_operations import \
     resample_streamlines_step_size
+from scilpy.version import version_string
+
 
 # Mapping the arguments to the cutting style
 # (keep_longest, trim_endpoints) -> CuttingStyle
@@ -61,9 +63,9 @@ args_to_style = {(False, False): CuttingStyle.DEFAULT,
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(
-        description=__doc__,
-        formatter_class=argparse.RawTextHelpFormatter)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
     p.add_argument('in_tractogram',
                    help='Input tractogram file.')
 

--- a/scripts/scil_tractogram_cut_streamlines.py
+++ b/scripts/scil_tractogram_cut_streamlines.py
@@ -54,7 +54,6 @@ from scilpy.tractograms.streamline_operations import \
     resample_streamlines_step_size
 from scilpy.version import version_string
 
-
 # Mapping the arguments to the cutting style
 # (keep_longest, trim_endpoints) -> CuttingStyle
 args_to_style = {(False, False): CuttingStyle.DEFAULT,

--- a/scripts/scil_tractogram_cut_streamlines.py
+++ b/scripts/scil_tractogram_cut_streamlines.py
@@ -66,6 +66,7 @@ def _build_arg_parser():
     p = argparse.ArgumentParser(description=__doc__,
                                 formatter_class=argparse.RawTextHelpFormatter,
                                 epilog=version_string)
+
     p.add_argument('in_tractogram',
                    help='Input tractogram file.')
 

--- a/scripts/scil_tractogram_detect_loops.py
+++ b/scripts/scil_tractogram_detect_loops.py
@@ -16,6 +16,11 @@ See also:
     scil_tractogram_filter_by_anatomy.py
 
 Formerly: scil_detect_streamlines_loops.py
+------------------------------------------------------------------------------
+References:
+    QuickBundles, based on [Garyfallidis12] Frontiers in Neuroscience, 2012.
+------------------------------------------------------------------------------
+
 """
 
 import argparse
@@ -37,17 +42,14 @@ from scilpy.io.utils import (add_json_args,
                              validate_nbr_processes, ranged_type)
 from scilpy.tractograms.streamline_operations import \
     remove_loops_and_sharp_turns
-
-
-EPILOG = """
-References:
-    QuickBundles, based on [Garyfallidis12] Frontiers in Neuroscience, 2012.
-"""
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
-                                description=__doc__, epilog=EPILOG)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
+
     p.add_argument('in_tractogram',
                    help='Tractogram input file name.')
     p.add_argument('out_tractogram',

--- a/scripts/scil_tractogram_detect_loops.py
+++ b/scripts/scil_tractogram_detect_loops.py
@@ -17,10 +17,9 @@ See also:
 
 Formerly: scil_detect_streamlines_loops.py
 ------------------------------------------------------------------------------
-References:
-    QuickBundles, based on [Garyfallidis12] Frontiers in Neuroscience, 2012.
+Reference:
+[1] QuickBundles, based on [Garyfallidis12] Frontiers in Neuroscience, 2012.
 ------------------------------------------------------------------------------
-
 """
 
 import argparse

--- a/scripts/scil_tractogram_dpp_math.py
+++ b/scripts/scil_tractogram_dpp_math.py
@@ -43,12 +43,13 @@ from scilpy.tractograms.dps_and_dpp_management import (
     perform_correlation_on_endpoints,
     perform_operation_on_dpp,
     perform_operation_dpp_to_dps)
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(
-        formatter_class=argparse.RawTextHelpFormatter,
-        description=__doc__)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('operation', metavar='OPERATION',
                    choices=['mean', 'sum', 'min', 'max', 'correlation'],

--- a/scripts/scil_tractogram_dps_math.py
+++ b/scripts/scil_tractogram_dps_math.py
@@ -35,13 +35,13 @@ from scilpy.io.utils import (add_overwrite_arg,
                              check_tract_trk,
                              load_matrix_in_any_format,
                              save_matrix_in_any_format)
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-
-    p = argparse.ArgumentParser(
-        description=__doc__,
-        formatter_class=argparse.RawTextHelpFormatter)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('in_tractogram',
                    help='Input tractogram (.trk for all operations,'

--- a/scripts/scil_tractogram_extract_ushape.py
+++ b/scripts/scil_tractogram_extract_ushape.py
@@ -29,11 +29,14 @@ from scilpy.io.utils import (add_json_args,
                              assert_outputs_exist,
                              check_tracts_same_format, ranged_type)
 from scilpy.tractanalysis.bundle_operations import detect_ushape
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
-                                description=__doc__)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
+
     p.add_argument('in_tractogram',
                    help='Tractogram input file name.')
     p.add_argument('out_tractogram',

--- a/scripts/scil_tractogram_filter_by_anatomy.py
+++ b/scripts/scil_tractogram_filter_by_anatomy.py
@@ -59,15 +59,17 @@ Formerly: scil_filter_streamlines_anatomically.py
 NOTE: As of version 2.0.0, the dilation of the cortical mask has changed; from
 an in-house process to scipy's dilation. Results may differ from previous
 versions.
----------------------------------------------------------------------------------
-    References:
-        [1] Jörgens, D., Descoteaux, M., Moreno, R., 2021. Challenges for
-        tractogram ﬁltering. In: Özarslan, E., Schultz, T., Zhang, E., Fuster,
-        A. (Eds.), Anisotropy Across Fields and Scales. Springer. Mathematics
-        and Visualization.
-        [2] Legarreta, J., Petit, L., Rheault, F., Theaud, G., Lemaire, C.,
-        Descoteaux, M., Jodoin, P.M. Filtering in tractography using
-        autoencoders (FINTA). Medical Image Analysis. 2021
+----------------------------------------------------------------------------
+References:
+[1] Jörgens, D., Descoteaux, M., Moreno, R., 2021. Challenges for
+    tractogram ﬁltering. In: Özarslan, E., Schultz, T., Zhang, E., Fuster,
+    A. (Eds.), Anisotropy Across Fields and Scales. Springer. Mathematics
+    and Visualization.
+
+[2] Legarreta, J., Petit, L., Rheault, F., Theaud, G., Lemaire, C.,
+    Descoteaux, M., Jodoin, P.M. Filtering in tractography using
+    autoencoders (FINTA). Medical Image Analysis. 2021
+----------------------------------------------------------------------------
 """
 
 import argparse

--- a/scripts/scil_tractogram_filter_by_anatomy.py
+++ b/scripts/scil_tractogram_filter_by_anatomy.py
@@ -59,6 +59,15 @@ Formerly: scil_filter_streamlines_anatomically.py
 NOTE: As of version 2.0.0, the dilation of the cortical mask has changed; from
 an in-house process to scipy's dilation. Results may differ from previous
 versions.
+---------------------------------------------------------------------------------
+    References:
+        [1] Jörgens, D., Descoteaux, M., Moreno, R., 2021. Challenges for
+        tractogram ﬁltering. In: Özarslan, E., Schultz, T., Zhang, E., Fuster,
+        A. (Eds.), Anisotropy Across Fields and Scales. Springer. Mathematics
+        and Visualization.
+        [2] Legarreta, J., Petit, L., Rheault, F., Theaud, G., Lemaire, C.,
+        Descoteaux, M., Jodoin, P.M. Filtering in tractography using
+        autoencoders (FINTA). Medical Image Analysis. 2021
 """
 
 import argparse
@@ -85,23 +94,13 @@ from scilpy.image.labels import (get_data_as_labels, load_wmparc_labels,
 from scilpy.segment.streamlines import filter_grid_roi
 from scilpy.tractograms.streamline_operations import \
     filter_streamlines_by_length, remove_loops_and_sharp_turns
-
-
-EPILOG = """
-    References:
-        [1] Jörgens, D., Descoteaux, M., Moreno, R., 2021. Challenges for
-        tractogram ﬁltering. In: Özarslan, E., Schultz, T., Zhang, E., Fuster,
-        A. (Eds.), Anisotropy Across Fields and Scales. Springer. Mathematics
-        and Visualization.
-        [2] Legarreta, J., Petit, L., Rheault, F., Theaud, G., Lemaire, C.,
-        Descoteaux, M., Jodoin, P.M. Filtering in tractography using
-        autoencoders (FINTA). Medical Image Analysis. 2021
-    """
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
-                                epilog=EPILOG, description=__doc__)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('in_tractogram',
                    help='Path of the input tractogram file.')

--- a/scripts/scil_tractogram_filter_by_length.py
+++ b/scripts/scil_tractogram_filter_by_length.py
@@ -30,11 +30,13 @@ from scilpy.io.utils import (add_json_args,
                              assert_outputs_exist, ranged_type)
 from scilpy.tractograms.streamline_operations import \
     filter_streamlines_by_length
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(
-        formatter_class=argparse.RawTextHelpFormatter, description=__doc__)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('in_tractogram',
                    help='Streamlines input file name.')

--- a/scripts/scil_tractogram_filter_by_orientation.py
+++ b/scripts/scil_tractogram_filter_by_orientation.py
@@ -40,11 +40,13 @@ from scilpy.io.utils import (add_json_args,
                              assert_outputs_exist)
 from scilpy.tractograms.streamline_operations import \
     filter_streamlines_by_total_length_per_dim
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(
-        formatter_class=argparse.RawTextHelpFormatter, description=__doc__)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('in_tractogram',
                    help='Streamlines input file name.')

--- a/scripts/scil_tractogram_filter_by_roi.py
+++ b/scripts/scil_tractogram_filter_by_roi.py
@@ -104,7 +104,6 @@ from scilpy.segment.streamlines import (filter_cuboid, filter_ellipsoid,
                                         filter_grid_roi)
 from scilpy.version import version_string
 
-
 MODES = ['any', 'all', 'either_end', 'both_ends']
 CRITERIA = ['include', 'exclude']
 

--- a/scripts/scil_tractogram_filter_by_roi.py
+++ b/scripts/scil_tractogram_filter_by_roi.py
@@ -102,14 +102,17 @@ from scilpy.io.utils import (add_json_args, add_overwrite_arg,
                              read_info_from_mb_bdo, assert_headers_compatible)
 from scilpy.segment.streamlines import (filter_cuboid, filter_ellipsoid,
                                         filter_grid_roi)
+from scilpy.version import version_string
+
 
 MODES = ['any', 'all', 'either_end', 'both_ends']
 CRITERIA = ['include', 'exclude']
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
-                                description=__doc__)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('in_tractogram',
                    help='Path of the input tractogram file.')

--- a/scripts/scil_tractogram_filter_collisions.py
+++ b/scripts/scil_tractogram_filter_collisions.py
@@ -90,12 +90,13 @@ from scilpy.io.utils import (assert_inputs_exist,
                              add_overwrite_arg,
                              add_verbose_arg,
                              add_json_args)
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(
-        formatter_class=argparse.RawTextHelpFormatter,
-        description=__doc__)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('in_tractogram',
                    help='Path to the tractogram file containing the \n'

--- a/scripts/scil_tractogram_flip.py
+++ b/scripts/scil_tractogram_flip.py
@@ -23,11 +23,13 @@ from scilpy.io.utils import (add_reference_arg,
                              assert_inputs_exist,
                              assert_outputs_exist)
 from scilpy.tractograms.tractogram_operations import flip_sft
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('in_tractogram',
                    help='Path of the input tractogram file.')

--- a/scripts/scil_tractogram_math.py
+++ b/scripts/scil_tractogram_math.py
@@ -61,12 +61,13 @@ from scilpy.io.utils import (add_bbox_arg,
 from scilpy.tractograms.lazy_tractogram_operations import lazy_concatenate
 from scilpy.tractograms.tractogram_operations import (
     perform_tractogram_operation_on_sft, concatenate_sft)
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(
-        formatter_class=argparse.RawTextHelpFormatter,
-        description=__doc__)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('operation', metavar='OPERATION',
                    choices=['difference', 'intersection', 'union',

--- a/scripts/scil_tractogram_pairwise_comparison.py
+++ b/scripts/scil_tractogram_pairwise_comparison.py
@@ -40,13 +40,13 @@ from scilpy.io.utils import (add_overwrite_arg, add_reference_arg,
                              validate_nbr_processes)
 from scilpy.tractanalysis.reproducibility_measures import \
     tractogram_pairwise_comparison
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-
-    p = argparse.ArgumentParser(
-        description=__doc__,
-        formatter_class=argparse.RawTextHelpFormatter)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('in_tractogram_1',
                    help='Input tractogram 1.')

--- a/scripts/scil_tractogram_print_info.py
+++ b/scripts/scil_tractogram_print_info.py
@@ -27,11 +27,13 @@ from scilpy.io.utils import (add_json_args,
                              add_reference_arg,
                              add_verbose_arg,
                              assert_inputs_exist)
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
     p = argparse.ArgumentParser(description=__doc__,
-                                formatter_class=argparse.RawTextHelpFormatter)
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('in_tractogram',
                    help='Tractogram file.')

--- a/scripts/scil_tractogram_project_map_to_streamlines.py
+++ b/scripts/scil_tractogram_project_map_to_streamlines.py
@@ -40,12 +40,13 @@ from scilpy.io.utils import (add_overwrite_arg,
 from scilpy.image.volume_space_management import DataVolume
 from scilpy.tractograms.dps_and_dpp_management import (
     project_map_to_streamlines)
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(
-        description=__doc__,
-        formatter_class=argparse.RawTextHelpFormatter)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     # Mandatory arguments input and output tractogram must be in trk format
     p.add_argument('in_tractogram',

--- a/scripts/scil_tractogram_project_streamlines_to_map.py
+++ b/scripts/scil_tractogram_project_streamlines_to_map.py
@@ -46,12 +46,13 @@ from scilpy.io.utils import (add_overwrite_arg, add_reference_arg,
 from scilpy.tractograms.dps_and_dpp_management import (
     convert_dps_to_dpp, perform_operation_dpp_to_dps, project_dpp_to_map)
 from scilpy.utils.filenames import split_name_with_nii
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(
-        description=__doc__,
-        formatter_class=argparse.RawTextHelpFormatter)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('in_bundle',
                    help='Fiber bundle file.')

--- a/scripts/scil_tractogram_qbx.py
+++ b/scripts/scil_tractogram_qbx.py
@@ -35,11 +35,13 @@ from scilpy.io.utils import (add_overwrite_arg,
                              assert_outputs_exist,
                              assert_output_dirs_exist_and_empty,
                              add_verbose_arg)
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
     p = argparse.ArgumentParser(description=__doc__,
-                                formatter_class=argparse.RawTextHelpFormatter)
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('in_tractogram',
                    help='Tractogram filename.\n'

--- a/scripts/scil_tractogram_register.py
+++ b/scripts/scil_tractogram_register.py
@@ -10,6 +10,13 @@ doc at:
 https://scilpy.readthedocs.io/en/latest/documentation/tractogram_registration.html
 
 Formerly: scil_register_tractogram.py
+----------------------------------------------------------------------------------
+Reference:
+[1] E. Garyfallidis, O. Ocegueda, D. Wassermann, M. Descoteaux
+    Robust and efficient linear registration of white-matter fascicles in the
+    space of streamlines, NeuroImage, Volume 117, 15 August 2015, Pages 124-140
+    (http://www.sciencedirect.com/science/article/pii/S1053811915003961)
+----------------------------------------------------------------------------------
 """
 
 import argparse
@@ -23,18 +30,13 @@ from scilpy.io.streamlines import load_tractogram_with_reference
 from scilpy.io.utils import (add_overwrite_arg, add_reference_arg,
                              add_verbose_arg,
                              assert_inputs_exist, assert_outputs_exist)
-
-EPILOG = """References:
-[1] E. Garyfallidis, O. Ocegueda, D. Wassermann, M. Descoteaux
-Robust and efficient linear registration of white-matter fascicles in the
-space of streamlines, NeuroImage, Volume 117, 15 August 2015, Pages 124-140
-(http://www.sciencedirect.com/science/article/pii/S1053811915003961)
-"""
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
-                                description=__doc__, epilog=EPILOG)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('moving_tractogram',
                    help='Path of the moving tractogram.')

--- a/scripts/scil_tractogram_remove_invalid.py
+++ b/scripts/scil_tractogram_remove_invalid.py
@@ -24,11 +24,13 @@ from scilpy.tractograms.streamline_operations import (
     cut_invalid_streamlines,
     remove_overlapping_points_streamlines,
     remove_single_point_streamlines)
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
     p = argparse.ArgumentParser(description=__doc__,
-                                formatter_class=argparse.RawTextHelpFormatter)
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('in_tractogram',
                    help='Tractogram filename. Format must be one of \n'

--- a/scripts/scil_tractogram_resample.py
+++ b/scripts/scil_tractogram_resample.py
@@ -53,11 +53,13 @@ from scilpy.tractograms.tractogram_operations import (
     split_sft_randomly,
     split_sft_randomly_per_cluster,
     upsample_tractogram)
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
-                                description=__doc__)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('in_tractogram',
                    help='Input tractography file.')

--- a/scripts/scil_tractogram_resample_nb_points.py
+++ b/scripts/scil_tractogram_resample_nb_points.py
@@ -20,11 +20,13 @@ from scilpy.io.utils import (add_overwrite_arg,
                              assert_outputs_exist)
 from scilpy.tractograms.streamline_operations import \
     resample_streamlines_num_points, resample_streamlines_step_size
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(
-        formatter_class=argparse.RawTextHelpFormatter, description=__doc__)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('in_tractogram',
                    help='Streamlines input file name.')

--- a/scripts/scil_tractogram_seed_density_map.py
+++ b/scripts/scil_tractogram_seed_density_map.py
@@ -29,11 +29,13 @@ from scilpy.io.utils import (add_bbox_arg,
                              add_overwrite_arg,
                              assert_inputs_exist,
                              assert_outputs_exist, ranged_type)
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
     p = argparse.ArgumentParser(description=__doc__,
-                                formatter_class=argparse.RawTextHelpFormatter)
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('tractogram_filename',
                    help='Tracts filename. Format must be .trk. \nFile should '

--- a/scripts/scil_tractogram_segment_connections_from_labels.py
+++ b/scripts/scil_tractogram_segment_connections_from_labels.py
@@ -85,7 +85,7 @@ from scilpy.tractanalysis.connectivity_segmentation import (
     construct_hdf5_from_connectivity,
     extract_longest_segments_from_profile)
 from scilpy.tractograms.uncompress import uncompress
-
+from scilpy.version import version_string
 
 def _get_output_paths(args):
     paths = {'raw': os.path.join(args.out_dir, 'raw_connections'),
@@ -132,9 +132,9 @@ def _create_required_output_dirs(args, out_paths):
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(
-        formatter_class=argparse.RawTextHelpFormatter,
-        description=__doc__)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
     p.add_argument('in_tractograms', nargs='+',
                    help='Tractogram filename (s). Format must be one of \n'
                         'trk, tck, vtk, fib, dpy.\n'

--- a/scripts/scil_tractogram_segment_connections_from_labels.py
+++ b/scripts/scil_tractogram_segment_connections_from_labels.py
@@ -86,10 +86,7 @@ from scilpy.tractanalysis.connectivity_segmentation import (
     extract_longest_segments_from_profile)
 from scilpy.tractograms.uncompress import streamlines_to_voxel_coordinates
 from scilpy.version import version_string
-<<<<<<< HEAD
-=======
 
->>>>>>> 119ed3a099643a5c39c142d18de899de2611a7f0
 
 def _get_output_paths(args):
     paths = {'raw': os.path.join(args.out_dir, 'raw_connections'),

--- a/scripts/scil_tractogram_segment_connections_from_labels.py
+++ b/scripts/scil_tractogram_segment_connections_from_labels.py
@@ -87,6 +87,7 @@ from scilpy.tractanalysis.connectivity_segmentation import (
 from scilpy.tractograms.uncompress import uncompress
 from scilpy.version import version_string
 
+
 def _get_output_paths(args):
     paths = {'raw': os.path.join(args.out_dir, 'raw_connections'),
              'final': os.path.join(args.out_dir, 'final_connections'),

--- a/scripts/scil_tractogram_segment_with_ROI_and_score.py
+++ b/scripts/scil_tractogram_segment_with_ROI_and_score.py
@@ -83,6 +83,7 @@ Example config file:
 References:
 [1] Côté, M.-A., et al. (2013). Tractometer: Towards Validation of Tractography
     Pipelines, Medical Image Analysis, 17(7), 844-857.
+
 [2] Renauld, E., et al. (2023) Validate your white matter tractography
     algorithms with a reappraised ISMRM 2015 Tractography Challenge scoring system,
     Scientific Reports, 13:2347 (2023). Online Enhanced PDF, or Download PDF.

--- a/scripts/scil_tractogram_segment_with_ROI_and_score.py
+++ b/scripts/scil_tractogram_segment_with_ROI_and_score.py
@@ -79,6 +79,14 @@ Example config file:
     "endpoints": "PATH/file1.nii.gz"
   }
 }
+---------------------------------------------------------------------------------
+References:
+[1] Côté, M.-A., et al. (2013). Tractometer: Towards Validation of Tractography
+    Pipelines, Medical Image Analysis, 17(7), 844-857.
+[2] Renauld, E., et al. (2023) Validate your white matter tractography
+    algorithms with a reappraised ISMRM 2015 Tractography Challenge scoring system,
+    Scientific Reports, 13:2347 (2023). Online Enhanced PDF, or Download PDF.
+---------------------------------------------------------------------------------
 """
 import argparse
 import json
@@ -105,22 +113,15 @@ from scilpy.segment.tractogram_from_roi import (compute_masks_from_bundles,
                                                 segment_tractogram_from_roi)
 from scilpy.tractanalysis.scoring import compute_tractometry
 from scilpy.tractanalysis.scoring import __doc__ as tractometry_description
+from scilpy.version import version_string
 
-EPILOG = """
-[1] Côté, M.-A., et al. (2013). Tractometer: Towards Validation of Tractography
-Pipelines, Medical Image Analysis, 17(7), 844-857.
-[2] Renauld, E., et al. (2023) Validate your white matter tractography
-algorithms with a reappraised ISMRM 2015 Tractography Challenge scoring system,
-Scientific Reports, 13:2347 (2023). Online Enhanced PDF, or Download PDF.
-"""
 def_len = [0, np.inf]
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(
-        description=__doc__ + tractometry_description,
-        formatter_class=argparse.RawTextHelpFormatter,
-        epilog=EPILOG)
+    p = argparse.ArgumentParser(description=__doc__ + tractometry_description,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument("in_tractogram",
                    help="Input tractogram to score")

--- a/scripts/scil_tractogram_segment_with_bundleseg.py
+++ b/scripts/scil_tractogram_segment_with_bundleseg.py
@@ -27,6 +27,12 @@ This is important because many instances of data structures are initialized
 in parallel and can lead to a RAM overflow.
 
 Formerly: scil_recognize_multi_bundles.py
+------------------------------------------------------------------------------------------
+Reference:
+[1] St-Onge, Etienne, Kurt G. Schilling, and Francois Rheault."BundleSeg: A versatile,
+    reliable and reproducible approach to white matter bundle segmentation." International 
+    Workshop on Computational Diffusion MRI. Cham: Springer Nature Switzerland (2023)
+------------------------------------------------------------------------------------------
 """
 
 import argparse
@@ -43,20 +49,13 @@ from scilpy.io.utils import (add_overwrite_arg, add_processes_arg,
                              assert_output_dirs_exist_and_empty,
                              load_matrix_in_any_format, ranged_type)
 from scilpy.segment.voting_scheme import VotingScheme
-
-EPILOG = """
-[1] St-Onge, Etienne, Kurt G. Schilling, and Francois Rheault.
-"BundleSeg: A versatile,reliable and reproducible approach to white
-matter bundle segmentation." International Workshop on Computational
-Diffusion MRI. Cham: Springer Nature Switzerland (2023)
-"""
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(
-        formatter_class=argparse.RawTextHelpFormatter,
-        description=__doc__,
-        epilog=EPILOG)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('in_tractograms', nargs='+',
                    help='Input tractogram filename (.trk or .tck).')

--- a/scripts/scil_tractogram_segment_with_recobundles.py
+++ b/scripts/scil_tractogram_segment_with_recobundles.py
@@ -18,6 +18,12 @@ Hints:
   transformation is very close to identity and both 'directions' will work.
 
 Formerly: scil_recognize_single_bundles.py
+-------------------------------------------------------------------------------
+Reference:
+[1] Garyfallidis, E., Cote, M. A., Rheault, F., ... & Descoteaux, M. (2018).
+    Recognition of white matter bundles using local and global streamline-based
+    registration and clustering. NeuroImage, 170, 283-295.
+-------------------------------------------------------------------------------
 """
 
 import argparse
@@ -36,18 +42,13 @@ from scilpy.io.utils import (add_overwrite_arg, add_reference_arg,
                              assert_outputs_exist, load_matrix_in_any_format,
                              ranged_type)
 from scilpy.utils.spatial import compute_distance_barycenters
-
-EPILOG = """
-Garyfallidis, E., Cote, M. A., Rheault, F., ... & Descoteaux, M. (2018).
-Recognition of white matter bundles using local and global streamline-based
-registration and clustering. NeuroImage, 170, 283-295.
-"""
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(
-        formatter_class=argparse.RawTextHelpFormatter,
-        description=__doc__, epilog=EPILOG)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('in_tractogram',
                    help='Input tractogram filename.')

--- a/scripts/scil_tractogram_shuffle.py
+++ b/scripts/scil_tractogram_shuffle.py
@@ -17,12 +17,13 @@ from scilpy.io.utils import (add_overwrite_arg, add_reference_arg,
                              assert_inputs_exist, add_verbose_arg,
                              assert_outputs_exist)
 from scilpy.tractograms.tractogram_operations import shuffle_streamlines
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-
-    p = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
-                                description=__doc__)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('in_tractogram',
                    help='Input tractography file.')

--- a/scripts/scil_tractogram_smooth.py
+++ b/scripts/scil_tractogram_smooth.py
@@ -39,11 +39,13 @@ from scilpy.io.utils import (add_overwrite_arg, add_reference_arg,
                              assert_outputs_exist, add_compression_arg)
 from scilpy.tractograms.streamline_operations import smooth_line_gaussian, \
     smooth_line_spline
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
-                                description=__doc__)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('in_tractogram',
                    help='Input tractography file.')

--- a/scripts/scil_tractogram_split.py
+++ b/scripts/scil_tractogram_split.py
@@ -28,12 +28,13 @@ from scilpy.tractograms.tractogram_operations import (
     split_sft_sequentially,
     split_sft_randomly,
     split_sft_randomly_per_cluster)
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(
-        formatter_class=argparse.RawTextHelpFormatter,
-        description=__doc__)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('in_tractogram',
                    help='Tractogram input file name.')

--- a/scripts/scil_viz_bingham_fit.py
+++ b/scripts/scil_viz_bingham_fit.py
@@ -22,6 +22,7 @@ from scilpy.io.utils import (add_overwrite_arg,
 from scilpy.utils.spatial import RAS_AXES_NAMES
 from scilpy.utils.spatial import get_axis_index
 
+from scilpy.version import version_string
 from scilpy.viz.backends.fury import (create_interactive_window,
                                       create_scene,
                                       snapshot_scenes)
@@ -31,7 +32,8 @@ from scilpy.viz.slice import create_bingham_slicer
 
 def _build_arg_parser():
     p = argparse.ArgumentParser(description=__doc__,
-                                formatter_class=argparse.RawTextHelpFormatter)
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     # Positional arguments
     p.add_argument('in_bingham', help='Input SH image file.')

--- a/scripts/scil_viz_bundle.py
+++ b/scripts/scil_viz_bundle.py
@@ -38,7 +38,6 @@ from scilpy.io.utils import (assert_inputs_exist,
 from scilpy.version import version_string
 from scilpy.viz.color import generate_local_coloring
 
-
 streamline_actor = {'tube': actor.streamtube,
                     'line': actor.line}
 

--- a/scripts/scil_viz_bundle.py
+++ b/scripts/scil_viz_bundle.py
@@ -35,6 +35,7 @@ from fury import window, actor
 from scilpy.io.utils import (assert_inputs_exist,
                              add_verbose_arg,
                              parser_color_type)
+from scilpy.version import version_string
 from scilpy.viz.color import generate_local_coloring
 
 
@@ -43,8 +44,10 @@ streamline_actor = {'tube': actor.streamtube,
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
+
     p.add_argument('in_bundles', nargs='+',
                    help='List of tractography files supported by nibabel.')
     p2 = p.add_argument_group(title='Colouring options')

--- a/scripts/scil_viz_bundle_screenshot_mni.py
+++ b/scripts/scil_viz_bundle_screenshot_mni.py
@@ -38,14 +38,16 @@ from scilpy.io.utils import (add_overwrite_arg,
                              assert_outputs_exist)
 from scilpy.image.volume_operations import register_image
 from scilpy.utils.spatial import get_axis_name, RAS_AXES_NAMES
+from scilpy.version import version_string
 from scilpy.viz.legacy import display_slices
 from scilpy.viz.color import get_lookup_table
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(
-        description=__doc__,
-        formatter_class=argparse.RawTextHelpFormatter)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
+
     p.add_argument('in_bundle',
                    help='Path of the input bundle.')
     p.add_argument('in_anat',

--- a/scripts/scil_viz_bundle_screenshot_mosaic.py
+++ b/scripts/scil_viz_bundle_screenshot_mosaic.py
@@ -27,12 +27,15 @@ from scilpy.io.utils import (add_overwrite_arg,
                              assert_output_dirs_exist_and_empty,
                              assert_headers_compatible)
 from scilpy.utils.filenames import split_name_with_nii
+from scilpy.version import version_string
 from scilpy.viz.backends.pil import fetch_truetype_font
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
+
     p.add_argument('in_volume',
                    help='Volume used as background (e.g. T1, FA, b0).')
     p.add_argument('in_bundles', nargs='+',

--- a/scripts/scil_viz_connectivity.py
+++ b/scripts/scil_viz_connectivity.py
@@ -44,13 +44,15 @@ from scilpy.io.utils import (add_overwrite_arg,
                              assert_outputs_exist,
                              add_verbose_arg,
                              load_matrix_in_any_format)
+from scilpy.version import version_string
 from scilpy.viz.legacy.chord_chart import chordDiagram, polar2xy
 from scilpy.viz.color import get_lookup_table
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
-                                description=__doc__)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('in_matrix',
                    help='Connectivity matrix in numpy (.npy) format.')

--- a/scripts/scil_viz_dti_screenshot.py
+++ b/scripts/scil_viz_dti_screenshot.py
@@ -28,13 +28,15 @@ from scilpy.gradients.bvec_bval_tools import normalize_bvecs
 from scilpy.image.volume_operations import register_image
 from scilpy.utils.spatial import RAS_AXES_NAMES
 from scilpy.utils.spatial import get_axis_name
+from scilpy.version import version_string
 from scilpy.viz.legacy import display_slices
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(
-        description=__doc__,
-        formatter_class=argparse.RawTextHelpFormatter)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
+    
     p.add_argument('in_dwi',
                    help='Path of the input diffusion volume.')
     p.add_argument('in_bval',

--- a/scripts/scil_viz_fodf.py
+++ b/scripts/scil_viz_fodf.py
@@ -34,6 +34,7 @@ from scilpy.io.utils import (add_overwrite_arg,
                              assert_headers_compatible)
 from scilpy.io.image import assert_same_resolution, get_data_as_mask
 from scilpy.utils.spatial import RAS_AXES_NAMES
+from scilpy.version import version_string
 from scilpy.viz.backends.fury import (create_interactive_window,
                                       create_scene,
                                       snapshot_scenes)
@@ -46,7 +47,8 @@ from scilpy.viz.slice import (create_odf_slicer,
 
 def _build_arg_parser():
     p = argparse.ArgumentParser(description=__doc__,
-                                formatter_class=argparse.RawTextHelpFormatter)
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     # Positional arguments
     p.add_argument('in_fodf', default=None, help='Input SH image file.')

--- a/scripts/scil_viz_gradients_screenshot.py
+++ b/scripts/scil_viz_gradients_screenshot.py
@@ -20,11 +20,10 @@ from scilpy.io.utils import (add_overwrite_arg,
                              assert_gradients_filenames_valid,
                              assert_inputs_exist,
                              assert_outputs_exist)
+from scilpy.version import version_string
 from scilpy.viz.gradients import (build_ms_from_shell_idx,
                                   plot_each_shell,
                                   plot_proj_shell)
-from scilpy.version import version_string
-
 
 sphere_choices = ['symmetric362', 'symmetric642', 'symmetric724',
                   'repulsion724', 'repulsion100', 'repulsion200']

--- a/scripts/scil_viz_gradients_screenshot.py
+++ b/scripts/scil_viz_gradients_screenshot.py
@@ -23,15 +23,17 @@ from scilpy.io.utils import (add_overwrite_arg,
 from scilpy.viz.gradients import (build_ms_from_shell_idx,
                                   plot_each_shell,
                                   plot_proj_shell)
+from scilpy.version import version_string
+
 
 sphere_choices = ['symmetric362', 'symmetric642', 'symmetric724',
                   'repulsion724', 'repulsion100', 'repulsion200']
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-        description=__doc__)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     g = p.add_mutually_exclusive_group(required=True)
     g.add_argument(

--- a/scripts/scil_viz_tractogram_collisions.py
+++ b/scripts/scil_viz_tractogram_collisions.py
@@ -17,12 +17,13 @@ from scilpy.io.utils import (add_overwrite_arg,
                              add_reference_arg,
                              assert_inputs_exist,
                              assert_outputs_exist)
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(
-        description=__doc__,
-        formatter_class=argparse.RawTextHelpFormatter)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('in_tractogram_invalid',
                    help='Tractogram file containing the colliding \n'

--- a/scripts/scil_viz_tractogram_seeds.py
+++ b/scripts/scil_viz_tractogram_seeds.py
@@ -21,12 +21,14 @@ from scilpy.io.utils import (add_overwrite_arg,
                              add_verbose_arg,
                              assert_inputs_exist,
                              assert_outputs_exist)
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(
-        description=__doc__,
-        formatter_class=argparse.RawTextHelpFormatter)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
+
     p.add_argument('tractogram',
                    help='Tractogram file (must be trk)')
     p.add_argument('--save',

--- a/scripts/scil_viz_tractogram_seeds_3d.py
+++ b/scripts/scil_viz_tractogram_seeds_3d.py
@@ -19,10 +19,8 @@ from fury import window, actor
 from scilpy.io.utils import (assert_inputs_exist,
                              add_verbose_arg,
                              parser_color_type)
-
 from scilpy.version import version_string
 from scilpy.viz.color import lut_from_matplotlib_name
-
 
 streamline_actor = {'tube': actor.streamtube,
                     'line': actor.line}

--- a/scripts/scil_viz_tractogram_seeds_3d.py
+++ b/scripts/scil_viz_tractogram_seeds_3d.py
@@ -19,6 +19,8 @@ from fury import window, actor
 from scilpy.io.utils import (assert_inputs_exist,
                              add_verbose_arg,
                              parser_color_type)
+
+from scilpy.version import version_string
 from scilpy.viz.color import lut_from_matplotlib_name
 
 
@@ -27,8 +29,10 @@ streamline_actor = {'tube': actor.streamtube,
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
+
     p.add_argument('in_seed_map',
                    help='Seed density map.')
     p.add_argument('--tractogram', type=str,

--- a/scripts/scil_viz_volume_histogram.py
+++ b/scripts/scil_viz_volume_histogram.py
@@ -21,11 +21,13 @@ from scilpy.io.image import get_data_as_mask
 from scilpy.io.utils import (add_overwrite_arg, assert_inputs_exist,
                              assert_outputs_exist, add_verbose_arg,
                              assert_headers_compatible)
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
-                                description=__doc__)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('in_metric',
                    help='Metric map ex : FA, MD,... .')

--- a/scripts/scil_viz_volume_scatterplot.py
+++ b/scripts/scil_viz_volume_scatterplot.py
@@ -51,11 +51,13 @@ from scilpy.image.labels import get_data_as_labels
 from scilpy.io.image import get_data_as_mask
 from scilpy.io.utils import (add_overwrite_arg, add_verbose_arg,
                              assert_inputs_exist, assert_headers_compatible)
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
-                                description=__doc__)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('in_x_map',
                    help='Map in x axis, FA for example.')

--- a/scripts/scil_viz_volume_screenshot.py
+++ b/scripts/scil_viz_volume_screenshot.py
@@ -65,6 +65,7 @@ from scilpy.io.utils import (add_default_screenshot_args,
                              get_default_screenshotting_data)
 from scilpy.image.utils import check_slice_indices
 from scilpy.utils.spatial import get_axis_index
+from scilpy.version import version_string
 from scilpy.viz.screenshot import (compose_image,
                                    screenshot_contour,
                                    screenshot_peaks,
@@ -72,9 +73,9 @@ from scilpy.viz.screenshot import (compose_image,
 
 
 def _build_arg_parser():
-
     p = argparse.ArgumentParser(description=__doc__,
-                                formatter_class=argparse.RawTextHelpFormatter)
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     sg = p.add_argument_group(title="Slicing")
     xg = p.add_argument_group(title="Input overlays")

--- a/scripts/scil_viz_volume_screenshot_mosaic.py
+++ b/scripts/scil_viz_volume_screenshot_mosaic.py
@@ -56,6 +56,7 @@ from scilpy.io.utils import (add_default_screenshot_args,
                              get_default_screenshotting_data,
                              ranged_type)
 from scilpy.image.utils import check_slice_indices
+from scilpy.version import version_string
 from scilpy.viz.screenshot import (compose_mosaic,
                                    screenshot_contour,
                                    screenshot_volume)
@@ -63,9 +64,9 @@ from scilpy.viz.utils import check_mosaic_layout
 
 
 def _build_arg_parser():
-
     p = argparse.ArgumentParser(description=__doc__,
-                                formatter_class=argparse.RawTextHelpFormatter)
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     xg = p.add_argument_group(title="Input overlays")
     vg = p.add_argument_group(title="Volume rendering")

--- a/scripts/scil_volume_apply_transform.py
+++ b/scripts/scil_volume_apply_transform.py
@@ -21,11 +21,13 @@ from scilpy.io.utils import (add_overwrite_arg, assert_inputs_exist,
                              assert_outputs_exist, add_verbose_arg,
                              load_matrix_in_any_format)
 from scilpy.utils.filenames import split_name_with_nii
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
-                                description=__doc__)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('in_file',
                    help='Path of the file to be transformed (nii or nii.gz)')

--- a/scripts/scil_volume_b0_synthesis.py
+++ b/scripts/scil_volume_b0_synthesis.py
@@ -16,6 +16,11 @@ default in Scilpy):
 - tensorflow-addons
 - tensorrt
 - tensorflow
+-------------------------------------------------------------------------------
+Reference:
+[1] Schilling, Kurt G., et al. "Synthesized b0 for diffusion distortion
+    correction (Synb0-DisCo)." Magnetic resonance imaging 64 (2019): 62-70.
+-------------------------------------------------------------------------------
 """
 
 import argparse
@@ -29,18 +34,14 @@ from scilpy.io.fetcher import get_synb0_template_path
 from scilpy.io.utils import (add_overwrite_arg, add_verbose_arg,
                              assert_inputs_exist, assert_outputs_exist,
                              assert_headers_compatible)
-
-EPILOG = """
-[1] Schilling, Kurt G., et al. "Synthesized b0 for diffusion distortion
-  correction (Synb0-DisCo)." Magnetic resonance imaging 64 (2019): 62-70.
-"""
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(
-        description=__doc__,
-        formatter_class=argparse.RawTextHelpFormatter,
-        epilog=EPILOG)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
+
     p.add_argument('in_b0',
                    help='Input b0 image.')
     p.add_argument('in_b0_mask',

--- a/scripts/scil_volume_count_non_zero_voxels.py
+++ b/scripts/scil_volume_count_non_zero_voxels.py
@@ -22,11 +22,14 @@ import numpy as np
 from scilpy.image.volume_operations import count_non_zero_voxels
 from scilpy.io.utils import assert_inputs_exist, add_verbose_arg, \
     assert_outputs_exist, add_overwrite_arg
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
+
     p.add_argument('in_image', metavar='IN_FILE',
                    help='Input file name, in nifti format.')
 

--- a/scripts/scil_volume_crop.py
+++ b/scripts/scil_volume_crop.py
@@ -34,11 +34,14 @@ from scilpy.io.utils import (add_overwrite_arg,
                              assert_outputs_exist)
 from scilpy.image.utils import compute_nifti_bounding_box
 from scilpy.image.volume_operations import crop_volume
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
-                                description=__doc__)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
+
     p.add_argument('in_image',
                    help='Path of the nifti file to crop.')
     p.add_argument('out_image',

--- a/scripts/scil_volume_distance_map.py
+++ b/scripts/scil_volume_distance_map.py
@@ -34,11 +34,14 @@ from scilpy.image.volume_operations import compute_distance_map
 from scilpy.io.image import get_data_as_mask
 from scilpy.io.utils import add_overwrite_arg, add_verbose_arg, \
     assert_headers_compatible, assert_inputs_exist, assert_outputs_exist
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
+
     p.add_argument('in_mask_1', metavar='IN_SOURCE',
                    help='Input file name, in nifti format.')
     p.add_argument('in_mask_2', metavar='IN_TARGET',

--- a/scripts/scil_volume_flip.py
+++ b/scripts/scil_volume_flip.py
@@ -15,12 +15,14 @@ import numpy as np
 from scilpy.image.volume_operations import flip_volume
 from scilpy.io.utils import (add_overwrite_arg, assert_inputs_exist,
                              add_verbose_arg, assert_outputs_exist)
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
-    p = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
-                                description=__doc__)
     p.add_argument('in_image',
                    help='Path of the input volume (nifti).')
     p.add_argument('out_image',

--- a/scripts/scil_volume_math.py
+++ b/scripts/scil_volume_math.py
@@ -28,6 +28,8 @@ from scilpy.io.utils import (add_overwrite_arg,
                              add_verbose_arg,
                              assert_outputs_exist)
 from scilpy.utils import is_float
+from scilpy.version import version_string
+
 
 OPERATIONS = get_image_ops()
 
@@ -35,9 +37,9 @@ __doc__ += get_operations_doc(OPERATIONS)
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(
-        formatter_class=argparse.RawTextHelpFormatter,
-        description=__doc__)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('operation',
                    choices=OPERATIONS.keys(),

--- a/scripts/scil_volume_math.py
+++ b/scripts/scil_volume_math.py
@@ -30,9 +30,7 @@ from scilpy.io.utils import (add_overwrite_arg,
 from scilpy.utils import is_float
 from scilpy.version import version_string
 
-
 OPERATIONS = get_image_ops()
-
 __doc__ += get_operations_doc(OPERATIONS)
 
 

--- a/scripts/scil_volume_pairwise_comparison.py
+++ b/scripts/scil_volume_pairwise_comparison.py
@@ -48,12 +48,14 @@ from scilpy.io.utils import (add_json_args,
                              validate_nbr_processes)
 from scilpy.image.labels import get_data_as_labels
 from scilpy.tractanalysis.reproducibility_measures import compare_volume_wrapper
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(
-        description=__doc__,
-        formatter_class=argparse.RawTextHelpFormatter)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
+
     p.add_argument('in_volumes', nargs='*',
                    help='Path of the input volumes.')
     p.add_argument('out_json',

--- a/scripts/scil_volume_remove_outliers_ransac.py
+++ b/scripts/scil_volume_remove_outliers_ransac.py
@@ -21,11 +21,13 @@ from scilpy.io.utils import (add_overwrite_arg,
                              add_verbose_arg,
                              assert_inputs_exist,
                              assert_outputs_exist)
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('in_image',
                    help='Nifti image.')

--- a/scripts/scil_volume_resample.py
+++ b/scripts/scil_volume_resample.py
@@ -25,11 +25,13 @@ import numpy as np
 from scilpy.io.utils import (add_verbose_arg, add_overwrite_arg,
                              assert_inputs_exist, assert_outputs_exist)
 from scilpy.image.volume_operations import resample_volume
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('in_image',
                    help='Path of the input volume.')

--- a/scripts/scil_volume_reshape.py
+++ b/scripts/scil_volume_reshape.py
@@ -24,11 +24,13 @@ import nibabel as nib
 from scilpy.io.utils import (add_verbose_arg, add_overwrite_arg,
                              assert_inputs_exist, assert_outputs_exist)
 from scilpy.image.volume_operations import reshape_volume
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
-    p = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('in_image',
                    help='Path of the input volume.')

--- a/scripts/scil_volume_reslice_to_reference.py
+++ b/scripts/scil_volume_reslice_to_reference.py
@@ -28,11 +28,13 @@ import numpy as np
 from scilpy.image.volume_operations import apply_transform
 from scilpy.io.utils import (add_overwrite_arg, assert_inputs_exist,
                              add_verbose_arg, assert_outputs_exist)
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
     p = argparse.ArgumentParser(description=__doc__,
-                                formatter_class=argparse.RawTextHelpFormatter)
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('in_file',
                    help='Path of the image (.nii or .mgz) to be reshaped.')

--- a/scripts/scil_volume_stats_in_ROI.py
+++ b/scripts/scil_volume_stats_in_ROI.py
@@ -27,11 +27,13 @@ from scilpy.io.utils import (add_overwrite_arg,
                              assert_headers_compatible)
 from scilpy.utils.filenames import split_name_with_nii
 from scilpy.utils.metrics_tools import weighted_mean_std
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
     p = argparse.ArgumentParser(description=__doc__,
-                                formatter_class=argparse.RawTextHelpFormatter)
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
 
     p.add_argument('in_rois', nargs='+',
                    help='ROIs volume filenames.\nCan be binary masks or '

--- a/scripts/scil_volume_stats_in_labels.py
+++ b/scripts/scil_volume_stats_in_labels.py
@@ -24,11 +24,14 @@ from scilpy.image.labels import get_data_as_labels, get_stats_in_label
 from scilpy.io.utils import (add_json_args, add_overwrite_arg, add_verbose_arg,
                              assert_inputs_exist, assert_headers_compatible)
 from scilpy.utils.filenames import split_name_with_nii
+from scilpy.version import version_string
 
 
 def _build_arg_parser():
     p = argparse.ArgumentParser(description=__doc__,
-                                formatter_class=argparse.RawTextHelpFormatter)
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
+
     p.add_argument('in_labels',
                    help='Path of the input label file.')
     p.add_argument('in_labels_lut',


### PR DESCRIPTION
# Quick description

Fix issue https://github.com/scilus/scilpy/issues/760

Part  3 (final)  of adding the Scilpy version to the scripts.

I also added a blank line in _build_arg_parser because some scripts (from scil_NODDI_maps.py to scil-volume_stats_in_ROI.py) had it and some others didn't:

```python
def _build_arg_parser():
    p = argparse.ArgumentParser(description=__doc__,
                                formatter_class=argparse.RawTextHelpFormatter,
                                epilog=version_string)
*added a blank line here*
    p.add_argument(...)
```