### PR TITLE
[BF] Fix odf viz with radial_scale_off option

### DIFF
--- a/scilpy/viz/backends/fury.py
+++ b/scilpy/viz/backends/fury.py
@@ -326,7 +326,7 @@ def create_contours_actor(contours, opacity=1., linewidth=3.,
 
 def create_odf_actors(sf_fodf, sphere, scale, sf_variance=None, mask=None,
                       radial_scale=False, norm=False, colormap=None,
-                      variance_k=1.0, variance_color=None):
+                      variance_k=1.0, variance_color=None, B_matrix=None):
     """
     Create an ODF slicer actor displaying a fODF slice. The input volume is a
     3-dimensional grid containing the SH coefficients of the fODF at each
@@ -355,6 +355,10 @@ def create_odf_actors(sf_fodf, sphere, scale, sf_variance=None, mask=None,
         Factor that multiplies sqrt(variance).
     variance_color : tuple, optional
         Color of the variance fODF data, in RGB.
+    B_matrix : ndarray (n_coeffs, n_vertices)
+        Optional SH to SF matrix for projecting `odfs` given in SH
+        coefficients on the `sphere`. If None, then the input is assumed
+        to be expressed in SF coefficients.
 
     Returns
     -------
@@ -366,6 +370,7 @@ def create_odf_actors(sf_fodf, sphere, scale, sf_variance=None, mask=None,
 
     var_actor = None
     if sf_variance is not None:
+        B_mat = None
         fodf_uncertainty = sf_fodf + variance_k * np.sqrt(
             np.clip(sf_variance, 0, None))
 
@@ -389,7 +394,7 @@ def create_odf_actors(sf_fodf, sphere, scale, sf_variance=None, mask=None,
     odf_actor = actor.odf_slicer(sf_fodf, mask=mask, norm=False,
                                  radial_scale=radial_scale,
                                  sphere=sphere, scale=scale,
-                                 colormap=colormap)
+                                 colormap=colormap, B_matrix=B_mat)
 
     return odf_actor, var_actor
 

--- a/scilpy/viz/backends/fury.py
+++ b/scilpy/viz/backends/fury.py
@@ -326,7 +326,7 @@ def create_contours_actor(contours, opacity=1., linewidth=3.,
 
 def create_odf_actors(sf_fodf, sphere, scale, sf_variance=None, mask=None,
                       radial_scale=False, norm=False, colormap=None,
-                      variance_k=1.0, variance_color=None, B_matrix=None):
+                      variance_k=1.0, variance_color=None, B_mat=None):
     """
     Create an ODF slicer actor displaying a fODF slice. The input volume is a
     3-dimensional grid containing the SH coefficients of the fODF at each
@@ -355,7 +355,7 @@ def create_odf_actors(sf_fodf, sphere, scale, sf_variance=None, mask=None,
         Factor that multiplies sqrt(variance).
     variance_color : tuple, optional
         Color of the variance fODF data, in RGB.
-    B_matrix : ndarray (n_coeffs, n_vertices)
+    B_mat : ndarray (n_coeffs, n_vertices)
         Optional SH to SF matrix for projecting `odfs` given in SH
         coefficients on the `sphere`. If None, then the input is assumed
         to be expressed in SF coefficients.

--- a/scilpy/viz/slice.py
+++ b/scilpy/viz/slice.py
@@ -265,7 +265,7 @@ def create_odf_slicer(sh_fodf, orientation, slice_index, sphere, sh_order,
                                              mask, radial_scale,
                                              norm, colormap,
                                              variance_k, variance_color,
-                                             B_matrix=B_mat)
+                                             B_mat=B_mat)
 
     set_display_extent(odf_actor, orientation, sh_fodf.shape[:3], slice_index)
     if sh_variance is not None:

--- a/scilpy/viz/slice.py
+++ b/scilpy/viz/slice.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from dipy.reconst.shm import sh_to_sf
+from dipy.reconst.shm import sh_to_sf, sh_to_sf_matrix
 from fury import actor
 import numpy as np
 
@@ -252,14 +252,20 @@ def create_odf_slicer(sh_fodf, orientation, slice_index, sphere, sh_order,
                     full_basis=full_basis, legacy=is_legacy)
 
     fodf_var = None
+    B_mat = None
     if sh_variance is not None:
         fodf_var = sh_to_sf(sh_variance, sphere, sh_order, sh_basis,
                             full_basis=full_basis, legacy=is_legacy)
+    else:
+        fodf = sh_fodf
+        B_mat = sh_to_sf_matrix(sphere, sh_order, sh_basis,
+                                full_basis, return_inv=False)
 
     odf_actor, var_actor = create_odf_actors(fodf, sphere, scale, fodf_var,
                                              mask, radial_scale,
                                              norm, colormap,
-                                             variance_k, variance_color)
+                                             variance_k, variance_color,
+                                             B_matrix=B_mat)
 
     set_display_extent(odf_actor, orientation, sh_fodf.shape[:3], slice_index)
     if sh_variance is not None:

--- a/scripts/scil_viz_fodf.py
+++ b/scripts/scil_viz_fodf.py
@@ -289,6 +289,8 @@ def main():
     variance = data['variance'] if args.variance else None
     var_color = np.asarray(args.var_color) * 255
     # Instantiate the ODF slicer actor
+    print('scale: {}'.format(args.scale))
+    print('Radial scale off: {}'.format(not args.radial_scale_off))
     odf_actor, var_actor = create_odf_slicer(data['fodf'], args.axis_name,
                                              args.slice_index, sph, sh_order,
                                              sh_basis, full_basis,

--- a/scripts/scil_viz_fodf.py
+++ b/scripts/scil_viz_fodf.py
@@ -289,8 +289,6 @@ def main():
     variance = data['variance'] if args.variance else None
     var_color = np.asarray(args.var_color) * 255
     # Instantiate the ODF slicer actor
-    print('scale: {}'.format(args.scale))
-    print('Radial scale off: {}'.format(not args.radial_scale_off))
     odf_actor, var_actor = create_odf_slicer(data['fodf'], args.axis_name,
                                              args.slice_index, sph, sh_order,
                                              sh_basis, full_basis,


### PR DESCRIPTION
# Quick description

Here is some data to test: [single_voxel_dwi_MTR_SH.nii.gz](https://github.com/user-attachments/files/20715179/single_voxel_dwi_MTR_SH.nii.gz)

Closes #1181 

...

## Type of change

Check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [ ] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
