### PR TITLE
[BF] Fix check when resampling with a ref

### DIFF
--- a/src/scilpy/cli/scil_volume_resample.py
+++ b/src/scilpy/cli/scil_volume_resample.py
@@ -102,9 +102,19 @@ def main():
     ref_img = None
     if args.ref:
         ref_img = nib.load(args.ref)
+        
         # Must not verify that headers are compatible. But can verify that, at
-        # least, the last columns of their affines are compatible.
-        if not np.array_equal(img.affine[:, -1], ref_img.affine[:, -1]):
+        # least, the first columns of their affines are compatible.
+        img_zoom_invert = []
+        ref_zoom_invert = []
+        for index, zoom in enumerate(img.header.get_zooms()):
+            img_zoom_invert.append(1/img.header.get_zooms()[index])
+            ref_zoom_invert.append(1/ref_img.header.get_zooms()[index])
+
+        img_affine = np.dot(img.affine[:3, :3], img_zoom_invert)
+        ref_affine = np.dot(ref_img.affine[:3, :3], ref_zoom_invert)
+
+        if not np.allclose(img_affine, ref_affine):
             parser.error("The --ref image should have the same affine as the "
                          "input image (but with a different sampling).")
 

--- a/src/scilpy/cli/scil_volume_resample.py
+++ b/src/scilpy/cli/scil_volume_resample.py
@@ -107,7 +107,7 @@ def main():
         # least, the first columns of their affines are compatible.
         img_zoom_invert = []
         ref_zoom_invert = []
-        for index, zoom in enumerate(img.header.get_zooms()):
+        for index in range(len(img.header.get_zooms())):
             img_zoom_invert.append(1/img.header.get_zooms()[index])
             ref_zoom_invert.append(1/ref_img.header.get_zooms()[index])
 

--- a/src/scilpy/cli/scil_volume_resample.py
+++ b/src/scilpy/cli/scil_volume_resample.py
@@ -105,11 +105,8 @@ def main():
         
         # Must not verify that headers are compatible. But can verify that, at
         # least, the first columns of their affines are compatible.
-        img_zoom_invert = []
-        ref_zoom_invert = []
-        for index in range(len(img.header.get_zooms())):
-            img_zoom_invert.append(1/img.header.get_zooms()[index])
-            ref_zoom_invert.append(1/ref_img.header.get_zooms()[index])
+        img_zoom_invert = [1 / zoom for zoom in img.header.get_zooms()]
+        ref_zoom_invert = [1 / zoom for zoom in ref_img.header.get_zooms()]
 
         img_affine = np.dot(img.affine[:3, :3], img_zoom_invert)
         ref_affine = np.dot(ref_img.affine[:3, :3], ref_zoom_invert)


### PR DESCRIPTION
# Quick description

When resampling using reference it didn't check the right part of the affine.

...

## Type of change

Check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [ ] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
