### PR TITLE
BundleSeg: option to ignore empty + change to float32

### DIFF
--- a/src/scilpy/cli/scil_tractogram_segment_with_bundleseg.py
+++ b/src/scilpy/cli/scil_tractogram_segment_with_bundleseg.py
@@ -90,8 +90,8 @@ def _build_arg_parser():
 
     p.add_argument('--out_dir', default='voting_results',
                    help='Path for the output directory [%(default)s].')
-    p.add_argument('--skip_empty', action='store_true',
-                   help="If set, empty tractograms are not saved.")
+    p.add_argument('--save_empty', action='store_true',
+                   help="If set, will save bundles even if empty.")
     p.add_argument('--minimal_vote_ratio',
                    type=ranged_type(float, 0, 1), default=0.5,
                    help='Streamlines will only be considered for saving if\n'
@@ -186,7 +186,7 @@ def main():
     voting = VotingScheme(config, in_models_directories,
                           transfo, args.out_dir,
                           minimal_vote_ratio=args.minimal_vote_ratio,
-                          save_empty=not args.skip_empty)
+                          save_empty=args.save_empty)
 
     voting(args.in_tractograms, nbr_processes=args.nbr_processes,
            seed=args.seed, reference=args.reference)

--- a/src/scilpy/cli/scil_tractogram_segment_with_bundleseg.py
+++ b/src/scilpy/cli/scil_tractogram_segment_with_bundleseg.py
@@ -90,6 +90,8 @@ def _build_arg_parser():
 
     p.add_argument('--out_dir', default='voting_results',
                    help='Path for the output directory [%(default)s].')
+    p.add_argument('--skip_empty', action='store_true',
+                   help="If set, empty tractograms are not saved.")
     p.add_argument('--minimal_vote_ratio',
                    type=ranged_type(float, 0, 1), default=0.5,
                    help='Streamlines will only be considered for saving if\n'
@@ -183,7 +185,8 @@ def main():
 
     voting = VotingScheme(config, in_models_directories,
                           transfo, args.out_dir,
-                          minimal_vote_ratio=args.minimal_vote_ratio)
+                          minimal_vote_ratio=args.minimal_vote_ratio,
+                          save_empty=not args.skip_empty)
 
     voting(args.in_tractograms, nbr_processes=args.nbr_processes,
            seed=args.seed, reference=args.reference)

--- a/src/scilpy/cli/scil_tractogram_segment_with_bundleseg.py
+++ b/src/scilpy/cli/scil_tractogram_segment_with_bundleseg.py
@@ -83,7 +83,7 @@ def _build_arg_parser():
     p.add_argument('in_directory',
                    help='Path of parent folder of models directories.\n'
                         'Each folder inside will be considered as a '
-                        'different atlas.')
+                        'different atlas. Bundles should be .trk files.')
     p.add_argument('in_transfo',
                    help='Path for the transformation to model space '
                         '(.txt, .npy or .mat).')

--- a/src/scilpy/io/streamlines.py
+++ b/src/scilpy/io/streamlines.py
@@ -314,6 +314,8 @@ def reconstruct_streamlines_from_memmap(memmap_filenames, indices=None,
         Tuple of 3 filepath to numpy memmap (data, offsets, lengths).
     indices : list
         List of int representing the indices to reconstruct.
+    strs_dtype: type
+        Data type for streamlines.
 
     Returns
     -------

--- a/src/scilpy/segment/bundleseg.py
+++ b/src/scilpy/segment/bundleseg.py
@@ -271,7 +271,7 @@ class BundleSeg(object):
         # Neighbors can be refined since the search space is smaller
         t0 = time()
         neighb_streamlines = reconstruct_streamlines_from_memmap(
-            self.memmap_filenames, self.neighb_indices, strs_dtype=np.float16)
+            self.memmap_filenames, self.neighb_indices)
 
         # Typically the neighbors is bigger than the model, so we flip the
         # FSS to be more memory efficient

--- a/src/scilpy/segment/bundleseg.py
+++ b/src/scilpy/segment/bundleseg.py
@@ -142,7 +142,8 @@ class BundleSeg(object):
 
         len_centroids = len(self.model_centroids)
         if len_centroids > 1000:
-            logger.warning(f'Model {identifier} simplified at threshold '
+            logger.warning(f'More than 1000 centroids. '
+                           f'Model {identifier} simplified at threshold '
                            f'{model_clust_thr}mm with {len_centroids} centroids')
 
     def _reduce_search_space(self, neighbors_reduction_thr=18):

--- a/src/scilpy/segment/voting_scheme.py
+++ b/src/scilpy/segment/voting_scheme.py
@@ -358,10 +358,8 @@ class VotingScheme(object):
                         f'in {self.output_directory} took '
                         f'{get_duration(save_timer)} sec.')
 
-        nb_invalid = len_wb_streamlines - nb_streamlines
-        logger.info(f"In total, {nb_streamlines} streamlines were recognized "
-                    f"in a bundle, and {nb_invalid} streamlines were "
-                    f"discarded.")
+        logger.info(f"In total, recognized bundles include {nb_streamlines} "
+                    f"streamlines (some streamlines could be included twice).")
 
 
 def single_recognize_parallel(args):


### PR DESCRIPTION
# Quick description

1) When using BundleSeg, all resulting segmented bundles were automatically saved. Added a --skip_empty option. Usually, we have --save_empty in other scripts, so I would actually prefer, but I didn't want to change the default action in case it is useful in your flows. If you want, I can change to --save_empty.

2) The resulting segmented bundles were created with float16. This complicated a lot my next analysis steps, as I couldn't use `scil_tractogram_math` (ex, difference) with my bundles without adding precision options. Changed to float32. I kept the centroid in float16.
...

## Type of change

Check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [x] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
