### PR TITLE
[FIX] Still save empty file for scil_tractogram_math.py

### DIFF
--- a/src/scilpy/cli/scil_tractogram_math.py
+++ b/src/scilpy/cli/scil_tractogram_math.py
@@ -153,8 +153,15 @@ def main():
         sft_list.append(tmp_sft)
 
     if np.all([len(sft) == 0 for sft in sft_list]):
-        logging.warning("All tractogram files are empty! Nothing to do. "
-                        "Exiting.")
+        if np.all([len(sft) == 0 for sft in sft_list]):
+        if args.save_empty:
+            logging.info("All input tractograms are empty. Saving empty file.")
+            save_tractogram(sft_list[0], args.out_tractogram,
+                            bbox_valid_check=args.bbox_check)
+        else:
+            logging.info("All input tractograms are empty. Not saving results.")
+            logging.warning("All tractogram files are empty! Nothing to do. "
+                        "Exiting, without saving results.")
         return
 
     # Processing

--- a/src/scilpy/cli/scil_tractogram_math.py
+++ b/src/scilpy/cli/scil_tractogram_math.py
@@ -153,7 +153,6 @@ def main():
         sft_list.append(tmp_sft)
 
     if np.all([len(sft) == 0 for sft in sft_list]):
-        if np.all([len(sft) == 0 for sft in sft_list]):
         if args.save_empty:
             logging.info("All input tractograms are empty. Saving empty file.")
             save_tractogram(sft_list[0], args.out_tractogram,


### PR DESCRIPTION
I would expect, if I supply the argument `--save_empty` to the `scil_tractogram_math.py` script, that I get an output file containing an empty tractogram even if all the input tractograms are empty.

NB: Not having that output file created breaks extractor_flow (the one I'm actively implementing, but also the original implementation of extractor_flow).