### PR TITLE
FIX: scil_bundle_label_map crash

### DIFF
--- a/scripts/scil_bundle_label_map.py
+++ b/scripts/scil_bundle_label_map.py
@@ -164,7 +164,7 @@ def main():
         parser.error('correlation_thr must be greater than 0')
 
     if args.hyperplane:
-        warning = 'WARNING: The --hyperplane option should be used carefully,' \
+        warning = 'WARNING: The --hyperplane option should be used carefully,'\
                   ' not fully tested!'
         heading = '=' * len(warning)
         logging.warning(f'{heading}\n{warning}\n{heading}')
@@ -230,8 +230,8 @@ def main():
         density_list.append(density)
 
     if not is_header_compatible(sft_centroid, sft_list[0]):
-        raise IOError(f'{args.in_centroid} and {args.in_bundles} do not have a '
-                      'compatible header')
+        raise IOError(f'{args.in_centroid} and {args.in_bundles} do not have a'
+                      ' compatible header')
 
     logging.debug('Computed density and binary map(s) in '
                   f'{round(time.time() - timer, 3)}.')
@@ -290,7 +290,8 @@ def main():
     labels_map = subdivide_bundles(concat_sft, sft_centroid, binary_mask,
                                    args.nb_pts, method=method)
 
-    # We trim the streamlines due to looping labels, so we have a new binary mask
+    # We trim the streamlines due to looping labels, so we have a new binary
+    # mask
     binary_mask = np.zeros(labels_map.shape, dtype=np.uint8)
     binary_mask[labels_map > 0] = 1
 
@@ -341,13 +342,14 @@ def main():
 
         # Iterate through each type to save the files
         for basename, map in data_dict.items():
-            nib.save(nib.Nifti1Image((binary_list[i] * map), sft_list[0].affine),
-                     os.path.join(sub_out_dir, f'{basename}_map.nii.gz'))
+            nib.save(
+                nib.Nifti1Image((binary_list[i] * map), sft_list[0].affine),
+                os.path.join(sub_out_dir, f'{basename}_map.nii.gz'))
 
             if basename == 'correlation' and len(args.in_bundles) == 1:
                 continue
 
-            if len(sft):
+            if len(cut_sft):
                 tmp_data = ndi.map_coordinates(
                     map, cut_sft.streamlines._data.T - 0.5, order=0)
 


### PR DESCRIPTION
# Quick description

`scil_bundle_label_map` could crash due to a wrong variable being checked. I fixed some PEP8 errors while at it.

## Type of change

Check the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)
[sub-c02_ses-01__CG_R_Po_.zip](https://github.com/user-attachments/files/20104880/sub-c02_ses-01__CG_R_Po_.zip)
`scil_bundle_label_map.py sub-c02_ses-01__CG_R_Po_ic.trk sub-c02_ses-01__CG_R_Po_centroid_20.trk tmp_dir -f`

# Checklist

- [X] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
