### PR TITLE
Small bug fix for scil_gradients_validate_sampling.py

### DIFF
--- a/scripts/scil_gradients_validate_sampling.py
+++ b/scripts/scil_gradients_validate_sampling.py
@@ -102,8 +102,8 @@ def main():
                                         in_gradients[1])
     elif len(args.in_gradients) == 1:
         assert_gradients_filenames_valid(parser, args.in_gradients, False)
-        bvecs = np.genfromtxt(args.in_gradients, delimiter=' ')[:, :3]
-        bvals = np.genfromtxt(args.in_gradients, delimiter=' ')[:, 3]
+        bvecs = np.genfromtxt(args.in_gradients[0], delimiter=' ')[:, :3]
+        bvals = np.genfromtxt(args.in_gradients[0], delimiter=' ')[:, 3]
     else:
         parser.error('Depending on the gradient format, you should have '
                      'two files for FSL format and one file for MRtrix')

--- a/scripts/tests/test_gradients_validate_sampling.py
+++ b/scripts/tests/test_gradients_validate_sampling.py
@@ -27,3 +27,12 @@ def test_execution_normal(script_runner, monkeypatch):
     ret = script_runner.run('scil_gradients_validate_sampling.py', in_bval,
                             in_bvec)
     assert ret.success
+
+
+def test_execution_mrtrix(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+    in_b = os.path.join(SCILPY_HOME, 'processing',
+                           '1000.b')
+
+    ret = script_runner.run('scil_gradients_validate_sampling.py', in_b)
+    assert ret.success


### PR DESCRIPTION
# Quick description

The script was not working with the .b filetype (mrtrix). I fixed the bug and added a test to catch it.

...

## Type of change

Check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [ ] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
