### PR TITLE
streamlines_to_voxel_coordinates requires float32

### DIFF
--- a/src/scilpy/cli/scil_tractogram_segment_connections_from_labels.py
+++ b/src/scilpy/cli/scil_tractogram_segment_connections_from_labels.py
@@ -284,6 +284,7 @@ def main():
     # Get the indices of the voxels traversed by each streamline
     logging.info('*** Computing voxels traversed by each streamline ***')
     time1 = time.time()
+    sft.streamlines._data = sft.streamlines._data.astype(np.float32)
     indices, points_to_idx = streamlines_to_voxel_coordinates(
         sft.streamlines,
         return_mapping=True

--- a/src/scilpy/tractograms/streamline_and_mask_operations.py
+++ b/src/scilpy/tractograms/streamline_and_mask_operations.py
@@ -114,6 +114,7 @@ def get_head_tail_density_maps(sft, point_to_select=1, to_millimeters=False,
 
     dimensions = sft.dimensions
     # Get the indices of the voxels intersected
+    streamlines._data = streamlines._data.astype(np.float32)
     list_indices, points_to_indices = streamlines_to_voxel_coordinates(
         streamlines, return_mapping=True)
 
@@ -328,6 +329,7 @@ def cut_streamlines_with_mask(sft, mask,
 
     # Get the indices of the voxels
     # intersected by the streamlines and the mapping from points to indices
+    sft.streamlines._data = sft.streamlines._data.astype(np.float32)
     indices, points_to_idx = streamlines_to_voxel_coordinates(
         sft.streamlines,
         return_mapping=True
@@ -429,6 +431,7 @@ def cut_streamlines_between_labels(
     mask = label_data_2 != unique_vals[1]
     label_data_2[mask] = 0
 
+    sft.streamlines._data = sft.streamlines._data.astype(np.float32)
     (indices, points_to_idx) = streamlines_to_voxel_coordinates(
         sft.streamlines,
         return_mapping=True


### PR DESCRIPTION
# Quick description

We get the error
```
  File "src/scilpy/tractograms/uncompress.pyx", line 84, in scilpy.tractograms.uncompress.streamlines_to_voxel_coordinates
ValueError: Buffer dtype mismatch, expected 'float' but got 'double'
```
The only fix without editing cython is to cast as float32 and keep the previous behavior. We could also modify the cython code to expect double, but we typically avoid touching cython code at the moment... (especially anything in uncompress.pyx)

...

## Type of change

Check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [ ] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
