### PR TITLE
DOC: Fix output label indices parameter name in script doc example

### DIFF
--- a/scripts/scil_labels_combine.py
+++ b/scripts/scil_labels_combine.py
@@ -8,7 +8,7 @@ overwrite them based on the input order.
     >>> scil_labels_combine.py out_labels.nii.gz
             --volume_ids animal_labels.nii 20
             --volume_ids DKT_labels.nii.gz 44 53
-            --out_labels_indices 20 44 53
+            --out_labels_ids 20 44 53
     >>> scil_labels_combine.py slf_labels.nii.gz
             --volume_ids a2009s_aseg.nii.gz all
             --volume_ids clean/s1__DKT.nii.gz 1028 2028


### PR DESCRIPTION
# Quick description

Fix output label indices parameter name in script doc example: use ``out_labels_ids`` instead of ``out_labels_indices`` to match the argument name,

## Type of change

Check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Do not apply.

## Provide data, screenshots, command line to test (if relevant)

Not necessary

# Checklist

- [X] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
