### PR TITLE
Clarified bundle scoring scripts. Added options

### DIFF
--- a/src/scilpy/cli/scil_bundle_pairwise_comparison.py
+++ b/src/scilpy/cli/scil_bundle_pairwise_comparison.py
@@ -14,6 +14,9 @@ For the streamline representation, the computed similarity measures are:
     bundle_adjacency_streamlines, dice_streamlines, streamlines_count_overlap,
     streamlines_count_overreach
 
+See also scil_bundle_score_many_bundles_one_tractogram or
+scil_bundle_score_same_bundle_many_segmentations.
+
 If you have volumes associated to your bundles, the following script could be
 of interest for you: scil_volume_pairwise_comparison.py
 

--- a/src/scilpy/cli/scil_bundle_pairwise_comparison.py
+++ b/src/scilpy/cli/scil_bundle_pairwise_comparison.py
@@ -5,20 +5,30 @@
 Evaluate pairwise similarity measures of bundles.
 All tractograms must be in the same space (aligned to one reference).
 
-For the voxel representation, the computed similarity measures are:
+Our bundle tractometry analysis scripts
+---------------------------------------
+- scil_bundle_pairwise_comparison:
+    - can compare any pair (any combo) from the input list.
+    - can compare the input list against a single file (--single_compare)
+- scil_bundle_score_many_bundles_one_tractogram:
+    - scores files against their individual ground truth.
+- scil_bundle_score_same_bundle_many_segmentations:
+    - compare many versions of a single bundle.
+* If you have volumes associated to your bundles, the following script could be
+of interest for you: scil_volume_pairwise_comparison
+
+Computed metrics
+----------------
+In this script, metrics can be based on the coverage masks of the bundles or
+directly on the streamlines:
+- For the voxel representation, the computed similarity measures are:
     bundle_adjacency_voxels, dice_voxels, w_dice_voxels, density_correlation
     volume_overlap, volume_overreach
 The same measures are also evaluated for the endpoints.
 
-For the streamline representation, the computed similarity measures are:
+- For the streamline representation, the computed similarity measures are:
     bundle_adjacency_streamlines, dice_streamlines, streamlines_count_overlap,
     streamlines_count_overreach
-
-See also scil_bundle_score_many_bundles_one_tractogram or
-scil_bundle_score_same_bundle_many_segmentations.
-
-If you have volumes associated to your bundles, the following script could be
-of interest for you: scil_volume_pairwise_comparison.py
 
 Formerly: scil_evaluate_bundles_pairwise_agreement_measures.py
 """

--- a/src/scilpy/cli/scil_bundle_score_many_bundles_one_tractogram.py
+++ b/src/scilpy/cli/scil_bundle_score_many_bundles_one_tractogram.py
@@ -10,8 +10,11 @@ Ex: It was used for the ISMRM 2015 Challenge scoring.
 See also scil_bundle_score_same_bundle_many_segmentations.py to score many
 versions of a same bundle, compared to ONE ground truth / gold standard.
 
-This script is the second part of script scil_score_tractogram, which also
-segments the wholebrain tractogram into bundles first.
+See also scil_bundle_pairwise_comparison to score any pair of bundle.
+
+This script is the second part of script
+scil_tractogram_segment_with_ROI_and_score, which also segments the wholebrain
+tractogram into bundles first.
 
 Here we suppose that the bundles are already segmented and saved as follows:
     main_dir/

--- a/src/scilpy/cli/scil_bundle_score_many_bundles_one_tractogram.py
+++ b/src/scilpy/cli/scil_bundle_score_many_bundles_one_tractogram.py
@@ -174,9 +174,9 @@ def load_and_verify_everything(parser, args):
 
     # Read the config file
     bundle_names, gt_masks_files = read_config_file(args)
-    all_vb_files = glob.glob(args.VB_folder + '/*')
 
     # Check that all bundles are associated to a unique VB
+    all_vb_files = glob.glob(args.VB_folder + '/*')
     ordered_vb_files = []
     for bname in bundle_names:
         vb_files = [filename for filename in all_vb_files if bname in filename]
@@ -184,14 +184,15 @@ def load_and_verify_everything(parser, args):
             parser.error("The bundle name {} was found in more than one valid "
                          "bundles: {}".format(bname, vb_files))
         if len(vb_files) == 0:
-            logging.warning("The bundle {} was not found in the VB folder."
-                            .format(bname))
+            logging.info("The bundle {} was not found in the name of any "
+                            "file inside the VB folder {}. Score will be 0."
+                            .format(bname, args.VB_folder))
             ordered_vb_files.append(None)
         else:
             ordered_vb_files.append(vb_files[0])
 
     # Not checking here IB and WPC files.
-    assert_headers_compatible(parser, ordered_vb_files + gt_masks_files,
+    assert_headers_compatible(parser, gt_masks_files, ordered_vb_files,
                               reference=args.reference)
 
     # ----------------------

--- a/src/scilpy/cli/scil_bundle_score_many_bundles_one_tractogram.py
+++ b/src/scilpy/cli/scil_bundle_score_many_bundles_one_tractogram.py
@@ -7,33 +7,63 @@ This script is intended to score all bundles from a single tractogram. Each
 valid bundle is compared to its ground truth.
 Ex: It was used for the ISMRM 2015 Challenge scoring.
 
-See also scil_bundle_score_same_bundle_many_segmentations.py to score many
-versions of a same bundle, compared to ONE ground truth / gold standard.
+Our bundle tractometry analysis scripts
+---------------------------------------
+- scil_bundle_pairwise_comparison:
+    - can compare any pair (any combo) from the input list.
+    - can compare the input list against a single file (--single_compare)
+- scil_bundle_score_many_bundles_one_tractogram:
+    - scores files against their individual ground truth.
+- scil_bundle_score_same_bundle_many_segmentations:
+    - compare many versions of a single bundle.
+* If you have volumes associated to your bundles, the following script could be
+of interest for you: scil_volume_pairwise_comparison
 
-See also scil_bundle_pairwise_comparison to score any pair of bundle.
+This script
+-----------
+We expect your tractogram to be already segmented into valid bundles.
+See our scripts scil_tractogram_segment_with [...].
+For usage in combination with scil_tractogram_segment_with_ROI_and_score, see
+particular instructions below.
 
-This script is the second part of script
-scil_tractogram_segment_with_ROI_and_score, which also segments the wholebrain
-tractogram into bundles first.
+The easiest usage of this script requires:
+    - Having all bundles to be scored in a single folder.
+    - Creating a config file associating each input tractogram to its
+      reference tractogram.
+>> scil_bundle_score_many_bundles_one_tractogram config_file VB_folder
 
-Here we suppose that the bundles are already segmented and saved as follows:
-    main_dir/
-        segmented_VB/*_VS.trk.
-        segmented_IB/*_*_IC.trk   (optional)
-        segmented_WPC/*_wpc.trk  (optional)
-        IS.trk  OR  NC.trk  (if segmented_IB is present)
+Additionnaly, this script can include, in the output json, the percentage of
+invalid streamlines (IS) or invalid bundles, using --is, --ib, etc.
 
 Config file
 -----------
 The config file needs to be a json containing a dict of the ground-truth
-bundles as keys. The value for each bundle is itself a dictionnary with:
+bundles as keys. The value for each bundle is itself a dictionnary with the
+path to reference bundles. The refernce names must be included in the
+segmented bundles' names. Ex: VB_folder/segmented_CC_subjX.trk.
 
-    - gt_mask: expected result. OL and OR metrics will be computed from this.*
-
+Example config file:
+{
+  "CC": "PATH/ref_grouth_truth_CC.nii.gz",
+  "OR_L": "PATH/ref_grouth_truth_OR_L.nii.gz",
+}
 * Files must be .tck, .trk, .nii or .nii.gz. If it is a tractogram, a mask will
 be created. If it is a nifti file, it will be considered to be a mask.
 
-Exemple config file:
+Usage as part 2 of segment_with_ROI
+-----------------------------------
+This script can be used as the second part of script
+>> scil_tractogram_segment_with_ROI_and_score
+Then, we suppose that the bundles are already segmented and saved as follows:
+    root_dir/
+        segmented_VB/*_VS.trk.
+        segmented_IB/*_*_IC.trk   (optional)
+        segmented_WPC/*_wpc.trk  (optional)
+        IS.trk  OR  NC.trk  (if segmented_IB is present)
+Use option --part2_ROI_segmentation, and, as main input folder, give the
+args.root_dir instead of the VB_folder. We will automatically set VB_folder, --is,
+--vb and --wpc to follow this organization. Also, use the same config file as
+in scil_tractogram_segment_with_ROI_and_score:
 {
   "Ground_truth_bundle_0": {
     "gt_mask": "PATH/bundle0.nii.gz",
@@ -56,7 +86,8 @@ from scilpy.io.utils import (add_bbox_arg,
                              add_reference_arg,
                              add_verbose_arg,
                              assert_inputs_exist,
-                             assert_outputs_exist)
+                             assert_outputs_exist, assert_inputs_dirs_exist,
+                             assert_headers_compatible)
 from scilpy.segment.tractogram_from_roi import compute_masks_from_bundles
 from scilpy.tractanalysis.scoring import compute_tractometry
 from scilpy.tractanalysis.scoring import __doc__ as tractometry_description
@@ -69,17 +100,33 @@ def _build_arg_parser():
                                 epilog=version_string)
 
     p.add_argument("gt_config",
-                   help=".json dict configured as specified above.")
-    p.add_argument("bundles_dir",
-                   help="Directory containing all bundles.\n"
+                   help=".json config file configured as specified above.")
+    p.add_argument("VB_folder",
+                   help="Directory containing all bundles to be scored.\n"
                         "(Ex: Output directory for scil_score_tractogram).\n"
                         "It is expected to contain a file IS.trk and \n"
                         "files segmented_VB/*_VS.trk, with, possibly, files \n"
                         "segmented_WPC/*_wpc.trk and segmented_IC/")
+    # Note. Can't name --invalid as --is. Created errors with the is keyword.
+    p.add_argument("--invalid", metavar="IS.trk",
+                   help="To include the percentage of invalid streamlines "
+                        "include your \ninvalid streamlines here (or "
+                        "no-connection streamlines)")
+    p.add_argument("--ib", metavar="IB/",
+                   help="To include the percentage of invalid streamlines in "
+                        "each segmented invalid \nbundle, add the path to "
+                        "your invalid bundles here.")
+    p.add_argument("--wpc", metavar="WPC/",
+                   help="To include the percentage of wrong path streamlines "
+                        "for each valid bundle, add the path to your WPC "
+                        "bundles here.")
     p.add_argument("--json_prefix", metavar='p', default='',
                    help="Prefix of the output json file. Ex: 'study_x_'.\n"
                         "Suffix will be results.json. File will be saved "
-                        "inside bundles_dir.\n")
+                        "inside your directory.\n")
+    p.add_argument("--part2_ROI_segmentation", action="store_true",
+                   help="If set, configure everything to be used as part 2 of "
+                        "script scil_tractogram_segment_with_ROI_and_score.")
 
     g = p.add_argument_group("Additions to gt_config")
     g.add_argument("--gt_dir", metavar='DIR',
@@ -98,73 +145,87 @@ def _build_arg_parser():
 
 def load_and_verify_everything(parser, args):
 
-    assert_inputs_exist(parser, args.gt_config, args.reference)
-    if not os.path.isdir(args.bundles_dir):
-        parser.error("Bundles dir ({}) does not exist."
-                     .format(args.bundles_dir))
+    # Input organization depends on option part2_ROI_segmentation
+    args.root_dir = args.VB_folder
+    if args.part2_ROI_segmentation:
+        if (args.invalid is not None or args.ib is not None or
+             args.wpc is not None):
+            parser.error("--part2_ROI_segmentation can't be used together "
+                         "with other options.")
+        args.VB_folder = os.path.join(args.root_dir, "segmented_VB")
+        sub_dirs = [x[0] for x in os.walk(args.root_dir)]
+        if 'segmented_IB' in sub_dirs:
+            args.ib = os.path.join(args.root_dir, "segmented_IB")
+            args.invalid = os.path.join(args.root_dir, "NC.trk")
+        elif os.path.exists(os.path.join(args.root_dir, "IS.trk")):
+            args.invalid = os.path.join(args.root_dir, "IS.trk")
+        if 'segmented_WPC' in sub_dirs:
+            args.wpc = os.path.join(args.root_dir, "segmented_WPC")
 
-    args.json_prefix = os.path.join(args.bundles_dir, args.json_prefix)
+    assert_inputs_exist(parser, args.gt_config,
+                        [args.reference, args.invalid])
+    assert_inputs_dirs_exist(parser, args.VB_folder,
+                             [args.ib, args.wpc])
+
+    # Outputs:
+    args.json_prefix = os.path.join(args.root_dir, args.json_prefix)
     json_output = args.json_prefix + 'results.json'
     assert_outputs_exist(parser, args, json_output)
 
     # Read the config file
     bundle_names, gt_masks_files = read_config_file(args)
+    all_vb_files = glob.glob(args.VB_folder + '/*')
 
-    # Not verifying compatibility of every mask with every sub-bundles...
-    # Was probably done during segmentation.
+    # Check that all bundles are associated to a unique VB
+    ordered_vb_files = []
+    for bname in bundle_names:
+        vb_files = [filename for filename in all_vb_files if bname in filename]
+        if len(vb_files) > 1:
+            parser.error("The bundle name {} was found in more than one valid "
+                         "bundles: {}".format(bname, vb_files))
+        if len(vb_files) == 0:
+            logging.warning("The bundle {} was not found in the VB folder."
+                            .format(bname))
+            ordered_vb_files.append(None)
+        else:
+            ordered_vb_files.append(vb_files[0])
 
-    # Verify file organization
-    # VB
-    vb_path = os.path.join(args.bundles_dir, 'segmented_VB')
-    if not os.path.isdir(vb_path):
-        parser.error("We expect bundles_dir to contain a segmented_VB dir.\n"
-                     "Read the help for more information.")
-    # WPC
-    wpc_path = os.path.join(args.bundles_dir, 'segmented_wpc')
-    if not os.path.isdir(wpc_path):
-        wpc_path = None
-    # IC
-    ib_path = os.path.join(args.bundles_dir, 'segmented_IB')
-    nc_filename = os.path.join(args.bundles_dir, 'NC.trk')
-    if not os.path.isdir(ib_path):  # --compute_ic was not used during segment.
-        ib_path = None
-        nc_filename = os.path.join(args.bundles_dir, 'IS.trk')
-    if not os.path.isfile(nc_filename):
-        logging.info("We expect bundles_dir to contain either a "
-                     "segmented_IB dir together with a file NC.trk,"
-                     "or a file IS.trk but neither was found.\n"
-                     "Are you scoring a perfect tractogram?\n"
-                     "Else, read the help for more information.")
-        nc_filename = None
+    # Not checking here IB and WPC files.
+    assert_headers_compatible(parser, ordered_vb_files + gt_masks_files,
+                              reference=args.reference)
 
+    # ----------------------
     # Now loading everything
+    # ----------------------
+    if args.reference is None:
+        args.reference = 'same'
+
     # Load gt masks
     logging.info("Loading and/or computing ground-truth masks.")
     gt_masks = compute_masks_from_bundles(gt_masks_files, parser, args)
 
-    ref_sft = None
+    ref_sft = None  # Will be the first sft
 
     # Load valid bundles
     vb_sft_list = []
     logging.info("Loading valid bundles")
-    for bundle in bundle_names:
-        vb_name = os.path.join(vb_path, bundle + '_VS.trk')
-        if os.path.isfile(vb_name):
-            sft = load_tractogram(vb_name, 'same',
+    for bname, vb_file in zip(bundle_names, ordered_vb_files):
+        if vb_file is not None:
+            sft = load_tractogram(vb_file, args.reference,
                                   bbox_valid_check=args.bbox_check)
             vb_sft_list.append(sft)
             if ref_sft is None:
                 ref_sft = sft
         else:
-            logging.debug("Bundle {} was not found!".format(bundle))
+            logging.debug("Bundle {} was not found!".format(bname))
             vb_sft_list.append([])  # nb streamlines will be len([]) = 0.
 
     # Load wpc bundles
     wpc_sft_list = []
-    if wpc_path is not None:
+    if args.wpc is not None:
         logging.info("Loading WPC bundles")
-        for bundle in glob.glob(wpc_path + '/*'):
-            sft = load_tractogram(bundle, 'same',
+        for bname in glob.glob(args.wpc + '/*'):
+            sft = load_tractogram(bname, args.reference,
                                   bbox_valid_check=args.bbox_check)
             wpc_sft_list.append(sft)
             if ref_sft is None:
@@ -175,11 +236,11 @@ def load_and_verify_everything(parser, args):
     # Load invalid bundles
     ib_sft_list = []
     ib_names = []
-    if ib_path is not None:
+    if args.ib is not None:
         logging.info("Loading invalid bundles")
-        for bundle in glob.glob(ib_path + '/*'):
-            ib_names.append(os.path.basename(bundle))
-            sft = load_tractogram(bundle, 'same',
+        for bname in glob.glob(args.ib + '/*'):
+            ib_names.append(os.path.basename(bname))
+            sft = load_tractogram(bname, args.reference,
                                   bbox_valid_check=args.bbox_check)
             ib_sft_list.append(sft)
             if ref_sft is None:
@@ -188,8 +249,8 @@ def load_and_verify_everything(parser, args):
         logging.info("Did not find any invalid bundles.")
 
     # Load either NC or IS
-    if nc_filename is not None:
-        nc_sft = load_tractogram(nc_filename, 'same',
+    if args.invalid is not None:
+        nc_sft = load_tractogram(args.invalid, args.reference,
                                  bbox_valid_check=args.bbox_check)
         ref_sft = nc_sft
     else:
@@ -213,25 +274,32 @@ def read_config_file(args):
     bundles: List
         The names of each bundle.
     gt_masks: List
-        The gt_mask filenames per bundle (None if not set) (used for
-        tractometry statistics).
+        The gt_mask filenames per bundle.
     """
     gt_masks = []
     with open(args.gt_config, "r") as json_file:
         config = json.load(json_file)
 
         bundles = list(config.keys())
-        for bundle in bundles:
-            bundle_config = config[bundle]
-            if 'gt_mask' not in bundle_config:
-                raise ValueError("Tracometry cannot be computed if no gt_mask "
-                                 "is given.")
-            if args.gt_dir:
-                gt_masks.append(os.path.join(args.gt_dir,
-                                             bundle_config['gt_mask']))
-            else:
-                gt_masks.append(bundle_config['gt_mask'])
 
+        if args.part2_ROI_segmentation:
+            for bundle in bundles:
+                bundle_config = config[bundle]
+                if 'gt_mask' not in bundle_config:
+                    raise ValueError("Tracometry cannot be computed if no "
+                                     "gt_mask is given.")
+                if args.gt_dir:
+                    gt_masks.append(os.path.join(args.gt_dir,
+                                                 bundle_config['gt_mask']))
+                else:
+                    gt_masks.append(bundle_config['gt_mask'])
+        else:
+            for bundle in bundles:
+                bundle_path = config[bundle]
+                if args.gt_dir:
+                    gt_masks.append(os.path.join(args.gt_dir, bundle_path))
+                else:
+                    gt_masks.append(bundle_path)
     return bundles, gt_masks
 
 
@@ -252,7 +320,7 @@ def main():
         vb_sft_list, wpc_sft_list, ib_sft_list, nc_sft,
         args, bundle_names, gt_masks, dimensions, ib_names)
     final_results.update({
-        "bundles_dir": str(args.bundles_dir),
+        "root_dir": str(args.root_dir),
     })
 
     logging.info("Final results saved in {}".format(out_filename))

--- a/src/scilpy/cli/scil_bundle_score_same_bundle_many_segmentations.py
+++ b/src/scilpy/cli/scil_bundle_score_same_bundle_many_segmentations.py
@@ -4,12 +4,24 @@
 """
 This script is intended to score many versions of a same bundle, compared to
 ONE ground truth / gold standard.
-
-See also scil_bundle_score_many_bundles_one_tractogram.py to score all bundles
-from a single tractogram by comparing each valid bundle to its ground truth.
-
 All tractograms must be in the same space (aligned to one reference).
-The measures can be applied to a voxel-wise or streamline-wise representation.
+
+Our bundle tractometry analysis scripts
+---------------------------------------
+- scil_bundle_pairwise_comparison:
+    - can compare any pair (any combo) from the input list.
+    - can compare the input list against a single file (--single_compare)
+- scil_bundle_score_many_bundles_one_tractogram:
+    - scores files against their individual ground truth.
+- scil_bundle_score_same_bundle_many_segmentations:
+    - compare many versions of a single bundle.
+* If you have volumes associated to your bundles, the following script could be
+of interest for you: scil_volume_pairwise_comparison
+
+Computed metrics
+----------------
+In this script, metrics can be based on the coverage masks of the bundles
+(voxel-wise) or directly on the streamlines:
 
 A gold standard must be provided for the desired representation.
 A gold standard would be a segmentation from an expert or a group of experts.

--- a/src/scilpy/cli/tests/test_bundle_score_many_bundles_one_tractogram.py
+++ b/src/scilpy/cli/tests/test_bundle_score_many_bundles_one_tractogram.py
@@ -22,21 +22,40 @@ def test_score_bundles(script_runner, monkeypatch):
     in_tractogram = os.path.join(SCILPY_HOME, 'tracking', 'pft.trk')
 
     # Pretend we have our segmented bundles on disk
+    os.mkdir('./VB_folder')
+    shutil.copyfile(in_tractogram, './VB_folder/bundle1.trk')
+    shutil.copyfile(in_tractogram, './VB_folder/bundle2.trk')
+    fake_path = os.path.join(SCILPY_HOME, 'tracking', 'seeding_mask.nii.gz')
+    json_contents = {
+        "bundle1": fake_path,
+        "bundle2": fake_path,
+    }
+    with open(os.path.join("config_file.json"), "w") as f:
+        json.dump(json_contents, f)
+
+    ret = script_runner.run(['scil_bundle_score_many_bundles_one_tractogram',
+                            "config_file.json", "./VB_folder/"])
+    assert ret.success
+
+
+def test_score_bundles_part2(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+    in_tractogram = os.path.join(SCILPY_HOME, 'tracking', 'pft.trk')
+
+    # Pretend we have our segmented bundles on disk
     shutil.copyfile(in_tractogram, './NC.trk')
     os.mkdir('./segmented_VB')
     shutil.copyfile(in_tractogram, './segmented_VB/bundle1_VS.trk')
     shutil.copyfile(in_tractogram, './segmented_VB/bundle2_VS.trk')
     os.mkdir('./segmented_IB')
     shutil.copyfile(in_tractogram, './segmented_IB/roi1_roi2_VS.trk')
-
+    fake_path = os.path.join(SCILPY_HOME, 'tracking', 'seeding_mask.nii.gz')
     json_contents = {
         "bundle1": {
-            "gt_mask": os.path.join(SCILPY_HOME, 'tracking',
-                                    'seeding_mask.nii.gz'),
+            "gt_mask": fake_path,
         },
         "bundle2": {
-            "gt_mask": os.path.join(SCILPY_HOME, 'tracking',
-                                    'seeding_mask.nii.gz'),
+            "gt_mask": fake_path,
         }
     }
     with open(os.path.join("config_file.json"), "w") as f:

--- a/src/scilpy/cli/tests/test_bundle_score_many_bundles_one_tractogram.py
+++ b/src/scilpy/cli/tests/test_bundle_score_many_bundles_one_tractogram.py
@@ -29,6 +29,7 @@ def test_score_bundles(script_runner, monkeypatch):
     json_contents = {
         "bundle1": fake_path,
         "bundle2": fake_path,
+        "bundle3": fake_path, # missing VB bundle. Should give score 0.
     }
     with open(os.path.join("config_file.json"), "w") as f:
         json.dump(json_contents, f)

--- a/src/scilpy/cli/tests/test_bundle_score_many_bundles_one_tractogram.py
+++ b/src/scilpy/cli/tests/test_bundle_score_many_bundles_one_tractogram.py
@@ -43,6 +43,7 @@ def test_score_bundles(script_runner, monkeypatch):
         json.dump(json_contents, f)
 
     ret = script_runner.run(['scil_bundle_score_many_bundles_one_tractogram',
-                            "config_file.json", "./", '--no_bbox_check'])
+                            "config_file.json", "./", '--no_bbox_check',
+                             '--part2_ROI_segmentation'])
 
     assert ret.success

--- a/src/scilpy/segment/tractogram_from_roi.py
+++ b/src/scilpy/segment/tractogram_from_roi.py
@@ -96,6 +96,8 @@ def compute_masks_from_bundles(gt_files, parser, args, inverse_mask=False):
 
         gt_bundle_masks.append(gt_mask)
 
+    args.reference = save_ref
+
     return gt_bundle_masks
 
 


### PR DESCRIPTION
# Quick description

Clarified the difference between the 3 bundle scoring scripts. ToDo: Test that they output the same values.

Added an option to scil_bundle_score_many_bundles to allow usage with any files.

## Type of change

Check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [x] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [x] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [X] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
