### PR TITLE
Adding mask and median options to fodf max in ventricles script

### DIFF
--- a/src/scilpy/cli/scil_fodf_max_in_ventricles.py
+++ b/src/scilpy/cli/scil_fodf_max_in_ventricles.py
@@ -51,14 +51,14 @@ def _build_arg_parser():
                    help='Minimal threshold of MD in mm2/s (voxels above that '
                         'threshold are \nconsidered for '
                         'evaluation. [%(default)s]).')
-    p.add_argument('--in_mask',
+    p.add_argument('--in_mask', metavar='file',
                    help='Path to a binary mask. Only the data inside the '
                         'mask will be used \nfor evaluation. Useful if the '
                         'FA and MD thresholds are not good enough.')
     p.add_argument('--max_value_output',  metavar='file',
                    help='Output path for the text file containing the value. '
                         'If not set the \nfile will not be saved.')
-    p.add_argument('--mask_output',  metavar='file',
+    p.add_argument('--out_mask',  metavar='file',
                    help='Output path for the ventricule mask. If not set, '
                         'the mask \nwill not be saved.')
     p.add_argument('--small_dims',  action='store_true',
@@ -81,9 +81,10 @@ def main():
     args = parser.parse_args()
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
-    assert_inputs_exist(parser, [args.in_fodfs, args.in_fa, args.in_md])
+    assert_inputs_exist(parser, [args.in_fodfs, args.in_fa, args.in_md],
+                        optional=args.in_mask)
     assert_outputs_exist(parser, args, [],
-                         [args.max_value_output, args.mask_output])
+                         [args.max_value_output, args.out_mask])
 
     # Load input image
     img_fODFs = nib.load(args.in_fodfs)
@@ -109,9 +110,9 @@ def main():
                                               is_legacy=is_legacy,
                                               use_median=args.use_median)
 
-    if args.mask_output:
+    if args.out_mask:
         img = nib.Nifti1Image(np.array(out_mask, 'float32'),  img_fODFs.affine)
-        nib.save(img, args.mask_output)
+        nib.save(img, args.out_mask)
 
     if args.max_value_output:
         text_file = open(args.max_value_output, "w")

--- a/src/scilpy/cli/scil_fodf_max_in_ventricles.py
+++ b/src/scilpy/cli/scil_fodf_max_in_ventricles.py
@@ -65,8 +65,8 @@ def _build_arg_parser():
                    help='If set, takes the full range of data to search the '
                         'max fodf amplitude \nin ventricles. Useful when the '
                         'data has small dimensions.')
-    p.add_argument('--return_median',  action='store_true',
-                   help='If set, returns the median value instead of the '
+    p.add_argument('--use_median',  action='store_true',
+                   help='If set, use the median value instead of the '
                         'mean.')
 
     add_sh_basis_args(p)
@@ -107,7 +107,7 @@ def main():
                                               mask=mask,
                                               small_dims=args.small_dims,
                                               is_legacy=is_legacy,
-                                              return_median=args.return_median)
+                                              use_median=args.use_median)
 
     if args.mask_output:
         img = nib.Nifti1Image(np.array(out_mask, 'float32'),  img_fODFs.affine)

--- a/src/scilpy/cli/scil_fodf_max_in_ventricles.py
+++ b/src/scilpy/cli/scil_fodf_max_in_ventricles.py
@@ -2,8 +2,8 @@
 # -*- coding: utf-8 -*-
 
 """
-Script to compute the mean/median maximum fODF in the ventricles. The ventricules
-are estimated from an MD and FA threshold.
+Script to compute the mean/median maximum fODF in the ventricles. The
+ventricules are estimated from an MD and FA threshold.
 
 This allows to clip the noise of fODF using an absolute thresold.
 

--- a/src/scilpy/cli/scil_fodf_max_in_ventricles.py
+++ b/src/scilpy/cli/scil_fodf_max_in_ventricles.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 """
-Script to compute the average maximum fODF in the ventricles. The ventricules
+Script to compute the mean/median maximum fODF in the ventricles. The ventricules
 are estimated from an MD and FA threshold.
 
 This allows to clip the noise of fODF using an absolute thresold.

--- a/src/scilpy/cli/scil_fodf_max_in_ventricles.py
+++ b/src/scilpy/cli/scil_fodf_max_in_ventricles.py
@@ -65,6 +65,9 @@ def _build_arg_parser():
                    help='If set, takes the full range of data to search the '
                         'max fodf amplitude \nin ventricles. Useful when the '
                         'data has small dimensions.')
+    p.add_argument('--return_median',  action='store_true',
+                   help='If set, returns the median value instead of the '
+                        'mean.')
 
     add_sh_basis_args(p)
     add_verbose_arg(p)
@@ -103,7 +106,8 @@ def main():
                                               args.md_threshold,
                                               mask=mask,
                                               small_dims=args.small_dims,
-                                              is_legacy=is_legacy)
+                                              is_legacy=is_legacy,
+                                              return_median=args.return_median)
 
     if args.mask_output:
         img = nib.Nifti1Image(np.array(out_mask, 'float32'),  img_fODFs.affine)

--- a/src/scilpy/cli/tests/test_fodf_max_in_ventricles.py
+++ b/src/scilpy/cli/tests/test_fodf_max_in_ventricles.py
@@ -26,5 +26,7 @@ def test_execution_processing(script_runner, monkeypatch):
     in_md = os.path.join(SCILPY_HOME, 'processing',
                          'md.nii.gz')
     ret = script_runner.run(['scil_fodf_max_in_ventricles', in_fodf,
-                            in_fa, in_md, '--sh_basis', 'tournier07'])
+                            in_fa, in_md, '--sh_basis', 'tournier07',
+                            '--mask_output', 'mask.nii.gz',
+                            '--max_value_output', 'max_value.txt'])
     assert ret.success

--- a/src/scilpy/cli/tests/test_fodf_max_in_ventricles.py
+++ b/src/scilpy/cli/tests/test_fodf_max_in_ventricles.py
@@ -27,6 +27,6 @@ def test_execution_processing(script_runner, monkeypatch):
                          'md.nii.gz')
     ret = script_runner.run(['scil_fodf_max_in_ventricles', in_fodf,
                             in_fa, in_md, '--sh_basis', 'tournier07',
-                            '--mask_output', 'mask.nii.gz',
+                            '--out_mask', 'mask.nii.gz',
                             '--max_value_output', 'max_value.txt'])
     assert ret.success

--- a/src/scilpy/reconst/fodf.py
+++ b/src/scilpy/reconst/fodf.py
@@ -18,7 +18,7 @@ cvx, have_cvxpy, _ = optional_package("cvxpy")
 def get_ventricles_max_fodf(data, fa, md, zoom, sh_basis,
                             fa_threshold, md_threshold, mask=None,
                             small_dims=False, is_legacy=True,
-                            return_median=False):
+                            use_median=False):
     """
     Compute mean maximal fodf value in ventricules. Given heuristics thresholds
     on FA and MD values, finds the voxels of the ventricules or CSF and
@@ -58,8 +58,8 @@ def get_ventricles_max_fodf(data, fa, md, zoom, sh_basis,
         data has small dimensions.
     is_legacy : bool, optional
         Whether the SH basis is in its legacy form.
-    return_median : bool, optional
-        If set, returns the median value instead of the mean.
+    use_median : bool, optional
+        If set, uses the median value instead of the mean.
 
     Returns
     -------
@@ -134,7 +134,7 @@ def get_ventricles_max_fodf(data, fa, md, zoom, sh_basis,
 
     logging.info('Average max fodf value: {}'.format(np.mean(list_of_max)))
     logging.info('Median max fodf value: {}'.format(np.median(list_of_max)))
-    if return_median:
+    if use_median:
         return np.median(list_of_max), out_mask
     else:
         return np.mean(list_of_max), out_mask

--- a/src/scilpy/reconst/fodf.py
+++ b/src/scilpy/reconst/fodf.py
@@ -112,22 +112,20 @@ def get_ventricles_max_fodf(data, fa, md, zoom, sh_basis,
 
     # Ok. Now find ventricle voxels.
     list_of_max = []
-    count = 0
     for i in all_i:
         for j in all_j:
             for k in all_k:
-                if count > max_number_of_voxels - 1:
+                if len(list_of_max) > max_number_of_voxels - 1:
                     continue
                 if fa[i, j, k] < fa_threshold \
                         and md[i, j, k] > md_threshold \
                             and mask[i, j, k] == 1:
                     sf = np.dot(data[i, j, k], b_matrix)
                     list_of_max.append(sf.max())
-                    count += 1
                     out_mask[i, j, k] = 1
 
-    logging.info('Number of voxels detected: {}'.format(count))
-    if count == 0:
+    logging.info('Number of voxels detected: {}'.format(len(list_of_max)))
+    if len(list_of_max) == 0:
         logging.warning('No voxels found for evaluation! Change your fa '
                         'and/or md thresholds')
         return 0, out_mask

--- a/src/scilpy/reconst/tests/test_fodf.py
+++ b/src/scilpy/reconst/tests/test_fodf.py
@@ -78,7 +78,7 @@ def test_get_ventricles_max_fodf_mask():
 
     # Should find that the only 2 ventricle voxels are at [1, 0:2, 0] with FA
     # and MD thresholds. But with the mask, only one voxel is kept.
-    mean, mask = get_ventricles_max_fodf(
+    _, mask = get_ventricles_max_fodf(
         fodf_3x3_order8_descoteaux07, fake_fa, fake_md, zoom, sh_basis,
         fa_threshold, md_threshold, mask=in_mask, small_dims=True,
         use_median=True)
@@ -87,16 +87,6 @@ def test_get_ventricles_max_fodf_mask():
     expected_mask = np.logical_and(expected_mask, in_mask.astype(bool))
     assert np.count_nonzero(mask) == 1
     assert np.array_equal(mask.astype(bool), expected_mask)
-
-    # Reconstruct SF values same as in method.
-    order = find_order_from_nb_coeff(fodf_3x3_order8_descoteaux07)
-    sphere = get_sphere(name='repulsion100')
-    b_matrix, _ = sh_to_sf_matrix(sphere, order, sh_basis, legacy=True)
-
-    sf1 = np.dot(fodf_3x3_order8_descoteaux07[1, 0, 0], b_matrix)
-    sf2 = np.dot(fodf_3x3_order8_descoteaux07[1, 1, 0], b_matrix)
-
-    assert mean == np.mean([np.max(sf1), np.max(sf2)])
 
 
 def test_fit_from_model():

--- a/src/scilpy/reconst/tests/test_fodf.py
+++ b/src/scilpy/reconst/tests/test_fodf.py
@@ -38,6 +38,67 @@ def test_get_ventricles_max_fodf():
     assert mean == np.mean([np.max(sf1), np.max(sf2)])
 
 
+def test_get_ventricles_max_fodf_median():
+    fake_fa = np.ones((3, 3, 1))  # High FA
+    fake_fa[1:3, 0:2, 0] = 0      # Low in ventricles
+    fake_md = np.zeros((3, 3, 1))  # Low MD
+    fake_md[0:2, 0:2, 0] = 1       # High in ventricles
+    zoom = [1, 1, 1]
+    fa_threshold = 0.5
+    md_threshold = 0.5
+    sh_basis = 'descoteaux07'
+
+    # Should find that the only 2 ventricle voxels are at [1, 0:2, 0]
+    median, _ = get_ventricles_max_fodf(
+        fodf_3x3_order8_descoteaux07, fake_fa, fake_md, zoom, sh_basis,
+        fa_threshold, md_threshold, small_dims=True, use_median=True)
+
+    # Reconstruct SF values same as in method.
+    order = find_order_from_nb_coeff(fodf_3x3_order8_descoteaux07)
+    sphere = get_sphere(name='repulsion100')
+    b_matrix, _ = sh_to_sf_matrix(sphere, order, sh_basis, legacy=True)
+
+    sf1 = np.dot(fodf_3x3_order8_descoteaux07[1, 0, 0], b_matrix)
+    sf2 = np.dot(fodf_3x3_order8_descoteaux07[1, 1, 0], b_matrix)
+
+    assert median == np.median([np.max(sf1), np.max(sf2)])
+
+
+def test_get_ventricles_max_fodf_mask():
+    fake_fa = np.ones((3, 3, 1))  # High FA
+    fake_fa[1:3, 0:2, 0] = 0      # Low in ventricles
+    fake_md = np.zeros((3, 3, 1))  # Low MD
+    fake_md[0:2, 0:2, 0] = 1       # High in ventricles
+    zoom = [1, 1, 1]
+    fa_threshold = 0.5
+    md_threshold = 0.5
+    sh_basis = 'descoteaux07'
+    in_mask = np.zeros((3, 3, 1))
+    in_mask[1, 1, 0] = 1  # Mask only one ventricle voxel
+
+    # Should find that the only 2 ventricle voxels are at [1, 0:2, 0] with FA
+    # and MD thresholds. But with the mask, only one voxel is kept.
+    mean, mask = get_ventricles_max_fodf(
+        fodf_3x3_order8_descoteaux07, fake_fa, fake_md, zoom, sh_basis,
+        fa_threshold, md_threshold, in_mask=in_mask, small_dims=True,
+        use_median=True)
+
+    expected_mask = np.logical_and(~fake_fa.astype(bool), fake_md)
+    expected_mask = np.logical_and(expected_mask, in_mask.astype(bool))
+    assert np.count_nonzero(mask) == 1
+    assert np.array_equal(mask.astype(bool), expected_mask)
+
+    # Reconstruct SF values same as in method.
+    order = find_order_from_nb_coeff(fodf_3x3_order8_descoteaux07)
+    sphere = get_sphere(name='repulsion100')
+    b_matrix, _ = sh_to_sf_matrix(sphere, order, sh_basis, legacy=True)
+
+    sf1 = np.dot(fodf_3x3_order8_descoteaux07[1, 0, 0], b_matrix)
+    sf2 = np.dot(fodf_3x3_order8_descoteaux07[1, 1, 0], b_matrix)
+
+    assert mean == np.mean([np.max(sf1), np.max(sf2)])
+
+
 def test_fit_from_model():
     # toDO
     pass

--- a/src/scilpy/reconst/tests/test_fodf.py
+++ b/src/scilpy/reconst/tests/test_fodf.py
@@ -80,7 +80,7 @@ def test_get_ventricles_max_fodf_mask():
     # and MD thresholds. But with the mask, only one voxel is kept.
     mean, mask = get_ventricles_max_fodf(
         fodf_3x3_order8_descoteaux07, fake_fa, fake_md, zoom, sh_basis,
-        fa_threshold, md_threshold, in_mask=in_mask, small_dims=True,
+        fa_threshold, md_threshold, mask=in_mask, small_dims=True,
         use_median=True)
 
     expected_mask = np.logical_and(~fake_fa.astype(bool), fake_md)


### PR DESCRIPTION
# Quick description

I added two options to `scil_fodf_max_in_ventricles`. First, we can now input a mask (ventricles or CSF) to help if the MD and FA thresholds don't work properly. Second, we can now use the median instand of the mean to compute the "max fodf". Indeed, I discovered that we take the mean of the maximum fODF in every voxels of the ventricles. I thought we were just taking the maximum value across all ventricle voxels, like the docstring suggested. The median can also help when we have outliers in the ventricles mask.

It would be nice if some people (@mdesco , @arnaudbore ) could test this with "normal data", be sure it does not change the result of the script.
