### PR TITLE
[BF] Add new color if dict_color is not enough

### DIFF
--- a/scripts/scil_tractogram_assign_uniform_color.py
+++ b/scripts/scil_tractogram_assign_uniform_color.py
@@ -128,6 +128,7 @@ def main():
     for color in dict_colors.values():
         tmp_color = format_hexadecimal_color_to_rgb(color)
         rgb_colors.append(tuple(tc/256 for tc in tmp_color))
+
     # Processing
     for i, filename in enumerate(args.in_tractograms):
         color = None

--- a/scripts/scil_tractogram_assign_uniform_color.py
+++ b/scripts/scil_tractogram_assign_uniform_color.py
@@ -124,10 +124,10 @@ def main():
         with open(args.dict_colors, 'r') as data:
             dict_colors = json.load(data)
 
-    rgb_colors = []
-    for color in dict_colors.values():
-        tmp_color = format_hexadecimal_color_to_rgb(color)
-        rgb_colors.append(tuple(tc/256 for tc in tmp_color))
+        rgb_colors = []
+        for color in dict_colors.values():
+            tmp_color = format_hexadecimal_color_to_rgb(color)
+            rgb_colors.append(tuple(tc/256 for tc in tmp_color))
 
     # Processing
     for i, filename in enumerate(args.in_tractograms):
@@ -147,6 +147,7 @@ def main():
             for key in dict_colors.keys():
                 if key in base:
                     color = dict_colors[key]
+
             if color is None and args.overwrite:
                 updated_dict = True
                 logging.warning('No color found for {} in your '
@@ -159,7 +160,8 @@ def main():
                 new_color = [tc*255 for tc in new_color]
                 color = '0x%02x%02x%02x' % tuple(new_color[0].astype(int))
                 dict_colors[base] = color
-            else:
+            
+            if color is None:
                 parser.error("Basename of file {} ({}) not found in your "
                              "dict_colors keys.".format(filename, base))
         else:  # args.fill_color is not None:

--- a/scripts/scil_tractogram_assign_uniform_color.py
+++ b/scripts/scil_tractogram_assign_uniform_color.py
@@ -159,9 +159,11 @@ def main():
                 # and not already used.
                 new_color = distinguishable_colormap(nb_colors=1,
                                                      exclude=rgb_colors)
-                new_color = [tc*255 for tc in new_color]
-                rgb_colors.append(tuple(tc/255 for tc in new_color[0]))
-                color = '0x%02x%02x%02x' % tuple(new_color[0].astype(int))
+                # Append the new color to the list of used colors
+                rgb_colors.append(tuple(tc for tc in new_color[0]))
+                # Convert to hexadecimal format
+                color = '0x%02x%02x%02x' % tuple(map(int, rgb_colors[-1]))
+                # Add the new color to the dictionary
                 dict_colors[base] = color
 
             if color is None:

--- a/scripts/tests/test_tractogram_assign_uniform_color.py
+++ b/scripts/tests/test_tractogram_assign_uniform_color.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 import json
 import os
+import shutil
 import tempfile
 
 from scilpy import SCILPY_HOME
@@ -40,5 +41,21 @@ def test_execution_dict(script_runner, monkeypatch):
 
     ret = script_runner.run('scil_tractogram_assign_uniform_color.py',
                             in_bundle, '--dict_colors', json_file,
+                            '--out_suffix', 'colored', '-f')
+    assert ret.success
+
+def test_execution_dict_new_color(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+
+    # Create a fake dictionary. Using the other hexadecimal format.
+    my_dict = {'IFGWM': '#000000'}
+    json_file = 'my_json_dict.json'
+    with open(json_file, "w+") as f:
+        json.dump(my_dict, f)
+
+    shutil.copy2(in_bundle, 'dummy.trk')
+    ret = script_runner.run('scil_tractogram_assign_uniform_color.py',
+                            in_bundle, "dummy.trk",
+                            '--dict_colors', json_file,
                             '--out_suffix', 'colored', '-f')
     assert ret.success


### PR DESCRIPTION
# Quick description

If you use scil_tractogram_assign_uniform_color.py and the tractogram you assigned color to is not in the dict the script was crashing. Now if you add -f it will find an extra color to use and save the new dict at the same place as the old one.
...

## Type of change

Check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [ ] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
