### PR TITLE
[ENH][BF] Can use float or integer with some volume operation

### DIFF
--- a/scilpy/image/tests/test_volume_math.py
+++ b/scilpy/image/tests/test_volume_math.py
@@ -312,6 +312,7 @@ def test_convert():
 def test_addition():
     img_data_1 = np.array([1, 2]).astype(float)
     img_data_2 = np.array([3, 4]).astype(float)
+    img_data_3 = np.array([5, 5]).astype(float)
     affine = np.eye(4)
     img1 = nib.Nifti1Image(img_data_1, affine)
     img2 = nib.Nifti1Image(img_data_2, affine)
@@ -319,11 +320,15 @@ def test_addition():
     output_data = addition([img1, img2], img1)
     assert_array_almost_equal(output_data, expected_output)
 
+    output_data = addition([img1, 5], img1)
+    expected_output = img_data_1 + img_data_3
+    assert_array_almost_equal(output_data, expected_output)
 
-# Test function for subtraction
+
 def test_subtraction():
     img_data_1 = np.array([1, 2]).astype(float)
     img_data_2 = np.array([3, 4]).astype(float)
+    img_data_3 = np.array([1, 1]).astype(float)
     affine = np.eye(4)
     img1 = nib.Nifti1Image(img_data_1, affine)
     img2 = nib.Nifti1Image(img_data_2, affine)
@@ -331,10 +336,15 @@ def test_subtraction():
     output_data = subtraction([img1, img2], img1)
     assert_array_almost_equal(output_data, expected_output)
 
+    output_data = subtraction([img1, 1], img1)
+    expected_output = img_data_1 - img_data_3
+    assert_array_almost_equal(output_data, expected_output)
+
 
 def test_multiplication():
     img_data_1 = np.array([1, 2]).astype(float)
     img_data_2 = np.array([3, 4]).astype(float)
+    img_data_3 = np.array([2, 2]).astype(float)
     affine = np.eye(4)
     img1 = nib.Nifti1Image(img_data_1, affine)
     img2 = nib.Nifti1Image(img_data_2, affine)
@@ -342,15 +352,24 @@ def test_multiplication():
     output_data = multiplication([img1, img2], img1)
     assert_array_almost_equal(output_data, expected_output)
 
+    output_data = multiplication([img1, 2], img1)
+    expected_output = img_data_1 * img_data_3
+    assert_array_almost_equal(output_data, expected_output)
+
 
 def test_division():
     img_data_1 = np.array([3, 4]).astype(float)
     img_data_2 = np.array([1, 2]).astype(float)
+    img_data_3 = np.array([2, 2]).astype(float)
     affine = np.eye(4)
     img1 = nib.Nifti1Image(img_data_1, affine)
     img2 = nib.Nifti1Image(img_data_2, affine)
     expected_output = img_data_1 / img_data_2
     output_data = division([img1, img2], img1)
+    assert_array_almost_equal(output_data, expected_output)
+
+    output_data = division([img1, 2], img1)
+    expected_output = img_data_1 / img_data_3
     assert_array_almost_equal(output_data, expected_output)
 
 

--- a/scilpy/image/tests/test_volume_math.py
+++ b/scilpy/image/tests/test_volume_math.py
@@ -324,6 +324,9 @@ def test_addition():
     expected_output = img_data_1 + img_data_3
     assert_array_almost_equal(output_data, expected_output)
 
+    output_data = addition([5, img1], img1)
+    assert_array_almost_equal(output_data, expected_output)
+
 
 def test_subtraction():
     img_data_1 = np.array([1, 2]).astype(float)
@@ -338,6 +341,10 @@ def test_subtraction():
 
     output_data = subtraction([img1, 1], img1)
     expected_output = img_data_1 - img_data_3
+    assert_array_almost_equal(output_data, expected_output)
+
+    output_data = subtraction([1, img1], img1)
+    expected_output = img_data_3 - img_data_1
     assert_array_almost_equal(output_data, expected_output)
 
 
@@ -356,6 +363,9 @@ def test_multiplication():
     expected_output = img_data_1 * img_data_3
     assert_array_almost_equal(output_data, expected_output)
 
+    output_data = multiplication([2, img1], img1)
+    assert_array_almost_equal(output_data, expected_output)
+
 
 def test_division():
     img_data_1 = np.array([3, 4]).astype(float)
@@ -370,6 +380,10 @@ def test_division():
 
     output_data = division([img1, 2], img1)
     expected_output = img_data_1 / img_data_3
+    assert_array_almost_equal(output_data, expected_output)
+
+    output_data = division([2, img1], img1)
+    expected_output = img_data_3 / img_data_1
     assert_array_almost_equal(output_data, expected_output)
 
 


### PR DESCRIPTION
# Quick description

This is the old behavior where you could do some volume operations (add, sub, div, mult) with numbers. 

...

## Type of change

Check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [ ] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
