### PR TITLE
[HOTFIX] Install vtk-osmesa in workflow, not provided by runner anymore

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,10 @@ jobs:
           python -m pip install --upgrade pip wheel
           python -m pip install --upgrade "setuptools<71.0.0" 
           python -m pip install -e .
+          # TODO: to adapt once Scilpy passes to VTK 9.4.0, which selects OSMesa at runtime
+          # https://discourse.vtk.org/t/status-update-runtime-opengl-render-window-selection-in-vtk/14583
+          VTK_VERSION=$(cat requirements.txt | grep 'vtk==' | sed 's/vtk==//g')
+          python -m pip install --extra-index-url https://wheels.vtk.org vtk-osmesa==$VTK_VERSION
 
       - name: Run tests
         run: |


### PR DESCRIPTION
# Quick description

Quick addition to the test workflows to install `vtk-osmesa` with scilpy. It is not built anymore in **containers-scilus** since (1) vtk distributes its own wheels, (2) mesa deb packages are officially distributed and  (3) selection of **offscreen-rendering** will be runtime from vtk 9.4 and onward.

**Why not upgrade to vtk 9.4 ?** I don't have time to do it, the patch will do enough for now. Once upgraded, we only need to remove the code.

...

## Type of change

Check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

Tests will run with the new **scilus/actions-runner:2.326.0-vtk9.2.6** (not deployed yet).

# Checklist

- [x] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [x] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
