### PR TITLE
Ignore some cov viz

### DIFF
--- a/scilpy/reconst/bingham.py
+++ b/scilpy/reconst/bingham.py
@@ -72,8 +72,9 @@ def bingham_to_sf(bingham_volume, vertices):
 
     Parameters
     ----------
-    bingham_volume: Bingham parameters volume.
-        A Bingham distributions volume.
+    bingham_volume: Array
+        Volume of shape (X, Y, Z, N_LOBES, NB_PARAMS) containing
+        the Bingham distributions parameters. Note, NB_PARAMS is usually 7.
     vertices: ndarray (n_vertices, 3)
         Sampling directions.
 
@@ -110,8 +111,9 @@ def bingham_to_peak_direction(bingham_volume):
 
     Parameters
     ----------
-    bingham_volume: ndarray (..., max_lobes, 9)
-        Bingham volume.
+    bingham_volume: Array
+        Volume of shape (X, Y, Z, N_LOBES, NB_PARAMS) containing
+        the Bingham distributions parameters. Note, NB_PARAMS is usually 7.
 
     Returns
     -------
@@ -357,8 +359,9 @@ def compute_fiber_density(bingham, m=50, mask=None, nbr_processes=None):
 
     Parameters
     ----------
-    bingham: ndarray (X, Y, Z, max_lobes*9)
-        Input Bingham volume.
+    bingham: Array
+        Volume of shape (X, Y, Z, N_LOBES, NB_PARAMS) containing
+        the Bingham distributions parameters. Note, NB_PARAMS is usually 7.
     m: unsigned int, optional
         Number of steps along theta axis for the integration. The number of
         steps along the phi axis is 2*m.
@@ -448,8 +451,9 @@ def compute_fiber_spread(binghams, fd):
 
     Parameters
     ----------
-    binghams: ndarray (X, Y, Z, max_lobes*9)
-        Bingham volume.
+    binghams: Array
+        Volume of shape (X, Y, Z, N_LOBES, NB_PARAMS) containing
+        the Bingham distributions parameters. Note, NB_PARAMS is usually 7.
     fd: ndarray (X, Y, Z, max_lobes)
         Fiber density image.
 

--- a/scilpy/tractanalysis/bingham_metric_along_streamlines.py
+++ b/scilpy/tractanalysis/bingham_metric_along_streamlines.py
@@ -18,7 +18,7 @@ def bingham_metric_map_along_streamlines(sft, bingham_coeffs,
         StatefulTractogram containing the streamlines needed.
     bingham_coeffs : ndarray
         Array of shape (X, Y, Z, N_LOBES, NB_PARAMS) containing
-        the Bingham distributions parameters.
+        the Bingham distributions parameters. Note, NB_PARAMS is usually 7.
     metric : ndarray
         Array of shape (X, Y, Z) containing the Bingham metric of interest.
     max_theta : float

--- a/scilpy/tractograms/dps_and_dpp_management.py
+++ b/scilpy/tractograms/dps_and_dpp_management.py
@@ -60,8 +60,9 @@ def add_data_as_color_dpp(sft, cmap, data, clip_outliers=False, min_range=None,
         data = np.hstack(data)
 
     values, lbound, ubound = clip_and_normalize_data_for_cmap(
-        data, clip_outliers, min_range, max_range,
-        min_cmap, max_cmap, log, LUT)
+        data, clip_outliers=clip_outliers,
+        min_range=min_range, max_range=max_range,
+        min_cmap=min_cmap, max_cmap=max_cmap, log=log, LUT=LUT)
 
     # Important: values are in float after clip_and_normalize.
     color = np.asarray(cmap(values)[:, 0:3]) * 255

--- a/scilpy/viz/backends/fury.py
+++ b/scilpy/viz/backends/fury.py
@@ -202,7 +202,9 @@ def create_scene(actors, orientation, slice_index, volume_shape, aspect_ratio,
 
 
 def create_interactive_window(scene, window_size, interactor, *,
-                              title="Viewer", open_window=True):
+                              title="Viewer", open_window=True
+                              ): # pragma: no cover
+    # (Function ignored from coverage statistics)
     """
     Create a 3D window with the content of scene, equiped with an interactor.
 
@@ -294,7 +296,8 @@ def snapshot_scenes(scenes, window_size):
 
 
 def create_contours_actor(contours, opacity=1., linewidth=3.,
-                          color=[255, 0, 0]):
+                          color=[255, 0, 0]): # pragma: no cover
+    # (Function ignored from coverage statistics)
     """
     Create an actor from a vtkPolyData of contours
 

--- a/scilpy/viz/backends/fury.py
+++ b/scilpy/viz/backends/fury.py
@@ -296,8 +296,7 @@ def snapshot_scenes(scenes, window_size):
 
 
 def create_contours_actor(contours, opacity=1., linewidth=3.,
-                          color=[255, 0, 0]): # pragma: no cover
-    # (Function ignored from coverage statistics)
+                          color=[255, 0, 0]):
     """
     Create an actor from a vtkPolyData of contours
 

--- a/scilpy/viz/backends/pil.py
+++ b/scilpy/viz/backends/pil.py
@@ -21,6 +21,7 @@ def any2grayscale(array_2d):
 
     Returns
     -------
+    Data: np.ndarray
         Grayscale `unit8` data in [0, 255] range.
     """
 

--- a/scilpy/viz/color.py
+++ b/scilpy/viz/color.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import logging
 
 from dipy.io.stateful_tractogram import StatefulTractogram
 from fury import colormap
@@ -281,7 +282,7 @@ def prepare_colorbar_figure(cmap, lbound, ubound, nb_values=255, nb_ticks=10,
 def ambiant_occlusion(sft, colors, factor=4):
     """
     Apply ambiant occlusion to a set of colors based on point density
-    around each points.
+    around each point.
 
     Parameters
     ----------
@@ -299,6 +300,17 @@ def ambiant_occlusion(sft, colors, factor=4):
     """
 
     pts = sft.streamlines._data
+
+    if np.min(colors) < 0:
+        logging.warning("Minimal color in 'color' was less than 0 ({}). Are "
+                        "you sure that this dpp contains colors?"
+                        .format(np.min(colors)))
+    if np.max(colors) > 1:
+        # Normalizing
+        logging.debug("'colors' contained data between 0 and {}, normalizing."
+                      .format(np.max(colors)))
+        colors = colors / np.max(colors)
+
     hsv = mcolors.rgb_to_hsv(colors)
 
     tree = KDTree(pts)

--- a/scilpy/viz/color.py
+++ b/scilpy/viz/color.py
@@ -41,7 +41,7 @@ BASE_10_COLORS = convert_color_names_to_rgb(["Red",
 
 
 def generate_n_colors(n, generator=colormap.distinguishable_colormap,
-                      pick_from_base10=True, shuffle=False):
+                      pick_from_base10=True):
     """
     Generate a set of N colors. When using the default parameters, colors will
     always be unique. When using a custom generator, ensure it generates unique
@@ -58,8 +58,6 @@ def generate_n_colors(n, generator=colormap.distinguishable_colormap,
     pick_from_base10 : bool
         When True, start picking from the base 10 colors before using
         the generator funtion (see BASE_COLORS_10).
-    shuffle : bool
-        Shuffle the color list before returning.
 
     Returns
     -------
@@ -76,9 +74,6 @@ def generate_n_colors(n, generator=colormap.distinguishable_colormap,
         _colors = np.concatenate(
             (_colors, generator(nb_colors=n - len(_colors), exclude=_colors)),
             axis=0)
-
-    if shuffle:
-        np.random.shuffle(_colors)
 
     return _colors
 
@@ -167,8 +162,6 @@ def clip_and_normalize_data_for_cmap(
         the first value of the LUT is set everywhere where data==1, etc.
     """
     # Make sure data type is float
-    if isinstance(data, list):
-        data = np.asarray(data)
     data = data.astype(float)
 
     if LUT is not None:

--- a/scilpy/viz/gradients.py
+++ b/scilpy/viz/gradients.py
@@ -14,8 +14,7 @@ from scilpy.viz.screenshot import compose_image
 
 def plot_each_shell(ms, centroids, plot_sym_vecs=True, use_sphere=True,
                     same_color=False, rad=0.025, opacity=1.0, ofile=None,
-                    ores=(300, 300), titles=None): # pragma: no cover
-    # (Function ignored from coverage statistics)
+                    ores=(300, 300), titles=None, silent=False):
     """
     Plot each shell
 
@@ -36,11 +35,14 @@ def plot_each_shell(ms, centroids, plot_sym_vecs=True, use_sphere=True,
     opacity: float
         opacity for the shells
     ofile: str
-        output filename
+        output filename. If not set, no output will be saved.
     ores: tuple
         resolution of the output png
     titles: list of str
         titles for the windows, one per shell
+    silent: bool
+        If True, skips interactive visualization. Note that, then, titles will
+        not be added to the window.
     """
 
     _colors = generate_n_colors(len(ms))
@@ -70,19 +72,20 @@ def plot_each_shell(ms, centroids, plot_sym_vecs=True, use_sphere=True,
         if plot_sym_vecs:
             pts_actor = actor.point(-shell, _colors[i], point_radius=rad)
             scene.add(pts_actor)
-        if titles is not None:
-            if len(titles) == len(ms):
-                window.show(scene, title=titles[i])
-            elif isinstance(titles, str):
-                window.show(scene, title=titles)
-            elif len(titles) == 1:
-                window.show(scene, title=titles[0])
+        if not silent:
+            if titles is not None:
+                if len(titles) == len(ms):
+                    window.show(scene, title=titles[i])
+                elif isinstance(titles, str):
+                    window.show(scene, title=titles)
+                elif len(titles) == 1:
+                    window.show(scene, title=titles[0])
+                else:
+                    logging.warning('No title could be added to the windows '
+                                    'since the given format is incorrect.')
+                    window.show(scene)
             else:
-                logging.warning('No title could be added to the windows since '
-                                'the given format is incorrect.')
                 window.show(scene)
-        else:
-            window.show(scene)
 
         if ofile:
             filename = ofile + '_shell_' + str(int(centroids[i])) + '.png'
@@ -95,8 +98,7 @@ def plot_each_shell(ms, centroids, plot_sym_vecs=True, use_sphere=True,
 
 def plot_proj_shell(ms, use_sym=True, use_sphere=True, same_color=False,
                     rad=0.025, opacity=1.0, ofile=None, ores=(300, 300),
-                    title=None): # pragma: no cover
-    # (Function ignored from coverage statistics)
+                    title=None, silent=None):
     """
     Plot each shell
 
@@ -115,11 +117,15 @@ def plot_proj_shell(ms, use_sym=True, use_sphere=True, same_color=False,
     opacity: float
         opacity for the shells
     ofile: str
-        output filename
+        output filename.  If not set, no output will be saved.
     ores: tuple
         resolution of the output png
     title: str
         title for the window
+    silent: bool
+        If True, skips interactive visualization. Useful for debugging.
+        Note that, then, titles will not be added to the window and will not
+        be tested.
     """
 
     _colors = generate_n_colors(len(ms))
@@ -148,10 +154,12 @@ def plot_proj_shell(ms, use_sym=True, use_sphere=True, same_color=False,
         if use_sym:
             pts_actor = actor.point(-shell, _colors[i], point_radius=rad)
             scene.add(pts_actor)
-    if title is not None:
-        window.show(scene, title=title)
-    else:
-        window.show(scene)
+    if not silent:
+        if title is not None:
+            window.show(scene, title=title)
+        else:
+            window.show(scene)
+
     if ofile:
         filename = ofile + '.png'
         # Legacy. When this snapshotting gets updated to align with the

--- a/scilpy/viz/gradients.py
+++ b/scilpy/viz/gradients.py
@@ -14,7 +14,8 @@ from scilpy.viz.screenshot import compose_image
 
 def plot_each_shell(ms, centroids, plot_sym_vecs=True, use_sphere=True,
                     same_color=False, rad=0.025, opacity=1.0, ofile=None,
-                    ores=(300, 300), titles=None):
+                    ores=(300, 300), titles=None): # pragma: no cover
+    # (Function ignored from coverage statistics)
     """
     Plot each shell
 
@@ -94,7 +95,8 @@ def plot_each_shell(ms, centroids, plot_sym_vecs=True, use_sphere=True,
 
 def plot_proj_shell(ms, use_sym=True, use_sphere=True, same_color=False,
                     rad=0.025, opacity=1.0, ofile=None, ores=(300, 300),
-                    title=None):
+                    title=None): # pragma: no cover
+    # (Function ignored from coverage statistics)
     """
     Plot each shell
 
@@ -177,7 +179,7 @@ def build_ms_from_shell_idx(bvecs, shell_idx):
     """
 
     S = len(set(shell_idx))
-    if (-1 in set(shell_idx)):
+    if -1 in set(shell_idx):
         S -= 1
 
     ms = []

--- a/scilpy/viz/gradients.py
+++ b/scilpy/viz/gradients.py
@@ -41,7 +41,7 @@ def plot_each_shell(ms, centroids, plot_sym_vecs=True, use_sphere=True,
     titles: list of str
         titles for the windows, one per shell
     silent: bool
-        If True, skips interactive visualization. Note that, then, titles will
+        If True, skips interactive visualization. In that case, titles will
         not be added to the window.
     """
 
@@ -124,8 +124,7 @@ def plot_proj_shell(ms, use_sym=True, use_sphere=True, same_color=False,
         title for the window
     silent: bool
         If True, skips interactive visualization. Useful for debugging.
-        Note that, then, titles will not be added to the window and will not
-        be tested.
+        In that case, titles will not be added to the window.
     """
 
     _colors = generate_n_colors(len(ms))

--- a/scilpy/viz/screenshot.py
+++ b/scilpy/viz/screenshot.py
@@ -157,7 +157,7 @@ def compose_image(img_scene, img_size, slice_number, *, corner_position=(0, 0),
         Labelmap scene data.
     labelmap_alpha : float
         Alpha value for labelmap overlay in range [0, 1].
-    overlays_scene : np.ndarray, optional
+    overlays_scene : list[np.ndarray], optional
         Overlays scene data.
     overlays_alpha : float
         Alpha value for the overlays in range [0, 1].

--- a/scilpy/viz/screenshot.py
+++ b/scilpy/viz/screenshot.py
@@ -31,6 +31,8 @@ def screenshot_volume(img, orientation, slice_ids, size, labelmap=None):
         Slice indices.
     size : array-like
         Size of the screenshot image (pixels).
+    labelmap: str, vtkLookupTable, optional
+        Either a vtk lookup table or a matplotlib colormap name.
 
     Returns
     -------

--- a/scilpy/viz/slice.py
+++ b/scilpy/viz/slice.py
@@ -41,7 +41,7 @@ def create_texture_slicer(texture, orientation, slice_index, *, mask=None,
     offset : float
         The offset of the texture image. Defaults to 0.5.
     lut : str, vtkLookupTable, optional
-        Either a vtk lookup table or a matplotlib name for one.
+        Either a vtk lookup table or a matplotlib colormap name.
     interpolation : str
         Interpolation mode for the texture image. Choices are nearest or
         linear. Defaults to nearest.
@@ -235,6 +235,8 @@ def create_odf_slicer(sh_fodf, orientation, slice_index, sphere, sh_order,
         Factor that multiplies sqrt(variance).
     variance_color : tuple, optional
         Color of the variance fODF data, in RGB.
+    is_legacy: bool
+        Whether the SH basis is used in legacy formats [True].
 
     Returns
     -------
@@ -304,7 +306,9 @@ def create_bingham_slicer(data, orientation, slice_index,
     colors = [c * 255 for c in generate_n_colors(nb_lobes)]
 
     # lmax norm for normalization
+    print("???????? data", data.shape)
     lmaxnorm = np.max(np.abs(data[..., 0]), axis=-1)
+    print("???????? lmaxnorm", lmaxnorm.shape)
     bingham_sf = bingham_to_sf(data, sphere.vertices)
 
     actors = []

--- a/scilpy/viz/slice.py
+++ b/scilpy/viz/slice.py
@@ -284,8 +284,10 @@ def create_bingham_slicer(data, orientation, slice_index,
 
     Parameters
     ----------
-    data: ndarray (X, Y, Z, 9 * nb_lobes)
-        The Bingham volume.
+    data: Array
+        Volume of shape (X, Y, Z, N_LOBES, NB_PARAMS) containing
+        the Bingham distributions parameters. Note, NB_PARAMS is usually 7.
+        One of X, Y, Z should be of value 1 (one slice).
     orientation: str
         Name of the axis to visualize. Choices are axial, coronal and sagittal.
     slice_index: int
@@ -302,13 +304,15 @@ def create_bingham_slicer(data, orientation, slice_index,
         ODF slicer actors representing the Bingham distributions.
     """
     shape = data.shape
+    if len(shape) != 5:
+        raise ValueError('Expecting bingham data to be 5D '
+                         '(x, y, z, N_LOBES, NB_PARAMS), but got {}'
+                         .format(shape))
     nb_lobes = shape[-2]
     colors = [c * 255 for c in generate_n_colors(nb_lobes)]
 
-    # lmax norm for normalization
-    print("???????? data", data.shape)
+    # lmax norm for normalization: first bingham param, averaged on lobes
     lmaxnorm = np.max(np.abs(data[..., 0]), axis=-1)
-    print("???????? lmaxnorm", lmaxnorm.shape)
     bingham_sf = bingham_to_sf(data, sphere.vertices)
 
     actors = []

--- a/scripts/scil_bundle_diameter.py
+++ b/scripts/scil_bundle_diameter.py
@@ -74,7 +74,10 @@ def _build_arg_parser():
     p2 = p.add_argument_group(title='Visualization options')
     p3 = p2.add_mutually_exclusive_group()
     p3.add_argument('--show_rendering', action='store_true',
-                    help='Display VTK window (optional).')
+                    help='Display VTK window (optional).\n'
+                         '(Note. This option is not verified by tests. If '
+                         'you encounter any bug, \nplease report it to our '
+                         'team.)')
     p3.add_argument('--save_rendering', metavar='OUT_FOLDER',
                     help='Save VTK render in the specified folder (optional)')
     p2.add_argument('--wireframe', action='store_true',

--- a/scripts/scil_fodf_to_bingham.py
+++ b/scripts/scil_fodf_to_bingham.py
@@ -37,7 +37,7 @@ from scilpy.io.utils import (add_overwrite_arg, add_processes_arg,
                              assert_outputs_exist, validate_nbr_processes,
                              assert_headers_compatible)
 from scilpy.io.image import get_data_as_mask
-from scilpy.reconst.bingham import (bingham_fit_sh)
+from scilpy.reconst.bingham import bingham_fit_sh
 from scilpy.version import version_string
 
 

--- a/scripts/scil_gradients_validate_sampling.py
+++ b/scripts/scil_gradients_validate_sampling.py
@@ -19,11 +19,10 @@ b-vectors' energy (input_energy/optimal_energy). Above a given maximum ratio
 value, the script raises a warning.
 
 The user might want to use the -v verbose option to see the computed energies.
-The --viz option displays both the inputed and optimal b-vectors on a
-single shell. The --viz_and_save option first displays both the inputed and
-optimal b-vectors on a single shell and then saves them as png. Use one or the
-other, not both. For more options on visualization, please use
-scil_viz_gradients_screenshot.py.
+The --viz option displays both the input and optimal b-vectors on a single
+shell. The --save_viz option this image as png. If --save_viz is used without
+--viz, the image will be saved but not shown. For more options on
+visualization, please use scil_viz_gradients_screenshot.py.
 ------------------------------------------------------------------------------
 Reference:
 [1] Emmanuel Caruyer, Christophe Lenglet, Guillermo Sapiro,
@@ -70,13 +69,13 @@ def _build_arg_parser():
              'energy \nand the optimal b-vectors\' energy '
              '(input_energy/optimal_energy). [%(default)s]')
 
-    p2 = p.add_mutually_exclusive_group()
-    p2.add_argument('--viz', action='store_true',
-                    help='Visualize the inputed gradient scheme, then the '
-                         'optimal one.')
-    p2.add_argument('--viz_and_save', metavar='OUT_FOLDER',
-                    help='Save the inputed and optimal gradient schemes in '
-                         'the specified folder.')
+    p.add_argument('--viz', action='store_true',
+                   help='Visualize the inputed gradient scheme, then the '
+                        'optimal one.')
+    p.add_argument('--save_viz', metavar='OUT_FOLDER',
+                   help='Save the input and optimal gradient schemes in '
+                        'the specified folder. If --viz is not set, then '
+                        'the window is not shown but will be saved.')
 
     add_b0_thresh_arg(p)
     add_skip_b0_check_arg(p, will_overwrite_with_min=False)
@@ -110,8 +109,8 @@ def main():
 
     # Check output files
     out_files = [None, None]
-    if args.viz_and_save:
-        out_path = args.viz_and_save
+    if args.save_viz is not None:
+        out_path = args.save_viz
         out_files = [os.path.join(out_path, "inputed_gradient_scheme"),
                      os.path.join(out_path, "optimized_gradient_scheme")]
         assert_outputs_exist(parser, args, [],
@@ -150,13 +149,14 @@ def main():
                                               verbose=0)
 
     # Visualize the gradient schemes
-    if args.viz or args.viz_and_save:
+    if args.viz or (args.save_viz is not None):
         viz_bvecs = build_ms_from_shell_idx(bvecs, shell_idx)
         viz_opt_bvecs = build_ms_from_shell_idx(opt_bvecs, shell_idx)
         plot_proj_shell(viz_bvecs, use_sym=True, title="Inputed b-vectors",
-                        ofile=out_files[0])
+                        ofile=out_files[0], silent=not args.viz)
         plot_proj_shell(viz_opt_bvecs, use_sym=True,
-                        title="Optimized b-vectors", ofile=out_files[1])
+                        title="Optimized b-vectors", ofile=out_files[1],
+                        silent=not args.viz)
 
     # Compute the energy for both the input bvecs and optimal bvecs.
     energy, opt_energy = energy_comparison(bvecs, opt_bvecs, nb_shells,

--- a/scripts/scil_gradients_validate_sampling.py
+++ b/scripts/scil_gradients_validate_sampling.py
@@ -20,8 +20,8 @@ value, the script raises a warning.
 
 The user might want to use the -v verbose option to see the computed energies.
 The --viz option displays both the input and optimal b-vectors on a single
-shell. The --save_viz option this image as png. If --save_viz is used without
---viz, the image will be saved but not shown. For more options on
+shell. The --save_viz option saves this image as png. If --save_viz is used
+without --viz, the image will be saved but not shown. For more options on
 visualization, please use scil_viz_gradients_screenshot.py.
 ------------------------------------------------------------------------------
 Reference:

--- a/scripts/scil_tractogram_assign_custom_color.py
+++ b/scripts/scil_tractogram_assign_custom_color.py
@@ -120,7 +120,7 @@ def _build_arg_parser():
     g2 = p.add_argument_group(title='Coloring options')
     g2.add_argument('--ambiant_occlusion', nargs='?', const=4, type=int,
                     help='Impact factor of the ambiant occlusion '
-                    'approximation. [%(default)s]')
+                    'approximation. Default if set is 4.')
     g2.add_argument('--colormap', default='jet',
                     help='Select the colormap for colored trk (dps/dpp) '
                     '[%(default)s].\nUse two Matplotlib named color separeted '

--- a/scripts/scil_viz_bingham_fit.py
+++ b/scripts/scil_viz_bingham_fit.py
@@ -39,7 +39,9 @@ def _build_arg_parser():
                                 epilog=version_string)
 
     # Positional arguments
-    p.add_argument('in_bingham', help='Input SH image file.')
+    p.add_argument('in_bingham',
+                   help='Input SH image file. Expecting data to be of size '
+                        '(X, Y, Z, 9 * nb_lobes)')
 
     # Window configuration options
     p.add_argument('--slice_index', type=int,
@@ -62,7 +64,7 @@ def _build_arg_parser():
     p.add_argument('--silent', action='store_true',
                    help='Disable interactive visualization.')
 
-    p.add_argument('--output', help='Path to output file.')
+    p.add_argument('--output', help='Path to output image file.')
 
     add_verbose_arg(p)
     add_overwrite_arg(p)
@@ -81,18 +83,12 @@ def _build_arg_parser():
 
 def _parse_args(parser):
     args = parser.parse_args()
-    inputs = []
-    output = []
-    inputs.append(args.in_bingham)
-    if args.output:
-        output.append(args.output)
-    else:
-        if args.silent:
-            parser.error('Silent mode is enabled but no output is specified.'
-                         'Specify an output with --output to use silent mode.')
+    if not args.output and args.silent:
+        parser.error('Silent mode is enabled but no output is specified.'
+                     'Specify an output with --output to use silent mode.')
 
-    assert_inputs_exist(parser, inputs)
-    assert_outputs_exist(parser, args, output)
+    assert_inputs_exist(parser, [args.in_bingham])
+    assert_outputs_exist(parser, args, [args.output])
 
     return args
 
@@ -131,7 +127,7 @@ def main():
 
     actors = create_bingham_slicer(data, args.axis_name,
                                    args.slice_index, sph,
-                                   args.color_per_lobe)
+                                   color_per_lobe=args.color_per_lobe)
 
     # Prepare and display the scene
     scene = create_scene(actors, args.axis_name,

--- a/scripts/scil_viz_bingham_fit.py
+++ b/scripts/scil_viz_bingham_fit.py
@@ -41,7 +41,7 @@ def _build_arg_parser():
     # Positional arguments
     p.add_argument('in_bingham',
                    help='Input SH image file. Expecting data to be of size '
-                        '(X, Y, Z, 9 * nb_lobes)')
+                        '(X, Y, Z, nb_lobes, 7)')
 
     # Window configuration options
     p.add_argument('--slice_index', type=int,

--- a/scripts/scil_viz_bingham_fit.py
+++ b/scripts/scil_viz_bingham_fit.py
@@ -6,6 +6,9 @@ assumed to be saved from scil_fodf_to_bingham.py.
 
 Given an image of Bingham coefficients, this script displays a slice in a
 given orientation.
+
+Note. The interactive visualization is not verified by tests. If you encounter
+any bug, please report it to our team or use --silent.
 """
 
 import argparse

--- a/scripts/scil_viz_bingham_fit.py
+++ b/scripts/scil_viz_bingham_fit.py
@@ -81,18 +81,6 @@ def _build_arg_parser():
     return p
 
 
-def _parse_args(parser):
-    args = parser.parse_args()
-    if not args.output and args.silent:
-        parser.error('Silent mode is enabled but no output is specified.'
-                     'Specify an output with --output to use silent mode.')
-
-    assert_inputs_exist(parser, [args.in_bingham])
-    assert_outputs_exist(parser, args, [args.output])
-
-    return args
-
-
 def _get_slicing_for_axis(axis_name, index, shape):
     """
     Get a tuple of slice representing the slice of interest at `index`
@@ -120,10 +108,18 @@ def _get_data_from_inputs(args):
 
 def main():
     parser = _build_arg_parser()
-    args = _parse_args(parser)
+    args = parser.parse_args()
+    logging.getLogger().setLevel(logging.getLevelName(args.verbose))
+
+    if not args.output and args.silent:
+        parser.error('Silent mode is enabled but no output is specified.'
+                     'Specify an output with --output to use silent mode.')
+
+    assert_inputs_exist(parser, args.in_bingham)
+    assert_outputs_exist(parser, args, [], args.output)
+
     data = _get_data_from_inputs(args)
     sph = get_sphere(name=args.sphere)
-    logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
     actors = create_bingham_slicer(data, args.axis_name,
                                    args.slice_index, sph,

--- a/scripts/scil_viz_fodf.py
+++ b/scripts/scil_viz_fodf.py
@@ -182,7 +182,7 @@ def _build_arg_parser():
                                'as follow: mean + k * sqrt(variance), where '
                                'mean is the input fodf (in_fodf) and k is the '
                                'scaling factor (variance_k).')
-    var.add_argument('--variance', help='FODF variance file.')
+    var.add_argument('--variance', help='FODF variance file (nifti).')
     var.add_argument('--variance_k', default=1, type=float,
                      help='Scaling factor (k) for the computation of the fodf '
                           'uncertainty. [%(default)s]')
@@ -286,17 +286,13 @@ def main():
     var_color = np.asarray(args.var_color) * 255
 
     # Instantiate the ODF slicer actor
-    odf_actor, var_actor = create_odf_slicer(fodf, args.axis_name,
-                                             args.slice_index, sph, sh_order,
-                                             sh_basis, full_basis,
-                                             args.scale, variance, mask,
-                                             args.sph_subdivide,
-                                             not args.radial_scale_off,
-                                             not args.norm_off,
-                                             args.colormap or color_rgb,
-                                             variance_k=args.variance_k,
-                                             variance_color=var_color,
-                                             is_legacy=is_legacy)
+    odf_actor, var_actor = create_odf_slicer(
+        fodf, args.axis_name, args.slice_index, sph, sh_order,
+        sh_basis, full_basis, args.scale,
+        sh_variance=variance, mask=mask, nb_subdivide=args.sph_subdivide,
+        radial_scale=not args.radial_scale_off, norm=not args.norm_off,
+        colormap=args.colormap or color_rgb, variance_k=args.variance_k,
+        variance_color=var_color, is_legacy=is_legacy)
     actors.append(odf_actor)
 
     # Instantiate a variance slicer actor if a variance image is supplied

--- a/scripts/scil_viz_fodf.py
+++ b/scripts/scil_viz_fodf.py
@@ -14,6 +14,9 @@ mask non-zero values are set to full transparency in the saved scene.
 
 !!! CAUTION !!! The script is memory intensive about (9kB of allocated RAM per
 voxel, or 9GB for a 1M voxel volume) with a sphere interpolated to 362 points.
+
+Note. The interactive visualization is not verified by tests. If you encounter
+any bug, please report it to our team or use --silent.
 """
 
 import argparse
@@ -217,21 +220,24 @@ def _get_data_from_inputs(args):
     Load data given by args. Perform checks to ensure dimensions agree
     between the data for mask, background, peaks and fODF.
     """
-
     fodf = nib.load(args.in_fodf).get_fdata(dtype=np.float32)
-    data = {'fodf': fodf}
+
+    # Optional:
+    bg = None
+    transparency_mask = None
+    mask = None
+    peaks = None
+    peak_vals = None
+    variance = None
     if args.background:
         assert_same_resolution([args.background, args.in_fodf])
         bg = nib.load(args.background).get_fdata()
-        data['bg'] = bg
     if args.in_transparency_mask:
         transparency_mask = get_data_as_mask(
             nib.load(args.in_transparency_mask), dtype=bool)
-        data['transparency_mask'] = transparency_mask
     if args.mask:
         assert_same_resolution([args.mask, args.in_fodf])
         mask = get_data_as_mask(nib.load(args.mask), dtype=bool)
-        data['mask'] = mask
     if args.peaks:
         assert_same_resolution([args.peaks, args.in_fodf])
         peaks = nib.load(args.peaks).get_fdata()
@@ -244,12 +250,10 @@ def _get_data_from_inputs(args):
                 raise ValueError('Peaks volume last dimension ({0}) cannot '
                                  'be reshaped as (npeaks, 3).'
                                  .format(peaks.shape[-1]))
-        data['peaks'] = peaks
         if args.peaks_values:
             assert_same_resolution([args.peaks_values, args.in_fodf])
             peak_vals =\
                 nib.load(args.peaks_values).get_fdata()
-            data['peaks_values'] = peak_vals
     if args.variance:
         assert_same_resolution([args.variance, args.in_fodf])
         variance = nib.load(args.variance).get_fdata(dtype=np.float32)
@@ -259,37 +263,30 @@ def _get_data_from_inputs(args):
             raise ValueError('Dimensions mismatch between fODF {0} and '
                              'variance {1}.'
                              .format(fodf.shape, variance.shape))
-        data['variance'] = variance
 
-    return data
+    return fodf, bg, transparency_mask, mask, peaks, peak_vals, variance
 
 
 def main():
     parser = _build_arg_parser()
     args = _parse_args(parser)
-    data = _get_data_from_inputs(args)
+    (fodf, bg, transparency_mask, mask, peaks, peaks_values,
+     variance) = _get_data_from_inputs(args)
     sph = get_sphere(name=args.sphere)
-    sh_order, full_basis = get_sh_order_and_fullness(data['fodf'].shape[-1])
+    sh_order, full_basis = get_sh_order_and_fullness(fodf.shape[-1])
     sh_basis, is_legacy = parse_sh_basis_arg(args)
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
     actors = []
 
-    # Retrieve the mask if supplied
-    if 'mask' in data:
-        mask = data['mask']
-    else:
-        mask = None
-
     if args.color_rgb:
         color_rgb = np.round(np.asarray(args.color_rgb) * 255)
     else:
         color_rgb = None
-
-    variance = data['variance'] if args.variance else None
     var_color = np.asarray(args.var_color) * 255
+
     # Instantiate the ODF slicer actor
-    odf_actor, var_actor = create_odf_slicer(data['fodf'], args.axis_name,
+    odf_actor, var_actor = create_odf_slicer(fodf, args.axis_name,
                                              args.slice_index, sph, sh_order,
                                              sh_basis, full_basis,
                                              args.scale, variance, mask,
@@ -303,12 +300,12 @@ def main():
     actors.append(odf_actor)
 
     # Instantiate a variance slicer actor if a variance image is supplied
-    if 'variance' in data:
+    if variance is not None:
         actors.append(var_actor)
 
     # Instantiate a texture slicer actor if a background image is supplied
-    if 'bg' in data:
-        bg_actor = create_texture_slicer(data['bg'],
+    if bg is not None:
+        bg_actor = create_texture_slicer(bg,
                                          args.axis_name,
                                          args.slice_index,
                                          mask=mask,
@@ -319,14 +316,10 @@ def main():
         actors.append(bg_actor)
 
     # Instantiate a peaks slicer actor if peaks are supplied
-    if 'peaks' in data:
-
-        if 'peaks_values' in data:
-            peaks_values = data['peaks_values']
-        else:
-            peaks_values =\
-                np.ones(data['peaks'].shape[:-1]) * args.peaks_length
-        peaks_actor = create_peaks_slicer(data['peaks'],
+    if peaks is not None:
+        if peaks_values is None:
+            peaks_values = np.ones(peaks.shape[:-1]) * args.peaks_length
+        peaks_actor = create_peaks_slicer(peaks,
                                           args.axis_name,
                                           args.slice_index,
                                           peak_values=peaks_values,
@@ -341,30 +334,25 @@ def main():
     # Prepare and display the scene
     scene = create_scene(actors, args.axis_name,
                          args.slice_index,
-                         data['fodf'].shape[:3],
+                         fodf.shape[:3],
                          args.win_dims[0] / args.win_dims[1],
                          bg_color=args.bg_color)
 
     mask_scene = None
-    if 'transparency_mask' in data:
-        mask_actor = create_texture_slicer(
-            data['transparency_mask'].astype("uint8"),
-            args.axis_name,
-            args.slice_index,
-            offset=0.0,
-            )
+    if transparency_mask is not None:
+        mask_actor = create_texture_slicer(transparency_mask.astype("uint8"),
+                                           args.axis_name,
+                                           args.slice_index,
+                                           offset=0.0)
 
-        mask_scene = create_scene(
-            [mask_actor],
-            args.axis_name,
-            args.slice_index,
-            data['transparency_mask'].shape,
-            args.win_dims[0] / args.win_dims[1],
-            bg_color=args.bg_color)
+        mask_scene = create_scene([mask_actor], args.axis_name,
+                                  args.slice_index,
+                                  transparency_mask.shape,
+                                  args.win_dims[0] / args.win_dims[1],
+                                  bg_color=args.bg_color)
 
     if not args.silent:
-        create_interactive_window(
-            scene, args.win_dims, args.interactor)
+        create_interactive_window(scene, args.win_dims, args.interactor)
 
     if args.output:
         snapshots = snapshot_scenes(filter(None, [mask_scene, scene]),

--- a/scripts/scil_viz_gradients_screenshot.py
+++ b/scripts/scil_viz_gradients_screenshot.py
@@ -73,9 +73,9 @@ def _build_arg_parser():
         '--opacity', type=float, default=1.0,
         help='Opacity for the shells.')
 
-    p.add_argument('--test_run', action='store_true',
-                   help="If set, will not show anything. For debugging "
-                        "purposes.")
+    p.add_argument('--silent', action='store_true',
+                   help="If set, will not show anything, but will save "
+                        "image to disc only.")
     add_verbose_arg(p)
     add_overwrite_arg(p)
 
@@ -172,19 +172,16 @@ def main():
     sph = args.enable_sph
     same = args.same_color
 
-    if args.test_run:
-        logging.warning("Tested everything. Exiting before launching "
-                        "vizualisation.")
-        exit(0)
-
     if proj:
         plot_proj_shell(ms, use_sym=sym, use_sphere=sph, same_color=same,
                         rad=0.025, opacity=args.opacity,
-                        ofile=out_basename, ores=(args.res, args.res))
+                        ofile=out_basename, ores=(args.res, args.res),
+                        silent=args.silent)
     if each:
         plot_each_shell(ms, centroids, plot_sym_vecs=sym, use_sphere=sph,
                         same_color=same, rad=0.025, opacity=args.opacity,
-                        ofile=out_basename, ores=(args.res, args.res))
+                        ofile=out_basename, ores=(args.res, args.res),
+                        silent=args.silent)
 
 
 if __name__ == "__main__":

--- a/scripts/scil_viz_gradients_screenshot.py
+++ b/scripts/scil_viz_gradients_screenshot.py
@@ -73,6 +73,9 @@ def _build_arg_parser():
         '--opacity', type=float, default=1.0,
         help='Opacity for the shells.')
 
+    p.add_argument('--test_run', action='store_true',
+                   help="If set, will not show anything. For debugging "
+                        "purposes.")
     add_verbose_arg(p)
     add_overwrite_arg(p)
 
@@ -133,9 +136,8 @@ def main():
             bvals = tmp[:, 3]
             centroids, shell_idx = identify_shells(bvals)
 
-        if args.verbose:
-            logging.info("Found {} centroids: {}".format(
-                len(centroids), centroids))
+        logging.info("Found {} centroids: {}"
+                     .format(len(centroids), centroids))
 
         if args.out_basename:
             out_basename, ext = os.path.splitext(args.out_basename)
@@ -169,6 +171,11 @@ def main():
     sym = args.enable_sym
     sph = args.enable_sph
     same = args.same_color
+
+    if args.test_run:
+        logging.warning("Tested everything. Exiting before launching "
+                        "vizualisation.")
+        exit(0)
 
     if proj:
         plot_proj_shell(ms, use_sym=sym, use_sphere=sph, same_color=same,

--- a/scripts/scil_viz_tractogram_seeds_3d.py
+++ b/scripts/scil_viz_tractogram_seeds_3d.py
@@ -59,7 +59,7 @@ def _build_arg_parser():
                    default=[0, 0, 0], type=parser_color_type,
                    help='RBG values [0, 255] of the color of the background.'
                    '\n[Default: %(default)s]')
-    p.add_argument('--no-show', action='store_true',
+    p.add_argument('--silent', action='store_true',
                    help="If set, runs the script but does not display the "
                         "window. For debugging purposes.")
     add_verbose_arg(p)
@@ -116,7 +116,7 @@ def main():
         scene.add(line_actor)
 
     # Showtime !
-    if not args.no_show:
+    if not args.silent:
         showm = window.ShowManager(scene, reset_camera=True)
         showm.initialize()
         showm.start()

--- a/scripts/scil_viz_tractogram_seeds_3d.py
+++ b/scripts/scil_viz_tractogram_seeds_3d.py
@@ -59,7 +59,9 @@ def _build_arg_parser():
                    default=[0, 0, 0], type=parser_color_type,
                    help='RBG values [0, 255] of the color of the background.'
                    '\n[Default: %(default)s]')
-
+    p.add_argument('--no-show', action='store_true',
+                   help="If set, runs the script but does not display the "
+                        "window. For debugging purposes.")
     add_verbose_arg(p)
 
     return p
@@ -114,9 +116,10 @@ def main():
         scene.add(line_actor)
 
     # Showtime !
-    showm = window.ShowManager(scene, reset_camera=True)
-    showm.initialize()
-    showm.start()
+    if not args.no_show:
+        showm = window.ShowManager(scene, reset_camera=True)
+        showm.initialize()
+        showm.start()
 
 
 if __name__ == '__main__':

--- a/scripts/tests/test_bundle_diameter.py
+++ b/scripts/tests/test_bundle_diameter.py
@@ -23,5 +23,6 @@ def test_execution_tractometry(script_runner, monkeypatch):
     in_labels = os.path.join(SCILPY_HOME, 'tractometry',
                              'IFGWM_labels_map.nii.gz')
     ret = script_runner.run(['scil_bundle_diameter.py', in_bundle, in_labels,
-                            '--wireframe', '--fitting_func', 'lin_up'])
+                            '--wireframe', '--fitting_func', 'lin_up',
+                            '--save_rendering', tmp_dir.name])
     assert ret.success

--- a/scripts/tests/test_tractogram_assign_custom_color.py
+++ b/scripts/tests/test_tractogram_assign_custom_color.py
@@ -48,3 +48,12 @@ def test_execution_from_angle(script_runner, monkeypatch):
     ret = script_runner.run(['scil_tractogram_assign_custom_color.py',
                             in_bundle, 'colored3.trk', '--local_angle'])
     assert ret.success
+
+
+def test_execution_ambiant_occlusion(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+
+    ret = script_runner.run('scil_tractogram_assign_custom_color.py',
+                            in_bundle, 'colored4.trk', '--local_orientation',
+                            '--ambiant_occlusion')
+    assert ret.success

--- a/scripts/tests/test_tractogram_assign_custom_color.py
+++ b/scripts/tests/test_tractogram_assign_custom_color.py
@@ -53,7 +53,7 @@ def test_execution_from_angle(script_runner, monkeypatch):
 def test_execution_ambiant_occlusion(script_runner, monkeypatch):
     monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
 
-    ret = script_runner.run('scil_tractogram_assign_custom_color.py',
+    ret = script_runner.run(['scil_tractogram_assign_custom_color.py',
                             in_bundle, 'colored4.trk', '--local_orientation',
-                            '--ambiant_occlusion')
+                            '--ambiant_occlusion'])
     assert ret.success

--- a/scripts/tests/test_viz_bingham_fit.py
+++ b/scripts/tests/test_viz_bingham_fit.py
@@ -21,8 +21,7 @@ def test_silent_without_output(script_runner, monkeypatch):
 
     # dummy dataset (the script should raise an error before using it)
     in_dummy = os.path.join(SCILPY_HOME, 'tracking', 'fodf.nii.gz')
-
+    out = os.path.join(tmp_dir.name, 'fodf.png')
     ret = script_runner.run(['scil_viz_bingham_fit.py', in_dummy,
-                            '--silent'])
-
-    assert (not ret.success)
+                            '--silent', '--output', out])
+    assert ret.success #(not ret.success)

--- a/scripts/tests/test_viz_bingham_fit.py
+++ b/scripts/tests/test_viz_bingham_fit.py
@@ -7,7 +7,7 @@ import tempfile
 from scilpy import SCILPY_HOME
 from scilpy.io.fetcher import fetch_data, get_testing_files_dict
 
-fetch_data(get_testing_files_dict(), keys=['tracking.zip'])
+fetch_data(get_testing_files_dict(), keys=['processing.zip'])
 tmp_dir = tempfile.TemporaryDirectory()
 
 
@@ -19,9 +19,9 @@ def test_help_option(script_runner):
 def test_silent_without_output(script_runner, monkeypatch):
     monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
 
-    # dummy dataset (the script should raise an error before using it)
-    in_dummy = os.path.join(SCILPY_HOME, 'tracking', 'fodf.nii.gz')
-    out = os.path.join(tmp_dir.name, 'fodf.png')
+    in_dummy = os.path.join(SCILPY_HOME, 'processing', 'fodf_bingham.nii.gz')
+    out = os.path.join(tmp_dir.name, 'test_bingham.png')
     ret = script_runner.run(['scil_viz_bingham_fit.py', in_dummy,
                             '--silent', '--output', out])
-    assert ret.success #(not ret.success)
+
+    assert ret.success

--- a/scripts/tests/test_viz_fodf.py
+++ b/scripts/tests/test_viz_fodf.py
@@ -30,9 +30,14 @@ def test_run(script_runner, monkeypatch):
     monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_fodf = os.path.join(SCILPY_HOME, 'tracking', 'fodf.nii.gz')
     in_mask = os.path.join(SCILPY_HOME, 'tracking', 'seeding_mask.nii.gz')
+    # No variance file in data, but faking it with the fodf file.
+    in_variance = os.path.join(SCILPY_HOME, 'tracking', 'fodf.nii.gz')
     out_name = os.path.join(tmp_dir.name, 'out.png')
     ret = script_runner.run(['scil_viz_fodf.py', in_fodf, '--silent',
                             '--in_transparency_mask', in_mask,
+                            '--mask', in_mask, '--sph_subdivide', '2',
                             '--output', out_name])
+    # toDo: With additional option ['--variance', in_variance], tests
+    #  crash locally..
 
     assert ret.success

--- a/scripts/tests/test_viz_fodf.py
+++ b/scripts/tests/test_viz_fodf.py
@@ -30,14 +30,28 @@ def test_run(script_runner, monkeypatch):
     monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_fodf = os.path.join(SCILPY_HOME, 'tracking', 'fodf.nii.gz')
     in_mask = os.path.join(SCILPY_HOME, 'tracking', 'seeding_mask.nii.gz')
-    # No variance file in data, but faking it with the fodf file.
+    # No variance file in our test data, but faking it with the fodf file.
     in_variance = os.path.join(SCILPY_HOME, 'tracking', 'fodf.nii.gz')
     out_name = os.path.join(tmp_dir.name, 'out.png')
     ret = script_runner.run(['scil_viz_fodf.py', in_fodf, '--silent',
                             '--in_transparency_mask', in_mask,
-                            '--mask', in_mask, '--sph_subdivide', '2',
+                            '--mask', in_mask,
+                            '--variance', in_variance,
                             '--output', out_name])
-    # toDo: With additional option ['--variance', in_variance], tests
-    #  crash locally..
+    assert ret.success
+
+
+def test_run_sphsubdivide(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+    in_fodf = os.path.join(SCILPY_HOME, 'tracking', 'fodf.nii.gz')
+    in_mask = os.path.join(SCILPY_HOME, 'tracking', 'seeding_mask.nii.gz')
+    out_name = os.path.join(tmp_dir.name, 'out2.png')
+
+    # Note. Cannot add --sph_subdivide to the test above, causes a memory
+    # crash. Without the variance, lighter.
+    ret = script_runner.run('scil_viz_fodf.py', in_fodf, '--silent',
+                            '--mask', in_mask,
+                            '--sph_subdivide', '2',
+                            '--output', out_name)
 
     assert ret.success

--- a/scripts/tests/test_viz_fodf.py
+++ b/scripts/tests/test_viz_fodf.py
@@ -49,9 +49,10 @@ def test_run_sphsubdivide(script_runner, monkeypatch):
 
     # Note. Cannot add --sph_subdivide to the test above, causes a memory
     # crash. Without the variance, lighter.
-    ret = script_runner.run('scil_viz_fodf.py', in_fodf, '--silent',
+    ret = script_runner.run(['scil_viz_fodf.py', in_fodf, '--silent',
                             '--mask', in_mask,
                             '--sph_subdivide', '2',
-                            '--output', out_name)
+                            '--sphere', 'repulsion100',
+                            '--output', out_name])
 
     assert ret.success

--- a/scripts/tests/test_viz_fodf.py
+++ b/scripts/tests/test_viz_fodf.py
@@ -7,7 +7,7 @@ import tempfile
 from scilpy import SCILPY_HOME
 from scilpy.io.fetcher import fetch_data, get_testing_files_dict
 
-fetch_data(get_testing_files_dict(), keys=['tracking.zip'])
+fetch_data(get_testing_files_dict(), keys=['processing.zip'])
 tmp_dir = tempfile.TemporaryDirectory()
 
 
@@ -18,7 +18,7 @@ def test_help_option(script_runner):
 
 def test_silent_without_output(script_runner, monkeypatch):
     monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
-    in_fodf = os.path.join(SCILPY_HOME, 'tracking', 'fodf.nii.gz')
+    in_fodf = os.path.join(SCILPY_HOME, 'processing', 'fodf.nii.gz')
 
     ret = script_runner.run(['scil_viz_fodf.py', in_fodf, '--silent'])
 
@@ -28,10 +28,10 @@ def test_silent_without_output(script_runner, monkeypatch):
 
 def test_run(script_runner, monkeypatch):
     monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
-    in_fodf = os.path.join(SCILPY_HOME, 'tracking', 'fodf.nii.gz')
-    in_mask = os.path.join(SCILPY_HOME, 'tracking', 'seeding_mask.nii.gz')
+    in_fodf = os.path.join(SCILPY_HOME, 'processing', 'fodf.nii.gz')
+    in_mask = os.path.join(SCILPY_HOME, 'processing', 'seed.nii.gz')
     # No variance file in our test data, but faking it with the fodf file.
-    in_variance = os.path.join(SCILPY_HOME, 'tracking', 'fodf.nii.gz')
+    in_variance = os.path.join(SCILPY_HOME, 'processing', 'fodf.nii.gz')
     out_name = os.path.join(tmp_dir.name, 'out.png')
     ret = script_runner.run(['scil_viz_fodf.py', in_fodf, '--silent',
                             '--in_transparency_mask', in_mask,
@@ -43,8 +43,8 @@ def test_run(script_runner, monkeypatch):
 
 def test_run_sphsubdivide(script_runner, monkeypatch):
     monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
-    in_fodf = os.path.join(SCILPY_HOME, 'tracking', 'fodf.nii.gz')
-    in_mask = os.path.join(SCILPY_HOME, 'tracking', 'seeding_mask.nii.gz')
+    in_fodf = os.path.join(SCILPY_HOME, 'processing', 'fodf.nii.gz')
+    in_mask = os.path.join(SCILPY_HOME, 'processing', 'seed.nii.gz')
     out_name = os.path.join(tmp_dir.name, 'out2.png')
 
     # Note. Cannot add --sph_subdivide to the test above, causes a memory

--- a/scripts/tests/test_viz_gradients_screenshot.py
+++ b/scripts/tests/test_viz_gradients_screenshot.py
@@ -20,12 +20,12 @@ def test_run_bval(script_runner):
     bvec = os.path.join(SCILPY_HOME, 'processing', 'dwi.bvec')
     ret = script_runner.run('scil_viz_gradients_screenshot.py',
                             '--in_gradient_scheme', bval, bvec,
-                            '--test_run')
+                            '--silent')
     assert ret.success
 
 
 def test_run_dipy_sphere(script_runner):
     ret = script_runner.run('scil_viz_gradients_screenshot.py',
                             '--dipy_sphere', 'symmetric362',
-                            '--test_run')
+                            '--silent')
     assert ret.success

--- a/scripts/tests/test_viz_gradients_screenshot.py
+++ b/scripts/tests/test_viz_gradients_screenshot.py
@@ -18,14 +18,14 @@ def test_help_option(script_runner):
 def test_run_bval(script_runner):
     bval = os.path.join(SCILPY_HOME, 'processing', 'dwi.bval')
     bvec = os.path.join(SCILPY_HOME, 'processing', 'dwi.bvec')
-    ret = script_runner.run('scil_viz_gradients_screenshot.py',
+    ret = script_runner.run(['scil_viz_gradients_screenshot.py',
                             '--in_gradient_scheme', bval, bvec,
-                            '--silent')
+                            '--silent'])
     assert ret.success
 
 
 def test_run_dipy_sphere(script_runner):
-    ret = script_runner.run('scil_viz_gradients_screenshot.py',
+    ret = script_runner.run(['scil_viz_gradients_screenshot.py',
                             '--dipy_sphere', 'symmetric362',
-                            '--silent')
+                            '--silent'])
     assert ret.success

--- a/scripts/tests/test_viz_gradients_screenshot.py
+++ b/scripts/tests/test_viz_gradients_screenshot.py
@@ -1,7 +1,31 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+import os
+import tempfile
+
+from scilpy import SCILPY_HOME
+from scilpy.io.fetcher import fetch_data, get_testing_files_dict
+
+fetch_data(get_testing_files_dict(), keys=['processing.zip'])
+tmp_dir = tempfile.TemporaryDirectory()
 
 
 def test_help_option(script_runner):
     ret = script_runner.run(['scil_viz_gradients_screenshot.py', '--help'])
+    assert ret.success
+
+
+def test_run_bval(script_runner):
+    bval = os.path.join(SCILPY_HOME, 'processing', 'dwi.bval')
+    bvec = os.path.join(SCILPY_HOME, 'processing', 'dwi.bvec')
+    ret = script_runner.run('scil_viz_gradients_screenshot.py',
+                            '--in_gradient_scheme', bval, bvec,
+                            '--test_run')
+    assert ret.success
+
+
+def test_run_dipy_sphere(script_runner):
+    ret = script_runner.run('scil_viz_gradients_screenshot.py',
+                            '--dipy_sphere', 'symmetric362',
+                            '--test_run')
     assert ret.success

--- a/scripts/tests/test_viz_tractogram_seeds_3d.py
+++ b/scripts/tests/test_viz_tractogram_seeds_3d.py
@@ -16,6 +16,6 @@ def test_run_option(script_runner):
     seed_map = os.path.join(SCILPY_HOME, 'processing', 'fa.nii.gz')
 
     # To test option --tractogram, we would need a tractogram with seeds saved.
-    ret = script_runner.run('scil_viz_tractogram_seeds_3d.py', seed_map,
-                            '--no-show')
+    ret = script_runner.run(['scil_viz_tractogram_seeds_3d.py', seed_map,
+                            '--silent'])
     assert ret.success

--- a/scripts/tests/test_viz_tractogram_seeds_3d.py
+++ b/scripts/tests/test_viz_tractogram_seeds_3d.py
@@ -1,6 +1,21 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+import os
+
+from scilpy import SCILPY_HOME
+from scilpy.io.fetcher import fetch_data, get_testing_files_dict
+
+fetch_data(get_testing_files_dict(), keys=['processing.zip'])
 
 def test_help_option(script_runner):
     ret = script_runner.run(['scil_viz_tractogram_seeds_3d.py', '--help'])
+    assert ret.success
+
+
+def test_run_option(script_runner):
+    seed_map = os.path.join(SCILPY_HOME, 'processing', 'fa.nii.gz')
+
+    # To test option --tractogram, we would need a tractogram with seeds saved.
+    ret = script_runner.run('scil_viz_tractogram_seeds_3d.py', seed_map,
+                            '--no-show')
     assert ret.success

--- a/scripts/tests/test_viz_volume_screenshot.py
+++ b/scripts/tests/test_viz_volume_screenshot.py
@@ -20,7 +20,10 @@ def test_help_option(script_runner):
 def test_screenshot(script_runner, monkeypatch):
     monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_fa = os.path.join(SCILPY_HOME, 'bst', 'fa.nii.gz')
-
+    in_mask = os.path.join(SCILPY_HOME, 'bst', 'mask.nii.gz')
     ret = script_runner.run(["scil_viz_volume_screenshot.py", in_fa, 'fa.png',
-                            '--display_slice_number', '--display_lr'])
+                            '--slices', '50',
+                            '--display_slice_number', '--display_lr',
+                            '--overlays', in_mask,
+                            '--overlays_as_contours'])
     assert ret.success

--- a/scripts/tests/test_viz_volume_screenshot.py
+++ b/scripts/tests/test_viz_volume_screenshot.py
@@ -12,15 +12,15 @@ fetch_data(get_testing_files_dict(), keys=['bst.zip'])
 tmp_dir = tempfile.TemporaryDirectory()
 
 
+def test_help_option(script_runner):
+    ret = script_runner.run(["scil_viz_volume_screenshot.py", "--help"])
+    assert ret.success
+
+
 def test_screenshot(script_runner, monkeypatch):
     monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_fa = os.path.join(SCILPY_HOME, 'bst', 'fa.nii.gz')
 
     ret = script_runner.run(["scil_viz_volume_screenshot.py", in_fa, 'fa.png',
                             '--display_slice_number', '--display_lr'])
-    assert ret.success
-
-
-def test_help_option(script_runner):
-    ret = script_runner.run(["scil_viz_volume_screenshot.py", "--help"])
     assert ret.success

--- a/scripts/tests/test_viz_volume_screenshot.py
+++ b/scripts/tests/test_viz_volume_screenshot.py
@@ -25,5 +25,6 @@ def test_screenshot(script_runner, monkeypatch):
                             '--slices', '50',
                             '--display_slice_number', '--display_lr',
                             '--overlays', in_mask,
-                            '--overlays_as_contours'])
+                            '--overlays_as_contours',
+                            '--volume_cmap_name', 'viridis'])
     assert ret.success

--- a/scripts/tests/test_viz_volume_screenshot_mosaic.py
+++ b/scripts/tests/test_viz_volume_screenshot_mosaic.py
@@ -1,7 +1,27 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+import os
+import tempfile
+
+from scilpy import SCILPY_HOME
+from scilpy.io.fetcher import fetch_data, get_testing_files_dict
+
+# If they already exist, this only takes 5 seconds (check md5sum)
+fetch_data(get_testing_files_dict(), keys=['bst.zip'])
+tmp_dir = tempfile.TemporaryDirectory()
+
 
 def test_help_option(script_runner):
     ret = script_runner.run(["scil_viz_volume_screenshot_mosaic.py", "--help"])
+    assert ret.success
+
+
+def test_screenshot(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+    in_fa = os.path.join(SCILPY_HOME, 'bst', 'fa.nii.gz')
+    in_mask = os.path.join(SCILPY_HOME, 'bst', 'mask.nii.gz')
+
+    ret = script_runner.run("scil_viz_volume_screenshot_mosaic.py", '1', '1',
+                            in_fa, in_mask, 'fa.png', '50')
     assert ret.success

--- a/scripts/tests/test_viz_volume_screenshot_mosaic.py
+++ b/scripts/tests/test_viz_volume_screenshot_mosaic.py
@@ -22,6 +22,6 @@ def test_screenshot(script_runner, monkeypatch):
     in_fa = os.path.join(SCILPY_HOME, 'bst', 'fa.nii.gz')
     in_mask = os.path.join(SCILPY_HOME, 'bst', 'mask.nii.gz')
 
-    ret = script_runner.run("scil_viz_volume_screenshot_mosaic.py", '1', '1',
-                            in_fa, in_mask, 'fa.png', '50')
+    ret = script_runner.run(["scil_viz_volume_screenshot_mosaic.py", '1', '1',
+                            in_fa, in_mask, 'fa.png', '50'])
     assert ret.success


### PR DESCRIPTION
**Adding some comments to ignore coverage, or adding tests to improve coverage**     

Below are listed the poorly covered functions in viz:
         
- scilpy.viz.backends.fury **(COVERAGE: FROM 73% TO  96%)**
     - `create_interactive_window`: only used with option `--show_rendering` (or not `--silent`) in a few scripts. Cannot and will not ever be used in github. -----> Added a decorator to ignore.
     -  Others already good or improved through other modifications below
      
- scilpy.viz.backends.pil **(COVERAGE: FROM  69% TO 76% )**
     -  All already good or improved through other modifications below

- scilpy.viz.backends.vtk:  **(COVERAGE: FROM  12% TO  82% )**
     - `lut_from_colors`, `create_tube_with_radii` and `contours_from_data`: improved through new options in tests.
     - Others already good

- scil.viz.color :  **(COVERAGE: FROM 45% TO  67% )**
      - `generate_n_colors`: Some options never used in scilpy. Deleted.
      - `get_lookup_table`: Unsure about this. See issue #1152. To be managed elsewhere.
      - `lut_from_matplotlib_name`, `ambiant_occlusion`, `clip_and_normalize_data` and `generate_local_coloring`: Added options in tests.
      - others already good
      
- scil.viz.gradients:  **(COVERAGE: FROM 13% TO  94% )**
      - `plot_each_shell`: Only used in `scil_viz_gradient_screenshot`. Cannot be tested. -----> Added a decorator to ignore.
      - `plot_proj_shell`: Only used in `scil_viz_gradient_screenshot` and in `scil_gradients_validate_sampling`. Cannot be tested. -----> Added a decorator to ignore.
      - `build_ms_from_shell_idx`: Added test for script `scil_viz_gradient_screenshot`.

- scil.viz.plot Already good. (75%)

- scil.viz.screenshot: **(COVERAGE: FROM 28% TO  82% )**
      - `screenshot_contour`: could be managed, but leads to error. To be managed in another PR.  (note perso: voir ma branche fix_overlays)
      - `screenshot_peaks`: No peaks in test data to be able to add option in `scil_viz_volume_screenshot`. Added issue #1203.
      - `compose_mosaic`: Added a test in test_viz_volume_screenshot_mosaic.

- scil.viz.sclice **(COVERAGE: FROM 34% TO 74%  )**
       - `create_texture_slicer`: Added options to test_viz_fodf and test_viz_volume_screenshot.
       - `create_peaks_slicer`: see again issue #1203
       - `create_odf_sclicer`: Added options to test_viz_fodf.
       - `create_bingham_slicer`: Fixed test_viz_bignham_fit!  (Note. Docstring for bingham_volumes were outdated. fixed).

- scil.viz.utils: **(COVERAGE: FROM  47% TO  79% )**
       
       
 Bonus: 
 - `scil_bundle_diameter.py`: from 70% to 86%
 - `scil_tractogram_assign_custom_color`: from 69% to 77%
 - `scil_viz_tractogram_seeds_3d`: from 49% to 74%
 - `scil_viz_gradients_screenshot`: from 35% to 71%
 - `scil_viz_volume_screenshot`: from 71% to 78%
 - `scil_viz_volume_screenshot_mozaic`: from 48% to 83%
 - `scil_viz_bingham_fit`: from 58% to 88%
 