### PR TITLE
scil_search_keywords .hidden missing file verification

### DIFF
--- a/src/scilpy/cli/scil_search_keywords.py
+++ b/src/scilpy/cli/scil_search_keywords.py
@@ -103,6 +103,9 @@ def main():
         logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
     hidden_dir = pathlib.Path(SCILPY_HOME) / ".hidden"
+    if not hidden_dir.exists():
+        hidden_dir.mkdir(parents=True, exist_ok=True)
+        logging.info("Dossier '.hidden' créé dans SCILPY_HOME")
 
     if args.regenerate_help_files:
         shutil.rmtree(hidden_dir, ignore_errors=True)


### PR DESCRIPTION
# Quick description

When the users were installing for the first time SCILPY and running scil_search_keywords we had the following error:

FileNotFoundError: [Errno 2] No such file or directory: '.../.scilpy/.hidden'. This is due to .scilpy not being created at this moment.

You could fix it by doing a : scil_data_download

But it was not intuitive. My fix verify if the .hidden exist when running scil_search_keywords and if it does not exist it create it in SCILPY_HOME.

...

## Type of change

Check the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [ X] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [ X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
