### PR TITLE
DOC: Fix script name in volume reslicing script documentation example

### DIFF
--- a/scripts/scil_volume_reslice_to_reference.py
+++ b/scripts/scil_volume_reslice_to_reference.py
@@ -6,7 +6,7 @@ Reshape / reslice / resample *.nii or *.nii.gz using a reference.
 This script can be used to align freesurfer/civet output, as .mgz,
 to the original input image.
 
->>> scil_volume_reshape_to_reference.py wmparc.mgz t1.nii.gz wmparc_t1.nii.gz\\
+>>> scil_volume_reslice_to_reference.py wmparc.mgz t1.nii.gz wmparc_t1.nii.gz\\
     --interpolation nearest
 
 To


### PR DESCRIPTION
# Quick description

Fix script name in volume reslicing script documentation example.

Left behind when the script was renamed in commit 0e925ed.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

N/A

# Checklist

- [X] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
