### PR TITLE
Add option to skip empty + log more info

### DIFF
--- a/src/scilpy/cli/scil_tractogram_segment_with_bundleseg.py
+++ b/src/scilpy/cli/scil_tractogram_segment_with_bundleseg.py
@@ -86,6 +86,8 @@ def _build_arg_parser():
 
     p.add_argument('--out_dir', default='voting_results',
                    help='Path for the output directory [%(default)s].')
+    p.add_argument('--skip_empty', action='store_true',
+                   help="If set, empty tractograms are not saved.")
     p.add_argument('--minimal_vote_ratio',
                    type=ranged_type(float, 0, 1), default=0.5,
                    help='Streamlines will only be considered for saving if\n'
@@ -179,7 +181,8 @@ def main():
 
     voting = VotingScheme(config, in_models_directories,
                           transfo, args.out_dir,
-                          minimal_vote_ratio=args.minimal_vote_ratio)
+                          minimal_vote_ratio=args.minimal_vote_ratio,
+                          save_empty=not args.skip_empty)
 
     voting(args.in_tractograms, nbr_processes=args.nbr_processes,
            seed=args.seed, reference=args.reference)

--- a/src/scilpy/segment/bundleseg.py
+++ b/src/scilpy/segment/bundleseg.py
@@ -142,7 +142,8 @@ class BundleSeg(object):
 
         len_centroids = len(self.model_centroids)
         if len_centroids > 1000:
-            logger.warning(f'Model {identifier} simplified at threshold '
+            logger.warning(f'More than 1000 centroids. '
+                           f'Model {identifier} simplified at threshold '
                            f'{model_clust_thr}mm with {len_centroids} centroids')
 
     def _reduce_search_space(self, neighbors_reduction_thr=18):


### PR DESCRIPTION
Add an option in BundleSeg to not save empty tractograms.

Show total number of streamlines in final logging.