### PR TITLE
ENH: Add option to keep original json structure for one input roi

### DIFF
--- a/src/scilpy/cli/scil_volume_stats_in_ROI.py
+++ b/src/scilpy/cli/scil_volume_stats_in_ROI.py
@@ -38,6 +38,10 @@ def _build_arg_parser():
                    help='ROIs volume filenames.\nCan be binary masks or '
                         'weighted masks.')
 
+    p.add_argument('--keep_unique_roi_name', action='store_true',
+                     help='If set, will keep the same JSON structure even if only '
+                            'one ROI is provided as input.')
+
     g = p.add_argument_group('Metrics input options')
     gg = g.add_mutually_exclusive_group(required=True)
     gg.add_argument('--metrics_dir', metavar='dir',
@@ -139,7 +143,7 @@ def main():
                     'Metric {} is not a 3D image ({}D shape).'
                     .format(f, len(metric_img.shape)))
 
-    if len(args.in_rois) == 1:
+    if len(args.in_rois) == 1 and not args.keep_unique_roi_name:
         json_stats = json_stats[roi_name]
 
     # Print results


### PR DESCRIPTION
# Quick description

Please include a summary of the changes and the related issue(s) or improvement(s).
Please also include relevant motivation and context. List any dependencies that are required for this change if needed.

...

## Type of change

Check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [ ] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
