### PR TITLE
[Major Fix] Change the reference volume for ratio

### DIFF
--- a/src/scilpy/tractanalysis/reproducibility_measures.py
+++ b/src/scilpy/tractanalysis/reproducibility_measures.py
@@ -718,7 +718,7 @@ def compare_volume_wrapper(data_1, data_2, voxel_size=1, ratio=False,
         Size of the voxel in mm.
     ratio: bool
         If true, the measures are normalized by the total number of voxels
-        in the first volume.
+        in the second volume.
     adjency_no_overlap: bool
         If true, exclude overlapping voxels (0mm) from the computation.
     labels_to_mask: bool
@@ -769,7 +769,7 @@ def compare_volume_wrapper(data_1, data_2, voxel_size=1, ratio=False,
             binary_1 + binary_2) - volume_overlap)
 
         if ratio:
-            count = np.count_nonzero(binary_1)
+            count = np.count_nonzero(binary_2)
             volume_overlap /= count
             volume_overreach /= count
 


### PR DESCRIPTION
I found an important bug.

In `scil_volume_pairwise_comparison`, used with the `--ratio --single_compare $ref` options:

(The description of ratio is: "Compute overlap and overreach as a ratio over the reference volume." But in practice, it's currently divided by its own volume.)

I have two volumes with the same ref:
- Ref volume: 543,633 voxels
- Volume 1: Overlap: 434,190 voxels. This should give me 79.87%. But it's actually calculated on its own volume (537,236), which gives me 80.82%
- Volume 2 (really big and overkill): Overlap 536,726, with a total volume of 1,170,659, which gives me 45%.

Changed the reference volume for ratio in the method `compare_volume_wrapper`. This method is only used in `scil_volume_pairwise_comparison`, and in that script, the `--ratio` option can only be chosen when used together with `--single_compare`.

Still this is a potentially major bug, any idea where it could have been used wrong?