### PR TITLE
Small fixes viz

### DIFF
--- a/scilpy/io/utils.py
+++ b/scilpy/io/utils.py
@@ -473,18 +473,18 @@ def add_overlays_screenshot_args(parser, default_alpha=0.5,
     rpg = rendering_parsing_group or parser
     rpg.add_argument("--overlays_as_contours", action='store_true',
                      help="Display overlays contours and reduce the opacity "
-                          "of their inner region (see the "
+                          "of their \ninner region (see the "
                           "`--overlays_opacity` argument).")
     rpg.add_argument("--overlays_colors", nargs="+",
                      type=ranged_type(int, 0, 255), metavar="R G B",
                      help="Colors for the overlays or contours. You may "
-                          "provide a single color, for all overlays/contours, "
-                          "or one color for each. Each color is given as "
-                          "three values: R G B")
+                          "provide a single color, \nfor all "
+                          "overlays/contours, or one color for each. Each "
+                          "color is given \nas three values: R G B")
     rpg.add_argument("--overlays_opacity", type=ranged_type(float, 0., 1.),
                      default=default_alpha,
                      help="Opacity value for the masks overlays. When "
-                          "combined with `--overlays_as_contours`, this will "
+                          "combined with `--overlays_as_contours`,\nthis will "
                           "be the opacity of the region inside the computed "
                           "contours. [%(default)s]")
 
@@ -567,10 +567,10 @@ def add_default_screenshot_args(parser, slice_ids_mandatory=True,
 
     _output_help = "Name of the output image (e.g. img.jpg, img.png)."
     if not slice_ids_mandatory:
-        _output_help = "Name of the output image(s). If multiple slices are " \
-                       "provided (or none), their index will be append to " \
-                       "the name (e.g. volume.jpg, volume.png becomes " \
-                       "volume_slice_0.jpg, volume_slice_0.png)."
+        _output_help = ("Name of the output image(s). If multiple slices are"
+                        "provided (or none),\ntheir index will be appended to "
+                        "the name (e.g. volume.jpg, volume.png \nbecome "
+                        "volume_slice_0.jpg, volume_slice_0.png).")
 
     add_volume_screenshot_args(parser, "volume",
                                cmap_parsing_group=cmap_parsing_group,
@@ -579,12 +579,12 @@ def add_default_screenshot_args(parser, slice_ids_mandatory=True,
     if transparency_mask_mandatory:
         parser.add_argument("transparency",
                             help="Transparency Nifti image (.nii/.nii.gz). "
-                                 "Can either be a binary mask or a scalar "
+                                 "Can either be a \nbinary mask or a scalar "
                                  "image in the range [0, 1].")
     else:
         parser.add_argument("--transparency",
                             help="Transparency Nifti image (.nii/.nii.gz). "
-                                 "Can either be a binary mask or a scalar "
+                                 "Can either be a \nbinary mask or a scalar "
                                  "image in the range [0, 1].")
 
     parser.add_argument("out_fname", help=_output_help)
@@ -601,7 +601,7 @@ def add_default_screenshot_args(parser, slice_ids_mandatory=True,
         sg = slicing_parsing_group or parser
         sg.add_argument("--slices", nargs="+", type=int, metavar="SID",
                         help="Slice indices to screenshot. If None are "
-                             "supplied, all slices inside the transparency "
+                             "supplied, \nall slices inside the transparency "
                              "mask are selected.")
 
         sg.add_argument("--axis", default="axial",

--- a/scilpy/viz/backends/fury.py
+++ b/scilpy/viz/backends/fury.py
@@ -284,8 +284,9 @@ def snapshot_scenes(scenes, window_size):
 
     Returns
     -------
-    snapshots : generator of 2d np.ndarray
+    snapshots : generator of 2d np.ndarray.
         Generator of snapshots.
+        The resulting numpy arrays are 3D (RGB 2D): (dimx, dimy, 3).
     """
 
     for scene in scenes:

--- a/scilpy/viz/backends/fury.py
+++ b/scilpy/viz/backends/fury.py
@@ -98,7 +98,7 @@ def initialize_camera(orientation, slice_index, volume_shape, aspect_ratio):
     # From vtkCamera documentation, see SetViewAngle and SetParallelScale
     # https://vtk.org/doc/nightly/html/classvtkCamera.html
     camera[CamParams.VIEW_ANGLE] = 2.0 * np.arctan(ref_height / 2.0)
-    camera[CamParams.PARA_SCALE] = ref_height / (2.0)
+    camera[CamParams.PARA_SCALE] = ref_height / 2.0
 
     return camera
 
@@ -252,7 +252,7 @@ def snapshot_slices(actors, slice_ids, orientation, shape, size):
         Name of the axis to snapshot.
     shape : tuple
         Shape of the volume.
-    size : tuple
+    size : tuple[int, int]
         Size of the viewport.
 
     Returns
@@ -279,7 +279,7 @@ def snapshot_scenes(scenes, window_size):
     ----------
     scenes : list of window.Scene
         List of scenes to snapshot.
-    window_size : tuple
+    window_size : tuple[int, int]
         Size of the window.
 
     Returns
@@ -311,7 +311,7 @@ def create_contours_actor(contours, opacity=1., linewidth=3.,
     Returns
     -------
     contours_actor : actor.odf_slicer
-        Fury object containing the contours information.
+        Fury object containing the contours' information.
     """
 
     contours_actor = get_actor_from_polydata(contours)
@@ -327,7 +327,7 @@ def create_odf_actors(sf_fodf, sphere, scale, sf_variance=None, mask=None,
                       radial_scale=False, norm=False, colormap=None,
                       variance_k=1.0, variance_color=None):
     """
-    Create a ODF slicer actor displaying a fODF slice. The input volume is a
+    Create an ODF slicer actor displaying a fODF slice. The input volume is a
     3-dimensional grid containing the SH coefficients of the fODF at each
     voxel, with the grid dimension having a size of 1 along the axis
     corresponding to the selected orientation.
@@ -423,13 +423,13 @@ def create_peaks_actor(peaks, mask, opacity=1.0, linewidth=1.0, color=None,
         If True, use level of detail rendering.
     lod_nb_points : int
         Number of points to use for level of detail rendering.
-    lod_points_size : float
+    lod_points_size : int
         Size of the points for level of detail rendering.
 
     Returns
     -------
     peaks_actor : actor.odf_slicer
-        Fury object containing the peaks information.
+        Fury object containing the peaks' information.
     """
 
     return actor.peak_slicer(peaks, mask=mask, affine=np.eye(4),

--- a/scilpy/viz/backends/pil.py
+++ b/scilpy/viz/backends/pil.py
@@ -46,7 +46,7 @@ def create_image_from_2d_array(array_2d, size, mode=None,
     Parameters
     ----------
     array_2d : ndarray
-        2d array data.
+        2d array data, or 3d (RGB) with [dimx, dimy, 3].
     size : array-like
         Image size (pixels) (width, height).
     mode : str, optional
@@ -301,8 +301,12 @@ def draw_2d_array_at_position(canvas, array_2d, size,
             overlays_colors = generate_n_colors(len(overlays))
 
         for img, color in zip(overlays, overlays_colors):
-            overlay = create_image_from_2d_array(img[:, :, None] * color,
-                                                 size, "RGB")
+            if len(img.shape) == 2:
+                overlay = create_image_from_2d_array(img[:, :, None] * color,
+                                                     size, "RGB")
+            else:
+                overlay = create_image_from_2d_array(img * color,
+                                                     size, "RGB")
 
             # Create transparency mask over the mask overlay image
             overlay_transparency = create_image_from_2d_array(

--- a/scilpy/viz/backends/pil.py
+++ b/scilpy/viz/backends/pil.py
@@ -70,30 +70,6 @@ def create_image_from_2d_array(array_2d, size, mode=None,
         .resize(size, resampling)
 
 
-def create_mask_from_2d_array(array_2d, size, greater_threshold=0):
-    """
-    Create a binary `PIL.Image` from the 2d array data.
-
-    Parameters
-    ----------
-    array_2d : ndarray
-        2d scene data.
-    size : array-like
-        Image size (pixels) (width, height).
-    greater_threshold: Any
-        Threshold to use to binarize the data.
-        Type must abide with the array dtype
-
-    Returns
-    -------
-    image : PIL.Image
-        Image.
-    """
-
-    _bin_arr = array_2d > greater_threshold
-    return create_image_from_2d_array(any2grayscale(_bin_arr), size)
-
-
 def compute_canvas_size(rows, columns, cell_width, cell_height,
                         width_overlap, height_overlap):
     """
@@ -104,7 +80,7 @@ def compute_canvas_size(rows, columns, cell_width, cell_height,
     ----------
     rows : int
         Number of rows.
-    cols : int
+    columns : int
         Number of columns.
     cell_width : int
         Cell width (pixels).
@@ -275,6 +251,8 @@ def draw_2d_array_at_position(canvas, array_2d, size,
         Top position (pixels).
     transparency : ndarray, optional
         Transparency mask.
+    image_alpha: float
+        Transparency alpha value.
     labelmap_overlay : ndarray
         Labelmap overlay scene data to be drawn.
     labelmap_overlay_alpha : float
@@ -283,11 +261,11 @@ def draw_2d_array_at_position(canvas, array_2d, size,
         Overlays scene data to be drawn.
     overlays_alpha : float
         Alpha value for the overlays in range [0, 1].
-    overlays_color : list, optional
+    overlays_colors : list, optional
         Color for the overlays as a list of 3 integers in range [0, 255].
-    peaks_overlay : ndarray
+    peak_overlay : ndarray
         Peaks overlay scene data to be drawn.
-    peaks_overlay_alpha : float
+    peak_overlay_alpha : float
         Alpha value for peaks overlay in range [0, 1].
     """
 

--- a/scilpy/viz/backends/pil.py
+++ b/scilpy/viz/backends/pil.py
@@ -257,8 +257,8 @@ def draw_2d_array_at_position(canvas, array_2d, size,
         Labelmap overlay scene data to be drawn.
     labelmap_overlay_alpha : float
         Alpha value for labelmap overlay in range [0, 1].
-    overlays : ndarray
-        Overlays scene data to be drawn.
+    overlays : list[ndarray], optional
+        Overlays scene data to be drawn. List of 2D arrays.
     overlays_alpha : float
         Alpha value for the overlays in range [0, 1].
     overlays_colors : list, optional
@@ -268,7 +268,6 @@ def draw_2d_array_at_position(canvas, array_2d, size,
     peak_overlay_alpha : float
         Alpha value for peaks overlay in range [0, 1].
     """
-
     image = create_image_from_2d_array(array_2d, size, "RGB")
 
     _transparency = None
@@ -302,7 +301,8 @@ def draw_2d_array_at_position(canvas, array_2d, size,
             overlays_colors = generate_n_colors(len(overlays))
 
         for img, color in zip(overlays, overlays_colors):
-            overlay = create_image_from_2d_array(img * color, size, "RGB")
+            overlay = create_image_from_2d_array(img[:, :, None] * color,
+                                                 size, "RGB")
 
             # Create transparency mask over the mask overlay image
             overlay_transparency = create_image_from_2d_array(

--- a/scilpy/viz/color.py
+++ b/scilpy/viz/color.py
@@ -52,7 +52,8 @@ def generate_n_colors(n, generator=colormap.distinguishable_colormap,
     n : int
         Number of colors to generate.
     generator : function
-        Color generating function f(n, exclude=[...]) -> [color, color, ...],
+        Color generating function
+        f(nb_colors=n, exclude=[...]) -> [color, color, ...],
         accepting an optional list of colors to exclude from the generation.
     pick_from_base10 : bool
         When True, start picking from the base 10 colors before using
@@ -73,7 +74,8 @@ def generate_n_colors(n, generator=colormap.distinguishable_colormap,
 
     if n - len(_colors):
         _colors = np.concatenate(
-            (_colors, generator(n - len(_colors), exclude=_colors)), axis=0)
+            (_colors, generator(nb_colors=n - len(_colors), exclude=_colors)),
+            axis=0)
 
     if shuffle:
         np.random.shuffle(_colors)

--- a/scilpy/viz/screenshot.py
+++ b/scilpy/viz/screenshot.py
@@ -142,7 +142,7 @@ def compose_image(img_scene, img_size, slice_number, *, corner_position=(0, 0),
     Parameters
     ----------
     img_scene : np.ndarray
-        Image scene data.
+        Image scene data. Data should be 2D (dimx, dimy, 3).
     img_size : array-like
         Image size (pixels) (width, height).
     slice_number : int
@@ -182,7 +182,6 @@ def compose_image(img_scene, img_size, slice_number, *, corner_position=(0, 0),
     canvas : PIL.Image
         Canvas containing the pasted scene.
     """
-
     if canvas is None:
         canvas = create_canvas(*img_size, 1, 1, 0, 0)
 

--- a/scripts/scil_viz_fodf.py
+++ b/scripts/scil_viz_fodf.py
@@ -371,7 +371,7 @@ def main():
                                     args.win_dims)
         _mask_arr = None
         if mask_scene:
-            _mask_arr = any2grayscale(next(snapshots))
+            _mask_arr = [any2grayscale(next(snapshots))]
 
         image = compose_image(next(snapshots),
                               args.win_dims,

--- a/scripts/scil_viz_fodf.py
+++ b/scripts/scil_viz_fodf.py
@@ -195,10 +195,9 @@ def _parse_args(parser):
     output = []
     if args.output:
         output.append(args.output)
-    else:
-        if args.silent:
-            parser.error('Silent mode is enabled but no output is specified.'
-                         'Specify an output with --output to use silent mode.')
+    elif args.silent:
+        parser.error('Silent mode is enabled but no output is specified.'
+                     'Specify an output with --output to use silent mode.')
 
     if args.peaks_values and not args.peaks:
         parser.error('Peaks values image supplied without peaks. Specify '
@@ -227,8 +226,7 @@ def _get_data_from_inputs(args):
         data['bg'] = bg
     if args.in_transparency_mask:
         transparency_mask = get_data_as_mask(
-            nib.load(args.in_transparency_mask), dtype=bool
-        )
+            nib.load(args.in_transparency_mask), dtype=bool)
         data['transparency_mask'] = transparency_mask
     if args.mask:
         assert_same_resolution([args.mask, args.in_fodf])

--- a/scripts/scil_viz_volume_screenshot.py
+++ b/scripts/scil_viz_volume_screenshot.py
@@ -84,7 +84,14 @@ def _build_arg_parser():
     og = p.add_argument_group(title="Overlay rendering")
     ag = p.add_argument_group(title="Annotations")
 
-    add_default_screenshot_args(p, False, False, False, sg, ag, vg, vg)
+    add_default_screenshot_args(p,
+                                slice_ids_mandatory=False,
+                                transparency_mask_mandatory=False,
+                                disable_annotations=False,
+                                slicing_parsing_group=sg,
+                                annotation_parsing_group=ag,
+                                cmap_parsing_group=vg,
+                                opacity_parsing_group=vg)
     add_labelmap_screenshot_args(xg, "viridis", 0.5, vg, vg)
     add_overlays_screenshot_args(xg, 0.5, og)
     add_peaks_screenshot_args(xg, rendering_parsing_group=pg)

--- a/scripts/tests/test_viz_fodf.py
+++ b/scripts/tests/test_viz_fodf.py
@@ -22,4 +22,17 @@ def test_silent_without_output(script_runner, monkeypatch):
 
     ret = script_runner.run('scil_viz_fodf.py', in_fodf, '--silent')
 
+    # Should say that requires an output with --silent mode
     assert (not ret.success)
+
+
+def test_run(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+    in_fodf = os.path.join(SCILPY_HOME, 'tracking', 'fodf.nii.gz')
+    in_mask = os.path.join(SCILPY_HOME, 'tracking', 'seeding_mask.nii.gz')
+
+    ret = script_runner.run('scil_viz_fodf.py', in_fodf, '--silent',
+                            '--in_transparency_mask', in_mask,
+                            '--output', tmp_dir.name)
+
+    assert ret.success

--- a/scripts/tests/test_viz_fodf.py
+++ b/scripts/tests/test_viz_fodf.py
@@ -30,9 +30,9 @@ def test_run(script_runner, monkeypatch):
     monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_fodf = os.path.join(SCILPY_HOME, 'tracking', 'fodf.nii.gz')
     in_mask = os.path.join(SCILPY_HOME, 'tracking', 'seeding_mask.nii.gz')
-
+    out_name = os.path.join(tmp_dir.name, 'out.png')
     ret = script_runner.run('scil_viz_fodf.py', in_fodf, '--silent',
                             '--in_transparency_mask', in_mask,
-                            '--output', tmp_dir.name)
+                            '--output', out_name)
 
     assert ret.success

--- a/scripts/tests/test_viz_volume_screenshot.py
+++ b/scripts/tests/test_viz_volume_screenshot.py
@@ -16,7 +16,8 @@ def test_screenshot(script_runner, monkeypatch):
     monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
     in_fa = os.path.join(SCILPY_HOME, 'bst', 'fa.nii.gz')
 
-    ret = script_runner.run("scil_viz_volume_screenshot.py", in_fa, 'fa.png')
+    ret = script_runner.run("scil_viz_volume_screenshot.py", in_fa, 'fa.png',
+                            '--display_slice_number', '--display_lr')
     assert ret.success
 
 


### PR DESCRIPTION
**Fixes:**
- scilpy.viz.backends.fury: Some wrong docstrings.
- scilpy.viz.backends.pil: Some wrong docstrings. Deleting function not used anywhere. Adding options in test for more coverage. Added some `\n` in the utils's help.

WIP BUG:
My test that I added to test_viz_fodf.py fails:

```
Traceback (most recent call last):
  File "scripts/scil_viz_fodf.py", line 376, in main
    image = compose_image(next(snapshots),
  File "scilpy/viz/screenshot.py", line 189, in compose_image
    draw_2d_array_at_position(canvas, img_scene, img_size,
  File "scilpy/viz/backends/pil.py", line 302, in draw_2d_array_at_position
    overlays_colors = generate_n_colors(len(overlays))
  File "scilpy/viz/color.py", line 75, in generate_n_colors
    _colors = np.concatenate(
ValueError: all the input arrays must have same number of dimensions, but the array at index 0 has 2 dimension(s) and the array at index 1 has 0 dimension(s)
```

@AlexVCaron ?