### PR TITLE
Switch from error to warning for DPP in HDF5

### DIFF
--- a/scilpy/io/hdf5.py
+++ b/scilpy/io/hdf5.py
@@ -102,6 +102,7 @@ def reconstruct_sft_from_hdf5(hdf5_handle, group_keys, space=Space.VOX,
         if i == 0 or not merge_groups:
             dps.append({})
         if len(tmp_streamlines) > 0:
+            discarded_keys = []
             for sub_key in hdf5_handle[group_key].keys():
                 if sub_key not in ['data', 'offsets', 'lengths']:
                     data = hdf5_handle[group_key][sub_key]
@@ -114,12 +115,14 @@ def reconstruct_sft_from_hdf5(hdf5_handle, group_keys, space=Space.VOX,
                             else:
                                 dps[i][sub_key] = np.concatenate(
                                     (dps[i][sub_key], data))
-                    elif load_dpp:
+                    elif data.shape == hdf5_handle[group_key]['data'].shape \
+                            and load_dpp and sub_key not in discarded_keys:
                         # Discovered dpp (the array is not the same length as
                         # offsets, so it is per point)
                         logging.warning("DPP discoverted in the HDF5, but "
                                         "not implemented yet. Skipping "
                                         "loading of {}.".format(sub_key))
+                        discarded_keys.append(sub_key)
 
     # 3) Format as SFT
     if merge_groups:

--- a/scilpy/io/hdf5.py
+++ b/scilpy/io/hdf5.py
@@ -106,18 +106,20 @@ def reconstruct_sft_from_hdf5(hdf5_handle, group_keys, space=Space.VOX,
                 if sub_key not in ['data', 'offsets', 'lengths']:
                     data = hdf5_handle[group_key][sub_key]
                     if data.shape == hdf5_handle[group_key]['offsets'].shape:
-                        # Discovered dps
+                        # Discovered dps (the array is the same length as
+                        # offsets, so it is per streamline)
                         if load_dps:
                             if i == 0 or not merge_groups:
                                 dps[i][sub_key] = data
                             else:
                                 dps[i][sub_key] = np.concatenate(
                                     (dps[i][sub_key], data))
-                    else:
-                        if load_dpp:
-                            raise NotImplementedError(
-                                "Don't know how to load dpp yet.")
-                        raise NotImplementedError("DPP data? Other?")
+                    elif load_dpp:
+                        # Discovered dpp (the array is not the same length as
+                        # offsets, so it is per point)
+                        logging.warning("DPP discoverted in the HDF5, but "
+                                        "not implemented yet. Skipping "
+                                        "loading of {}.".format(sub_key))
 
     # 3) Format as SFT
     if merge_groups:


### PR DESCRIPTION
# Quick description

An error was happening all the time when applying transform to HDF5 if DPP was discovered (even when told not to handle it). Added docs, remove error and added logging.warning instead.

...

## Type of change

Check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [x] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
