### PR TITLE
ENH: Add miscellaneous tractogram extensions to header check

### DIFF
--- a/scilpy/io/utils.py
+++ b/scilpy/io/utils.py
@@ -966,7 +966,7 @@ def assert_headers_compatible(parser, required, optional=None, reference=None):
         if in_extension in ['.trk', '.nii', '.nii.gz']:
             headers.append(filepath)
             files.append(filepath)
-        elif in_extension == '.tck':
+        elif in_extension in ['.tck', '.fib', '.vtk', '.dpy']:
             if reference is None:
                 parser.error(
                     '{} must be provided with a reference.'.format(filepath))


### PR DESCRIPTION
# Quick description

Add miscellaneous tractogram extensions to header compatibility check function to require a reference file.

## Type of change

Check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

N/A

# Checklist

- [x] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
