### PR TITLE
Misleading warning for reference #1218

### DIFF
--- a/src/scilpy/io/streamlines.py
+++ b/src/scilpy/io/streamlines.py
@@ -87,7 +87,7 @@ def load_tractogram_with_reference(parser, args, filepath, arg_name=None):
     if ext == '.trk':
         if (is_argument_set(args, 'reference') or
                 arg_name and args.__getattribute__(arg_name + '_ref')):
-            logging.warning('Reference is discarded for this file format '
+            logging.debug('Reference is discarded for this file format '
                             '{}.'.format(filepath))
         sft = load_tractogram(filepath, 'same',
                               bbox_valid_check=bbox_check)


### PR DESCRIPTION
When using load_tractogram_with_reference, loading a .trk file while also providing a reference (e.g., via command-line arguments) previously emitted a warning:

"Reference is discarded for this file format"

This behavior is technically correct—.trk files embed their own spatial reference in the header, so any externally provided reference is ignored. However, emitting this as a WARNING is misleading and unnecessarily noisy, particularly in scripts or pipelines that process mixed file formats (.trk, .tck) and pass a reference by default.

This pull request downgrades the log level of this message from WARNING to DEBUG, preserving the information for debugging purposes while avoiding clutter in normal execution.

Changes

Updated src/scilpy/io/streamlines.py

Changed logging.warning to logging.debug for the message indicating that a provided reference is discarded for .trk files.