### PR TITLE
Fix loading dps from hdf5

### DIFF
--- a/src/scilpy/io/hdf5.py
+++ b/src/scilpy/io/hdf5.py
@@ -104,7 +104,7 @@ def reconstruct_sft_from_hdf5(hdf5_handle, group_keys, space=Space.VOX,
 
             for sub_key in hdf5_handle[group_key].keys():
                 if sub_key not in ['data', 'offsets', 'lengths']:
-                    data = hdf5_handle[group_key][sub_key]
+                    data = np.asarray(hdf5_handle[group_key][sub_key])
                     if data.shape == hdf5_handle[group_key]['offsets'].shape or np.isreal(data):
                         if data.shape == ():  # If data is a scalar (data_per_group coming from afd_fixel)
                             data = np.asarray(data).astype(float) * np.ones(hdf5_handle[group_key]['offsets'].shape)


### PR DESCRIPTION
# Quick description

Loading an HDF5 with DPS returned an error (described below). This PR proposes a fix for that.

## Type of change

Check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

When trying to apply a transform to an HDF5 that contained DPS (e.g., after commit or afd fixel), I got this error:
```
Traceback (most recent call last):
  File "/Users/anthonygagnon/envs/scilus3.12/bin/scil_tractogram_apply_transform_to_hdf5", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/anthonygagnon/code/scilpy/src/scilpy/cli/scil_tractogram_apply_transform_to_hdf5.py", line 110, in main
    moving_sft, _ = reconstruct_sft_from_hdf5(
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/anthonygagnon/code/scilpy/src/scilpy/io/hdf5.py", line 133, in reconstruct_sft_from_hdf5
    sft = StatefulTractogram(streamlines, header, space=space,
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/anthonygagnon/envs/scilus3.12/lib/python3.12/site-packages/dipy/testing/decorators.py", line 201, in wrapper
    return convert_positional_to_keyword(func, args, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/anthonygagnon/envs/scilus3.12/lib/python3.12/site-packages/dipy/testing/decorators.py", line 192, in convert_positional_to_keyword
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/anthonygagnon/envs/scilus3.12/lib/python3.12/site-packages/dipy/io/stateful_tractogram.py", line 119, in __init__
    self._tractogram = Tractogram(
                       ^^^^^^^^^^^
  File "/Users/anthonygagnon/envs/scilus3.12/lib/python3.12/site-packages/nibabel/streamlines/tractogram.py", line 349, in __init__
    self.data_per_streamline = data_per_streamline
    ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/anthonygagnon/envs/scilus3.12/lib/python3.12/site-packages/nibabel/streamlines/tractogram.py", line 366, in data_per_streamline
    self._data_per_streamline = PerArrayDict(
                                ^^^^^^^^^^^^^
  File "/Users/anthonygagnon/envs/scilus3.12/lib/python3.12/site-packages/nibabel/streamlines/tractogram.py", line 102, in __init__
    super().__init__(*args, **kwargs)
  File "/Users/anthonygagnon/envs/scilus3.12/lib/python3.12/site-packages/nibabel/streamlines/tractogram.py", line 41, in __init__
    self.update(dict(*args, **kwargs))
  File "<frozen _collections_abc>", line 982, in update
  File "/Users/anthonygagnon/envs/scilus3.12/lib/python3.12/site-packages/nibabel/streamlines/tractogram.py", line 112, in __setitem__
    elif not all(len(v) == len(value[0]) for v in value[1:]):
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/anthonygagnon/envs/scilus3.12/lib/python3.12/site-packages/nibabel/streamlines/tractogram.py", line 112, in <genexpr>
    elif not all(len(v) == len(value[0]) for v in value[1:]):
                 ^^^^^^
TypeError: object of type 'numpy.float64' has no len()
```

You can reproduce the error using this data: https://drive.google.com/file/d/1-5uqGkZgry0pgL4gfaq8w-yS0xERfO1x/view?usp=sharing
and the following command: `scil_tractogram_apply_transform_to_hdf5 hdf5.h5 t1.nii.gz affine.mat test_warped.h5 --in_deformation inverse_warp.nii.gz --inverse --cut_invalid -f`

Converting the HDF5 object into an array solved the issue.

# Checklist

- [x] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [x] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
