### PR TITLE
FIX: BundleParc -- min_blob_size and keep_biggest were not used

### DIFF
--- a/src/scilpy/cli/scil_fodf_bundleparc.py
+++ b/src/scilpy/cli/scil_fodf_bundleparc.py
@@ -85,7 +85,7 @@ def _build_arg_parser():
                              'will be downloaded.')
     parser.add_argument('--volume_size', default=128, type=int,
                         help='Size of volume to resample to for inference. '
-                             'Only modify if you know what you are doing. ')
+                             'Only modify if you know what you are doing.')
     parcel_group = parser.add_mutually_exclusive_group()
     parcel_group.add_argument('--nb_pts', type=int, default=10,
                               help='Number of divisions per bundle. Default is'


### PR DESCRIPTION
# Quick description

See title. The `predict` function was incorrectly called which put `--min_blob_size=1` and `--keep_biggest_blob=False` no matter the arguments.

## Type of change

Check the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [X] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
