### PR TITLE
FIX: volume_operations - keep dtype after reshape

### DIFF
--- a/scilpy/image/volume_operations.py
+++ b/scilpy/image/volume_operations.py
@@ -633,7 +633,7 @@ def reshape_volume(
     reshaped_img : nib.Nifti1Image
         The reshaped image.
     """
-
+    orig_dtype = img.get_data_dtype()
     data = img.get_fdata(dtype=np.float32)
     affine = img.affine
 
@@ -683,7 +683,7 @@ def reshape_volume(
     new_affine = np.copy(affine)
     new_affine[0:3, 3] = translation[0:3]
 
-    return nib.Nifti1Image(cropped_data, new_affine)
+    return nib.Nifti1Image(cropped_data.astype(orig_dtype), new_affine)
 
 
 def mask_data_with_default_cube(data):


### PR DESCRIPTION
# Quick description

When reshaping a volume to fit a resolution or a reference volume, its data was always cast to float32. This is problematic when reshaping masks.

## Type of change

Check the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

TODO

# Checklist

- [X] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
