### PR TITLE
FIX: Can't resample a 4d volume using a reference

### DIFF
--- a/src/scilpy/cli/scil_volume_resample.py
+++ b/src/scilpy/cli/scil_volume_resample.py
@@ -103,8 +103,8 @@ def main():
 
         # Must not verify that headers are compatible. But can verify that, at
         # least, the first columns of their affines are compatible.
-        img_zoom_invert = [1 / zoom for zoom in img.header.get_zooms()]
-        ref_zoom_invert = [1 / zoom for zoom in ref_img.header.get_zooms()]
+        img_zoom_invert = [1 / zoom for zoom in img.header.get_zooms()[:3]]
+        ref_zoom_invert = [1 / zoom for zoom in ref_img.header.get_zooms()[:3]]
 
         img_affine = np.dot(img.affine[:3, :3], img_zoom_invert)
         ref_affine = np.dot(ref_img.affine[:3, :3], ref_zoom_invert)


### PR DESCRIPTION
# Quick description

scil_volume_resample presumes the volumes are 3D if using the --ref options. Now it doesn't.

## Type of change

Check the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

TODO

# Checklist

- [ ] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
