### PR TITLE
[MAJOR][BF] Cut invalid streamlines

### DIFF
--- a/scilpy/tractograms/tests/test_streamline_operations.py
+++ b/scilpy/tractograms/tests/test_streamline_operations.py
@@ -87,20 +87,46 @@ def test_compress_sft():
 
 
 def test_cut_invalid_streamlines():
-    sft = load_tractogram(in_long_sft, in_ref)
+    sft = load_tractogram(in_short_sft, in_ref)
     sft.to_vox()
 
     cut, nb = cut_invalid_streamlines(sft)
     assert len(cut) == len(sft)
     assert nb == 0
 
-    # Faking an invalid streamline. Currently, volume is 64x64x3
+    # Faking an invalid streamline at all positions.
+    # Currently, volume is 64x64x3
+    remaining_streamlines = [11, 10, 9, 8, 7, 6, 6, 7, 8, 9, 10, 11]
+    for index, ind_cut in enumerate(sft.streamlines[0]):
+        sft = load_tractogram(in_short_sft, in_ref)
+        sft.streamlines[0][index, :] = [65.0, 65.0, 2.0]
+        cut, nb = cut_invalid_streamlines(sft)
+        assert len(cut) == len(sft)
+        assert np.all([len(sc) <= len(s) for s, sc in
+                       zip(sft.streamlines, cut.streamlines)])
+        assert len(cut.streamlines[0]) == remaining_streamlines[index]
+        assert nb == 1
+
+    # Faking an invalid streamline at position 0 and -1
+    sft = load_tractogram(in_short_sft, in_ref)
+    sft.streamlines[0][0, :] = [65.0, 65.0, 2.0]
     sft.streamlines[0][-1, :] = [65.0, 65.0, 2.0]
     cut, nb = cut_invalid_streamlines(sft)
     assert len(cut) == len(sft)
     assert np.all([len(sc) <= len(s) for s, sc in
                    zip(sft.streamlines, cut.streamlines)])
-    assert len(cut.streamlines[0]) == len(sft.streamlines[0]) - 1
+    assert len(cut.streamlines[0]) == len(sft.streamlines[0]) - 2
+    assert nb == 1
+
+    # Faking an invalid streamline at position 2 and 2
+    sft = load_tractogram(in_short_sft, in_ref)
+    sft.streamlines[0][2, :] = [65.0, 65.0, 2.0]
+    sft.streamlines[0][9, :] = [65.0, 65.0, 2.0]
+    cut, nb = cut_invalid_streamlines(sft)
+    assert len(cut) == len(sft)
+    assert np.all([len(sc) <= len(s) for s, sc in
+                   zip(sft.streamlines, cut.streamlines)])
+    assert len(cut.streamlines[0]) == 6
     assert nb == 1
 
 

--- a/scripts/scil_tractogram_remove_invalid.py
+++ b/scripts/scil_tractogram_remove_invalid.py
@@ -79,7 +79,6 @@ def main():
 
     # Processing
     ori_len = len(sft)
-    ori_len_pts = len(sft.streamlines._data)
     if args.cut_invalid:
         sft, cutting_counter = cut_invalid_streamlines(sft,
                                                        epsilon=args.threshold)
@@ -89,15 +88,18 @@ def main():
 
     if args.remove_single_point:
         sft = filter_streamlines_by_nb_points(sft, min_nb_points=2)
+        logging.warning('Removed {} streamlines one point.'.format(
+            ori_len - len(sft)))
 
     if args.remove_overlapping_points:
+        ori_len_pts = len(sft.streamlines._data)
         sft = remove_overlapping_points_streamlines(sft, args.threshold)
         logging.warning("data_per_point will be discarded.")
         logging.warning('Removed {} overlapping points "'
                         'from tractogram.'.format(ori_len_pts -
                                                   len(sft.streamlines._data)))
 
-    logging.warning('Removed {} invalid streamlines.'.format(
+    logging.warning('Removed a total of {} invalid streamlines.'.format(
         ori_len - len(sft)))
 
     save_tractogram(sft, args.out_tractogram, args.no_empty)


### PR DESCRIPTION
# Quick description

The cut_invalid_streamlines  function has some corner cases not working when a streamline had its first point invalid.
This new version with new tests fixes it.

You can play with this data: [data.tar.gz](https://github.com/user-attachments/files/19782028/data.tar.gz)

...

## Type of change

Check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [ ] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
