### PR TITLE
ENH: scil_volume_pairwise_comparison - hausdorff + labels-to-mask compare

### DIFF
--- a/scilpy/tractanalysis/reproducibility_measures.py
+++ b/scilpy/tractanalysis/reproducibility_measures.py
@@ -13,6 +13,7 @@ from dipy.tracking.distances import bundles_distances_mdf
 import numpy as np
 from numpy.random import RandomState
 from scipy.spatial import cKDTree
+from scipy.spatial.distance import directed_hausdorff
 from sklearn.metrics import cohen_kappa_score
 from sklearn.neighbors import KDTree
 from tqdm import tqdm
@@ -354,6 +355,33 @@ def compute_dice_voxel(density_1, density_2):
     return dice, w_dice
 
 
+def compute_hausdorff_voxel(map_1, map_2):
+    """
+    Compute the Hausdorff distance between two sets of coordinates,
+    representing density or binary maps.
+
+    Parameters
+    ----------
+    map_1: ndarray
+        Density (or binary) map computed from the first bundle
+    map_2: ndarray
+        Density (or binary) map computed from the second bundle
+
+    Returns
+    -------
+    distance: float
+        Value representing the Hausdorff distance in voxels. Should
+        be multiplied afterwards by the voxel size to get the distance in mm.
+    """
+
+    coords_1 = np.argwhere(map_1)
+    coords_2 = np.argwhere(map_2)
+
+    dist, _, _ = directed_hausdorff(coords_1, coords_2)
+
+    return dist
+
+
 def compute_correlation(density_1, density_2):
     """
     Compute the overlap (dice coefficient) between two density
@@ -676,7 +704,7 @@ def tractogram_pairwise_comparison(sft_one, sft_two, mask, nbr_cpu=1,
 
 
 def compare_volume_wrapper(data_1, data_2, voxel_size=1, ratio=False,
-                           adjency_no_overlap=False):
+                           adjency_no_overlap=False, labels_to_mask=False):
     """
     Compute the similarity between binary mask or labels maps in the voxel
     representation.
@@ -700,6 +728,10 @@ def compare_volume_wrapper(data_1, data_2, voxel_size=1, ratio=False,
         in the first volume.
     adjency_no_overlap: bool
         If true, exclude overlapping voxels (0mm) from the computation.
+    labels_to_mask: bool
+        If true, explicitely compare every labels in the first image to
+        the ROI in the second image. Otherwise, the computation presumes
+        both images are either label maps or binary masks.
 
     Returns
     -------
@@ -709,14 +741,19 @@ def compare_volume_wrapper(data_1, data_2, voxel_size=1, ratio=False,
     # Exclude 0 (background)
     unique_values_1 = np.unique(data_1)[1:]
     unique_values_2 = np.unique(data_2)[1:]
+
     union_values = np.union1d(unique_values_1, unique_values_2)
 
     dict_measures = {}
     for val in union_values:
         binary_1 = np.zeros(data_1.shape, dtype=np.uint8)
         binary_1[data_1 == val] = 1
+
         binary_2 = np.zeros(data_2.shape, dtype=np.uint8)
-        binary_2[data_2 == val] = 1
+        if labels_to_mask:
+            binary_2[data_2 == unique_values_2[0]] = 1
+        else:
+            binary_2[data_2 == val] = 1
 
         # These measures are in mm^3
         volume_overlap = np.count_nonzero(binary_1 * binary_2)
@@ -737,8 +774,11 @@ def compare_volume_wrapper(data_1, data_2, voxel_size=1, ratio=False,
         dice_vox, _ = compute_dice_voxel(binary_1,
                                          binary_2)
 
+        hausdorff_vox = compute_hausdorff_voxel(binary_1, binary_2)
+
         measures_name = ['adjacency_voxels',
                          'dice_voxels',
+                         'hausdorff',
                          'volume_overlap',
                          'volume_overreach']
 
@@ -746,7 +786,7 @@ def compare_volume_wrapper(data_1, data_2, voxel_size=1, ratio=False,
         if ratio:
             voxel_size = 1.
         measures = [bundle_adjacency_voxel,
-                    dice_vox,
+                    dice_vox, hausdorff_vox * voxel_size,
                     volume_overlap * voxel_size,
                     volume_overreach * voxel_size]
 

--- a/scripts/scil_volume_pairwise_comparison.py
+++ b/scripts/scil_volume_pairwise_comparison.py
@@ -47,7 +47,8 @@ from scilpy.io.utils import (add_json_args,
                              assert_outputs_exist,
                              validate_nbr_processes)
 from scilpy.image.labels import get_data_as_labels
-from scilpy.tractanalysis.reproducibility_measures import compare_volume_wrapper
+from scilpy.tractanalysis.reproducibility_measures import \
+    compare_volume_wrapper
 from scilpy.version import version_string
 
 
@@ -71,6 +72,10 @@ def _build_arg_parser():
                    help='Compute overlap and overreach as a ratio over the '
                         'reference volume rather than volume.\n'
                         'Can only be used if also using --single_compare`.')
+    p.add_argument('--labels_to_mask', action='store_true',
+                   help='Allows for comparison between labels and single '
+                        'binary mask. Can only be used with '
+                        '--single_compare.')
 
     add_processes_arg(p)
     add_json_args(p)
@@ -85,6 +90,7 @@ def compute_all_measures(args):
     filename_2 = args[0][1]
     adjency_no_overlap = args[1]
     ratio = args[2]
+    labels_to_mask = args[3]
 
     img_1, dtype_1 = load_img(filename_1)
 
@@ -102,10 +108,11 @@ def compute_all_measures(args):
     data_2 = get_data_as_labels(img_2)
 
     _, _, voxel_size, _ = get_reference_info(img_1)
-    voxel_size = np.product(voxel_size)
+    voxel_size = np.prod(voxel_size)
     logging.info(f"Comparing {filename_1} and {filename_2}")
     dict_measures = compare_volume_wrapper(data_1, data_2, voxel_size,
-                                           ratio, adjency_no_overlap)
+                                           ratio, adjency_no_overlap,
+                                           labels_to_mask)
     return dict_measures
 
 
@@ -120,6 +127,10 @@ def main():
 
     if args.ratio and not args.single_compare:
         parser.error('Can only compute ratio if also using `single_compare`')
+
+    if args.labels_to_mask and not args.single_compare:
+        parser.error('Can only compare labels to a mask if also using '
+                     '`single_compare`.')
 
     nbr_cpu = validate_nbr_processes(parser, args)
     if nbr_cpu > 1:
@@ -142,13 +153,15 @@ def main():
             all_measures_dict.append(compute_all_measures([
                 curr_tuple,
                 args.ignore_zeros_in_BA,
-                args.ratio]))
+                args.ratio,
+                args.labels_to_mask]))
     else:
         all_measures_dict = pool.map(
             compute_all_measures,
             zip(comb_dict_keys,
                 itertools.repeat(args.ignore_zeros_in_BA),
-                itertools.repeat(args.ratio)))
+                itertools.repeat(args.ratio),
+                itertools.repeat(args.labels_to_mask)))
         pool.close()
         pool.join()
 

--- a/scripts/tests/test_volume_pairwise_comparison.py
+++ b/scripts/tests/test_volume_pairwise_comparison.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import os
+import tempfile
+
+from scilpy import SCILPY_HOME
+from scilpy.io.fetcher import get_testing_files_dict, fetch_data
+
+
+# If they already exist, this only takes 5 seconds (check md5sum)
+fetch_data(get_testing_files_dict(), keys=[
+           'atlas.zip', 'tractograms.zip', 'tractometry.zip'])
+tmp_dir = tempfile.TemporaryDirectory()
+
+
+def test_help_option(script_runner):
+    ret = script_runner.run('scil_volume_pairwise_comparison.py', '--help')
+    assert ret.success
+
+
+def test_label_comparison(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+    in_atlas = os.path.join(SCILPY_HOME, 'atlas',
+                            'atlas_freesurfer_v2_single_brainstem.nii.gz')
+    in_atlas_dilated = os.path.join(
+        SCILPY_HOME, 'atlas',
+        'atlas_freesurfer_v2_single_brainstem_dil.nii.gz')
+    ret = script_runner.run('scil_volume_pairwise_comparison.py',
+                            in_atlas, in_atlas_dilated, 'atlas.json')
+    assert ret.success
+
+
+def test_binary_comparison(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+    in_bin_1 = os.path.join(SCILPY_HOME, 'tractograms',
+                            'streamline_and_mask_operations',
+                            'bundle_4_head_tail.nii.gz')
+    in_bin_2 = os.path.join(SCILPY_HOME, 'tractograms',
+                            'streamline_and_mask_operations',
+                            'bundle_4_head_tail_offset.nii.gz')
+
+    ret = script_runner.run('scil_volume_pairwise_comparison.py',
+                            in_bin_1, in_bin_2, 'binary.json')
+    assert ret.success
+
+
+def test_multiple_compare(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+    in_bin_1 = os.path.join(SCILPY_HOME, 'tractograms',
+                            'streamline_and_mask_operations',
+                            'bundle_4_head_tail.nii.gz')
+    in_bin_2 = os.path.join(SCILPY_HOME, 'tractograms',
+                            'streamline_and_mask_operations',
+                            'bundle_4_head_tail_offset.nii.gz')
+
+    in_bin_3 = os.path.join(SCILPY_HOME, 'tractograms',
+                            'streamline_and_mask_operations',
+                            'bundle_4_center.nii.gz')
+
+    ret = script_runner.run('scil_volume_pairwise_comparison.py',
+                            in_bin_1, in_bin_2, in_bin_3, 'multiple.json')
+    assert ret.success
+
+
+def test_single_compare(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+    in_bin_1 = os.path.join(SCILPY_HOME, 'tractograms',
+                            'streamline_and_mask_operations',
+                            'bundle_4_head_tail.nii.gz')
+    in_bin_2 = os.path.join(SCILPY_HOME, 'tractograms',
+                            'streamline_and_mask_operations',
+                            'bundle_4_head_tail_offset.nii.gz')
+
+    in_bin_3 = os.path.join(SCILPY_HOME, 'tractograms',
+                            'streamline_and_mask_operations',
+                            'bundle_4_center.nii.gz')
+
+    ret = script_runner.run('scil_volume_pairwise_comparison.py',
+                            in_bin_1, in_bin_2, 'single.json',
+                            '--single_compare', in_bin_3)
+    assert ret.success
+
+
+def test_ratio_compare(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+    in_bin_1 = os.path.join(SCILPY_HOME, 'tractograms',
+                            'streamline_and_mask_operations',
+                            'bundle_4_head_tail.nii.gz')
+    in_bin_2 = os.path.join(SCILPY_HOME, 'tractograms',
+                            'streamline_and_mask_operations',
+                            'bundle_4_head_tail_offset.nii.gz')
+
+    in_bin_3 = os.path.join(SCILPY_HOME, 'tractograms',
+                            'streamline_and_mask_operations',
+                            'bundle_4_center.nii.gz')
+
+    ret = script_runner.run('scil_volume_pairwise_comparison.py',
+                            in_bin_1, in_bin_2, 'ratio.json',
+                            '--single_compare', in_bin_3,
+                            '--ratio')
+    assert ret.success
+
+
+def test_labels_to_mask_compare(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+    in_atlas = os.path.join(SCILPY_HOME, 'atlas',
+                            'atlas_freesurfer_v2_no_brainstem.nii.gz')
+    in_mask = os.path.join(
+        SCILPY_HOME, 'atlas',
+        'brainstem_bin.nii.gz')
+    ret = script_runner.run('scil_volume_pairwise_comparison.py',
+                            in_atlas, 'labels_to_maskjson',
+                            '--single_compare', in_mask,
+                            '--labels_to_mask')
+    assert ret.success


### PR DESCRIPTION
# Quick description

Added Hausdorff distance to scil_volume_pairwise_comparison (https://en.wikipedia.org/wiki/Hausdorff_distance, "it is the greatest of all the distances from a point in one set to the closest point in the other set.") and the option to compare labels (ie multiple ROI per image) to a binary mask. 

Example use cases: comparing label maps to a tumor mask. Comparing JHU template regions to a MS lesion.  

Additionally, I removed a deprecation warning from numpy.

## Type of change

Check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)
[test-1176.zip](https://github.com/user-attachments/files/20412670/test-1176.zip)

`scil_volume_pairwise_comparison.py labels_map.nii.gz test_1176.json --single_compare sub-PAT06__t1_warped_label-tumor_mask.nii.gz -f --labels_to_mask`

# Checklist

- [X] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
