### PR TITLE
Update to most recent Pop Average atlas

### DIFF
--- a/src/scilpy/cli/scil_tractogram_segment_with_bundleseg.py
+++ b/src/scilpy/cli/scil_tractogram_segment_with_bundleseg.py
@@ -103,7 +103,7 @@ def _build_arg_parser():
     p2 = g.add_mutually_exclusive_group()
     p2.add_argument('--exploration_mode', action='store_true',
                     help='Use higher pruning threshold, but optimal filtering '
-                    'can be explored using \nscil_bundle_explore_bundleseg.py')
+                    'can be explored using \nscil_bundle_explore_bundleseg')
     p2.add_argument('--modify_distance_thr', type=float, default=0.0,
                     help='Increase or decrease the distance threshold for '
                          'pruning for all bundles \nin the configuration '


### PR DESCRIPTION
Previous doc in BundleSeg pointed towards an old version of the Atlas, where the doc still uses `scil_recognize_multi_bundles.py`. Updated to version 3.1. of the atlas.