### PR TITLE
ENH: optimize `cut_invalid_streamlines`

### DIFF
--- a/scilpy/tractograms/streamline_operations.py
+++ b/scilpy/tractograms/streamline_operations.py
@@ -268,26 +268,28 @@ def cut_invalid_streamlines(sft, epsilon=0.001):
             blobs, _ = ndi.label(in_vol)
 
             # Get the largest blob
-            largest_blob = np.argmax(np.bincount(blobs.ravel())[1:]) + 1
+            bins = np.bincount(blobs.ravel())[1:]
+            if len(bins) > 0:
+                largest_blob = np.argmax(bins) + 1
 
-            # Get the indices of the points in the largest blob
-            ind_in_vol = np.where(blobs == largest_blob)[0]
-            # If there are points in the volume
-            if len(ind_in_vol):
-                # Get the streamline segment that is within the volume
-                new_streamline = sft.streamlines[ind][ind_in_vol]
-                new_streamlines.append(new_streamline)
-
-                for key in sft.data_per_streamline.keys():
-                    new_data_per_streamline[key].append(
-                        sft.data_per_streamline[key][ind])
-                for key in sft.data_per_point.keys():
-                    new_data_per_point[key].append(
-                        sft.data_per_point[key][ind][
-                            ind_in_vol])
-                cutting_counter += 1
+                # Get the indices of the points in the largest blob
+                ind_in_vol = np.where(blobs == largest_blob)[0]
             else:
                 logging.warning('Streamline entirely out of the volume.')
+                continue
+
+            # Get the streamline segment that is within the volume
+            new_streamline = sft.streamlines[ind][ind_in_vol]
+            new_streamlines.append(new_streamline)
+
+            for key in sft.data_per_streamline.keys():
+                new_data_per_streamline[key].append(
+                    sft.data_per_streamline[key][ind])
+            for key in sft.data_per_point.keys():
+                new_data_per_point[key].append(
+                    sft.data_per_point[key][ind][
+                        ind_in_vol])
+            cutting_counter += 1
         else:
             # No reason to try to cut if all points are within the volume
             new_streamlines.append(sft.streamlines[ind])

--- a/scilpy/tractograms/streamline_operations.py
+++ b/scilpy/tractograms/streamline_operations.py
@@ -310,21 +310,27 @@ def cut_invalid_streamlines(sft, epsilon=0.001):
     return new_sft, cutting_counter
 
 
-def remove_single_point_streamlines(sft):
+def filter_streamlines_by_nb_points(sft, min_nb_points=2):
     """
-    Remove single point streamlines from a StatefulTractogram.
+    Remove streamlines from a StatefulTractogram with fewer nb_points.
 
     Parameters
     ----------
     sft: StatefulTractogram
         The sft to remove single point streamlines from.
+    min_nb_points: int
+        Minimum number of point a streamline needs to have to kept.
 
     Returns
     -------
     new_sft : StatefulTractogram
         New object with the single point streamlines removed.
     """
-    indices = [i for i in range(len(sft)) if len(sft.streamlines[i]) > 1]
+    if min_nb_points <= 1:
+        raise ValueError("The value of min_nb_points "
+                         "should be greater than 1!")
+
+    indices = [i for i in range(len(sft)) if len(sft.streamlines[i]) > min_nb_points - 1]
     if len(indices):
         new_sft = sft[indices]
     else:
@@ -980,6 +986,7 @@ def get_streamlines_as_fixed_array(streamlines):
     Parameters
     ----------
     streamlines: list
+        The list of streamlines to convert into a fixed length array
 
     Return
     ------
@@ -989,9 +996,45 @@ def get_streamlines_as_fixed_array(streamlines):
         Single dimensional array of all the streamline lengths.
     """
     lengths = [len(streamline) for streamline in streamlines]
-    streamlines_fixed = np.ndarray((len(streamlines), max(lengths), 3))
+    streamlines_fixed = np.zeros((len(streamlines), max(lengths), 3))
     for i, f in enumerate(streamlines_fixed):
         for j, c in enumerate(streamlines[i]):
             f[j] = c
 
     return streamlines_fixed, np.array(lengths)
+
+
+def find_seed_indexes_on_streamlines(seeds, streamlines, atol=1.e-8):
+    """
+    Given a list of seeds and a corresponding list of streamlines, finds
+    the index of each seed on its respective streamline.
+
+    Parameters
+    ----------
+    seeds: list
+        List of seeds to locate on streamlines
+    streamlines: list
+        List of streamlines produced from seeds
+    atol: float
+        Absolute tolerance of the comparison between a seed and each of the
+        streamline coordinates.
+
+    Return
+    ------
+    seed_indexes: list
+        A list containing the index of each seed on its streamline.
+    """
+    seed_indexes = []
+    for seed, streamline in zip(seeds, streamlines):
+        seed_index = -1
+
+        for i, point in enumerate(streamline):
+            if np.allclose(point, seed, rtol=0, atol=atol):
+                seed_index = i
+                break
+
+        if seed_index == -1:
+            raise ValueError('A seed coordinate was not found on streamline.')
+
+        seed_indexes.append(seed_index)
+    return seed_indexes


### PR DESCRIPTION
# Quick description

This function optimizes and simplifies `scilpy/tractograms/streamline_operations.cut_invalid_streamlines`. This PR alleviates some load from #1105 .

## Type of change

Check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

[test_pr_1105](https://github.com/user-attachments/files/18608970/test_pr_1105.zip)

# Checklist

- [X] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
