### PR TITLE
Ignore fake scripts from doc building in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ coverage.xml
 
 # Sphinx documentation
 docs/build/
+docs/source/scripts
 
 # PyBuilder
 target/


### PR DESCRIPTION
These are created automatically when building the documentation locally, and it's annoying.