### PR TITLE
FIX: scil_bundle_label_map min labelled streamline length

### DIFF
--- a/scripts/scil_bundle_label_map.py
+++ b/scripts/scil_bundle_label_map.py
@@ -69,7 +69,6 @@ from dipy.io.streamline import save_tractogram
 from dipy.io.stateful_tractogram import StatefulTractogram, Space
 from dipy.io.utils import is_header_compatible
 from dipy.tracking.streamline import transform_streamlines
-from dipy.tracking.streamlinespeed import length
 import nibabel as nib
 from nibabel.streamlines.array_sequence import ArraySequence
 import numpy as np
@@ -281,9 +280,6 @@ def main():
     logging.debug(
         f'Trim bundle(s) in {round(time.time() - timer, 3)} seconds.')
 
-    # Use later to trim the streamlines without assignement
-    min_len = np.min(length(concat_sft.streamlines))
-
     method = 'hyperplane' if args.hyperplane else 'centerline'
     args.nb_pts = len(sft_centroid.streamlines[0]) if args.nb_pts is None \
         else args.nb_pts
@@ -327,7 +323,7 @@ def main():
         timer = time.time()
         new_sft = StatefulTractogram.from_sft(sft.streamlines, sft_list[0])
         cut_sft = cut_streamlines_with_mask(
-            new_sft, binary_mask, min_len=min_len,
+            new_sft, binary_mask,
             cutting_style=CuttingStyle.KEEP_LONGEST)
         logging.debug(
             f'Cut streamlines in {round(time.time() - timer, 3)} seconds')


### PR DESCRIPTION
# Quick description

Remove a streamline length threshold for the labelized streamlines. There was an edge case where the labels do not span the length of the streamlines, which caused no labelized streamlines to be saved. 

This is potentially an issue that stems from `compute_tract_counts_map`, as the labels **should** span the entire length of the streamlines.

## Type of change

Check the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

In blue, the bundle
In green, the centroid
In red, the volume occupied by the computed labels.

![Screenshot from 2025-05-15 09-26-52](https://github.com/user-attachments/assets/7a5d277b-cd55-4b8a-964c-a7812923c8e5)

[sub-33609_ses-V3__CC_Fr_2_.zip](https://github.com/user-attachments/files/20229080/sub-33609_ses-V3__CC_Fr_2_.zip)

```bash 
python scripts/scil_bundle_label_map.py sub-33609_ses-V3__CC_Fr_2_ic.trk sub-33609_ses-V3__CC_Fr_2_centroid_5.trk test_CC_Fr_2 -f -v DEBUG
```

# Checklist

- [X] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
