### PR TITLE
Add `.h5` in extension using the 'same' reference in `scil_tractogram_commit`

### DIFF
--- a/src/scilpy/cli/scil_tractogram_commit.py
+++ b/src/scilpy/cli/scil_tractogram_commit.py
@@ -238,8 +238,9 @@ def _save_results(args, tmp_dir, ext, in_hdf5_file, offsets_list, sub_dir,
 
     # Loading the tractogram (we never did yet! Only sent the filename to
     # commit). Reminder. If input was a hdf5, we have changed
-    # args.in_tractogram to our tmp_tractogram saved in tmp_dir.
-    if ext == '.trk' and args.reference is None:
+    # args.in_tractogram to our tmp_tractogram saved in tmp_dir. However,
+    # ext is still .h5 so we need to set the reference accordingly.
+    if ext in ['.trk', '.h5'] and args.reference is None:
         args.reference = 'same'
     logging.debug('Loading tractogram from {} with reference {}.'
                   .format(args.in_tractogram, args.reference))


### PR DESCRIPTION
# Quick description

Reference was set to 'same' only if the input tractogram was a `.trk`, which made the following saving function fail. Simply added the `.h5` in the extension possibilities.

## Type of change

Check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

error message:
```bash
DEBUG:root:Loading tractogram from /var/folders/23/p0fh1nrd473dtfz3cx_4g0j00000gn/T/tmpvd14_zqp/tractogram.trk with reference None.
Traceback (most recent call last):
  File "/Users/anthonygagnon/envs/scilus3.12/bin/scil_tractogram_commit", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/anthonygagnon/code/scilpy/src/scilpy/cli/scil_tractogram_commit.py", line 487, in main
    _save_results(args, tmp_dir, ext, hdf5_file, offsets_list,
  File "/Users/anthonygagnon/code/scilpy/src/scilpy/cli/scil_tractogram_commit.py", line 247, in _save_results
    sft = load_tractogram(args.in_tractogram, args.reference)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/anthonygagnon/envs/scilus3.12/lib/python3.12/site-packages/dipy/testing/decorators.py", line 201, in wrapper
    return convert_positional_to_keyword(func, args, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/anthonygagnon/envs/scilus3.12/lib/python3.12/site-packages/dipy/testing/decorators.py", line 192, in convert_positional_to_keyword
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/anthonygagnon/envs/scilus3.12/lib/python3.12/site-packages/dipy/io/streamline.py", line 154, in load_tractogram
    if not is_header_compatible(filename, reference):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/anthonygagnon/envs/scilus3.12/lib/python3.12/site-packages/dipy/io/utils.py", line 376, in is_header_compatible
    affine_2, dimensions_2, voxel_sizes_2, voxel_order_2 = get_reference_info(
                                                           ^^^^^^^^^^^^^^^^^^^
  File "/Users/anthonygagnon/envs/scilus3.12/lib/python3.12/site-packages/dipy/io/utils.py", line 345, in get_reference_info
    raise TypeError("Input reference is not one of the supported format")
TypeError: Input reference is not one of the supported format
```

# Checklist

- [ ] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
