### PR TITLE
[FIX] Add non-root user to devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,14 @@
 FROM scilus/scilus:latest
 
+RUN groupadd -g 1001 scilus && \
+    useradd -s /bin/bash -m -u 1001 -g scilus scilus
+
+USER root
+
 RUN apt update && apt install -y \
         git \
         wget \
     && rm -rf /var/lib/apt/lists/*
+
+USER scilus
+ENV PATH=/home/scilus/.local/bin:$PATH

--- a/.devcontainer/setup_container.sh
+++ b/.devcontainer/setup_container.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 echo "Rebind development Scilpy to Python"
-pip install -e .
+pip install --user -e .


### PR DESCRIPTION
# Quick description

The devcontainer stopped to build correctly. I added a non-root user to the Dockerfile and slightly modified the installation of scilpy to target this user instead of root.
...

## Type of change

Check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

Open scilpy in VS Code and Reopen in Container

# Checklist

- [x] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [x] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
