### PR TITLE
FIX: Streamline cutting 3 - Tokyo drift

### DIFF
--- a/scilpy/tractograms/streamline_and_mask_operations.py
+++ b/scilpy/tractograms/streamline_and_mask_operations.py
@@ -155,7 +155,7 @@ def _trim_streamline_in_mask(
         in_strl_idx, out_strl_idx = strml[1], strml[-1]
         cut_strl = compute_streamline_segment(streamline, idx,
                                               in_strl_idx, out_strl_idx,
-                                              pts_to_idx, mask)
+                                              pts_to_idx)
         new_strmls.append(cut_strl)
 
     return new_strmls
@@ -200,7 +200,7 @@ def _trim_streamline_endpoints_in_mask(
     out_strl_idx = np.amax(mask_idx)
     cut_strl = compute_streamline_segment(streamline, idx,
                                           in_strl_idx, out_strl_idx,
-                                          pts_to_idx, mask)
+                                          pts_to_idx)
     return [cut_strl]
 
 
@@ -248,7 +248,7 @@ def _trim_streamline_in_mask_keep_longest(
     in_strl_idx, out_strl_idx = longest_strml[id_to_pick], longest_strml[-1]
     cut_strl = compute_streamline_segment(streamline, idx,
                                           in_strl_idx, out_strl_idx,
-                                          pts_to_idx, mask)
+                                          pts_to_idx)
     return [cut_strl]
 
 
@@ -469,7 +469,7 @@ def _cut_streamline_with_labels(
         # the two ROIs
         cut_strl = compute_streamline_segment(streamline, idx,
                                               in_strl_idx, out_strl_idx,
-                                              pts_to_idx, roi_data_1)
+                                              pts_to_idx)
     return cut_strl
 
 
@@ -628,7 +628,7 @@ def _intersects_two_rois(roi_data_1, roi_data_2, strl_indices,
 
 
 def compute_streamline_segment(orig_strl, inter_vox, in_vox_idx, out_vox_idx,
-                               points_to_indices, mask):
+                               points_to_indices):
     """ Compute the segment of a streamline that is in a given ROI or
     between two ROIs.
 
@@ -717,21 +717,6 @@ def compute_streamline_segment(orig_strl, inter_vox, in_vox_idx, out_vox_idx,
     # add it to the segment.
     if additional_exit_pt is not None:
         segment = np.append(segment, [additional_exit_pt], axis=0)
-
-    assert not np.any(segment < 0), print(segment)
-    try:
-        assert not np.any(segment > mask.shape)
-    except AssertionError as e:
-        print(mask.shape)
-        print(segment)
-        print(additional_start_pt)
-        print(out_strl_point)
-        print(orig_strl[out_strl_point])
-        print(orig_strl[out_strl_point + 1])
-        print(inter_vox[out_vox_idx])
-        print(points_to_indices)
-        print(additional_exit_pt)
-        raise e
 
     # Return the segment
     return segment

--- a/scilpy/tractograms/streamline_operations.py
+++ b/scilpy/tractograms/streamline_operations.py
@@ -92,9 +92,11 @@ def _get_point_on_line(first_point, second_point, vox_lower_corner):
     return first_point + ray * (t0 + t1) / 2.
 
 
-def _find_closest_index(indices, index, end=False):
-    """ Return the index (before or after) of the point where index is smaller,
+def _get_next_real_point(points_to_index, vox_index):
+    """ Return the index after the point in points_to_index is smaller,
     presuming the indices are sorted.
+
+    ~~~ HERE BE DRAGONS, modify with care. ~~~
 
     Although np.searchsorted may seem like a better option, it is not
     appropriate here since we need to return the first index encountered that
@@ -102,19 +104,53 @@ def _find_closest_index(indices, index, end=False):
 
     Parameters
     ----------
-    indices: list
+    points_to_index: list
         The indices to search in.
-    index: int
+    vox_index: int
         The index to search for.
-    end: bool
-        If True, will return the position before the index.
-        If False, will return the position after the index.
     """
-    mod = -1 if end else 0
-    for i, ind in enumerate(indices):
-        if ind >= index:
-            return i + mod
-    return len(indices) - 1
+
+    map_idx, next_point = -1, -1
+    nb_points_to_index = len(points_to_index)
+    internal_vox_index = vox_index
+    pts_to_index_view = points_to_index
+
+    while map_idx < internal_vox_index and next_point < nb_points_to_index - 1:
+        next_point += 1
+        map_idx = pts_to_index_view[next_point]
+
+    return next_point
+
+
+def _get_previous_real_point(points_to_index, vox_index):
+    """ Return the index before the point in points_to_index is larger,
+    presuming the indices are sorted.
+
+    ~~~ HERE BE DRAGONS, modify with care. ~~~
+
+    Although np.searchsorted may seem like a better option, it is not
+    appropriate here since we need to return the first index encountered that
+    fits our condition, regardless if there is a better option later.
+
+    Parameters
+    ----------
+    points_to_index: list
+        The indices to search in.
+    vox_index: int
+        The index to search for.
+    """
+
+    previous_point = len(points_to_index)
+    internal_vox_index = vox_index
+
+    map_idx = internal_vox_index + 1
+    pts_to_index_view = points_to_index
+
+    while map_idx > internal_vox_index and previous_point > 0:
+        previous_point -= 1
+        map_idx = pts_to_index_view[previous_point]
+
+    return previous_point
 
 
 def get_angles(sft, degrees=True, add_zeros=False):


### PR DESCRIPTION
# Quick description

Actually reverts back to the functions removed in https://github.com/scilus/scilpy/commit/a7d2a5fb39c54002ef3e08ec3ff5da48fb9f5503, but in Python instead of Cython.

Future grad students may want to optimize them, but right now they're gonna do as is.

## Type of change

Check the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)
[sub-p19_ses-01__CC_Pr_Po.zip](https://github.com/user-attachments/files/20194005/sub-p19_ses-01__CC_Pr_Po.zip)

```bash
scil_bundle_label_map.py sub-p19_ses-01__CC_Pr_Po_cleaned.trk sub-p19_ses-01__CC_Pr_Po.trk tmp_out -f -v
```
# Checklist

- [X] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [ ] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
