### PR TITLE
[FIX] Erroneous normalization of bvecs on rows

### DIFF
--- a/src/scilpy/cli/scil_gradients_normalize_bvecs.py
+++ b/src/scilpy/cli/scil_gradients_normalize_bvecs.py
@@ -41,8 +41,8 @@ def main():
     assert_inputs_exist(parser, args.in_bvec)
     assert_outputs_exist(parser, args, args.out_bvec)
 
-    bvecs = np.loadtxt(args.in_bvec)
-    np.savetxt(args.out_bvec, normalize_bvecs(bvecs))
+    bvecs = np.loadtxt(args.in_bvec).T
+    np.savetxt(args.out_bvec, normalize_bvecs(bvecs).T)
 
 
 if __name__ == "__main__":

--- a/src/scilpy/cli/tests/test_gradients_normalize_bvecs.py
+++ b/src/scilpy/cli/tests/test_gradients_normalize_bvecs.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import os
+import numpy as np
 import tempfile
 
 from scilpy import SCILPY_HOME
@@ -25,3 +26,28 @@ def test_execution_processing_fsl(script_runner, monkeypatch):
     ret = script_runner.run(['scil_gradients_normalize_bvecs',
                             in_bvec, '1000_norm.bvec'])
     assert ret.success
+
+
+def test_normalization_axis_is_right(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+    bvec = [
+        [1., 2., 3., 4., 5., 6.],
+        [1., 1., 1., 1., 1., 1.],
+        [1., 1., 1., 1., 1., 1.]
+    ]
+
+    expected_norms = [np.sqrt(3.), np.sqrt(6.), np.sqrt(11.),
+                      np.sqrt(18.), np.sqrt(27.), np.sqrt(38.)]
+    expected_bvecs = np.asarray(bvec) / expected_norms
+
+    in_bvec = os.path.join(tmp_dir.name, 'in.bvec')
+    out_bvec = os.path.join(tmp_dir.name, 'expected.bvec')
+    np.savetxt(in_bvec, bvec, fmt='%.8f')
+    ret = script_runner.run(['scil_gradients_normalize_bvecs',
+                             in_bvec, out_bvec])
+    assert ret.success
+
+    out_bvec = np.loadtxt(out_bvec)
+    np.testing.assert_almost_equal(out_bvec, expected_bvecs, decimal=6)
+    np.testing.assert_almost_equal(np.linalg.norm(out_bvec, axis=0),
+                                   np.ones(len(bvec[0])), decimal=6)


### PR DESCRIPTION
# Quick description

The `scil_gradients_normalize_bvecs` script is normalizing **rows**, but it should be doing **columns** if we follow FSL gradients convention.

(Just a question, are there really people here with gradient files in **row ordering** ?)

## Type of change

Check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

1. Run the following to generate a **column ordered** bvec file easy to investigate :
    echo -e "1 2 3\n1 2 3\n 1 2 3" > test.bvec
2. Using the **old version** of the  script, run : `scil_gradients_normalize_bvecs test.bvec out.bvec`. All rows will have the same values, columns won't be unit norm.
3. Using the **new version** of the script, run : `scil_gradients_normalize_bvecs test.bvec out.bvec`. Values should differ and columns have unit norms.

# Checklist

- [x] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [x] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
