### PR TITLE
ENH: shorten scil_fodf_bundleparc.py --help

### DIFF
--- a/scripts/scil_fodf_bundleparc.py
+++ b/scripts/scil_fodf_bundleparc.py
@@ -82,7 +82,7 @@ def _build_arg_parser():
                              'reduced accuracy.')
     parser.add_argument('--bundles', choices=DEFAULT_BUNDLES, nargs='+',
                         default=DEFAULT_BUNDLES,
-                        help='Bundles to predict. Default is [%(default)s].')
+                        help='Bundles to predict. Default is every bundle.')
     parser.add_argument('--checkpoint', default=DEFAULT_CKPT,
                         help='Checkpoint (.ckpt) containing hyperparameters '
                              'and weights of model. Default is '


### PR DESCRIPTION
# Quick description

See title. --help was too long, due to bundles names being printed twice.

## Type of change

Check the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

scil_fodf_bundleparc.py --help

# Checklist

- [X] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
