### PR TITLE
Match multiple T1s with matching run entity

### DIFF
--- a/src/scilpy/cli/scil_bids_validate.py
+++ b/src/scilpy/cli/scil_bids_validate.py
@@ -74,6 +74,13 @@ def _build_arg_parser():
     p.add_argument("--readout", type=float, default=0.062,
                    help="Default total readout time value [%(default)s].")
 
+    p.add_argument('--match_t1_run',
+                   action='store_true',
+                   help='If set, when multiple T1 files are found for a '
+                        'subject/session, select the one matching the DWI '
+                        'run entity. If not set, no T1 is selected in this '
+                        'ambiguous case.')
+
     add_verbose_arg(p)
     add_overwrite_arg(p)
 
@@ -127,7 +134,8 @@ def get_opposite_pe_direction(phase_encoding_direction):
         return phase_encoding_direction+'-'
 
 
-def get_data(layout, nSub, dwis, t1s, fs, default_readout, clean):
+def get_data(layout, nSub, dwis, t1s, fs, default_readout, clean,
+             match_t1_run):
     """ Return subject data
 
     Parameters
@@ -153,6 +161,10 @@ def get_data(layout, nSub, dwis, t1s, fs, default_readout, clean):
     clean: Boolean
         If True, if some critical files are missing it will
         remove this specific subject/session/run
+
+    match_t1_run: Boolean
+        If True, try matching T1 and DWI using the run entity when
+        multiple T1 files are found for the same subject/session.
 
     Returns
     -------
@@ -302,17 +314,25 @@ def get_data(layout, nSub, dwis, t1s, fs, default_readout, clean):
         elif len(t1_nSess) == 0:
             logging.warning('No T1 file found.')
         else:
-            t1_run_match = [t for t in t1_nSess if t.entities.get('run') == nRun]
-            if len(t1_run_match) == 1:
-                # We found a single T1 with the same run number.
-                logging.warning('Multiple T1 files found, but only one with the same run number as the DWI. '
-                                'Using the T1 file with matching run number: [{}]'.format(t1_run_match[0].path))
-                t1_path = t1_run_match[0].path
+            t1_paths = [curr_t1.path for curr_t1 in t1_nSess]
+            if not match_t1_run:
+                logging.warning('More than one T1 file found. Matching the DWI with the T1 is ambiguous. '
+                                'No T1 will be assigned. [{}]'.format(','.join(t1_paths)))
+            elif 'run' not in curr_dwi.entities:
+                logging.warning('More than one T1 file found, but DWI has no run entity. '
+                                'No T1 will be assigned. [{}]'.format(','.join(t1_paths)))
             else:
-                # Either 0 matches or more than 1 match for the same run.
-                t1_paths = [curr_t1.path for curr_t1 in t1_nSess]
-                logging.warning('More than one T1 file found.'
-                                ' [{}]'.format(','.join(t1_paths)))
+                # Try to match T1 and DWI based on run entity
+                t1_run_match = [t for t in t1_nSess
+                                if 'run' in t.entities and
+                                t.entities['run'] == nRun]
+                if len(t1_run_match) == 1:
+                    logging.warning('Multiple T1 files found, but only one with the same run number as the DWI. '
+                                    'Using the T1 file with matching run number: [{}]'.format(t1_run_match[0].path))
+                    t1_path = t1_run_match[0].path
+                else:
+                    logging.warning('More than one T1 file found and run-based matching could not identify '
+                                    'a unique T1. No T1 will be assigned. [{}]'.format(','.join(t1_paths)))
 
     return {'subject': nSub,
             'session': nSess,
@@ -525,7 +545,8 @@ def main():
                                  t1s,
                                  fs_inputs,
                                  args.readout,
-                                 args.clean))
+                                 args.clean,
+                                 args.match_t1_run))
 
     if args.clean:
         data = [d for d in data if d]

--- a/src/scilpy/cli/tests/test_bids_validate.py
+++ b/src/scilpy/cli/tests/test_bids_validate.py
@@ -303,6 +303,62 @@ def generate_fake_bids_structure(
     return structure_dir
 
 
+def generate_fake_bids_structure_with_multiple_t1(
+        output_dir,
+        dwi_has_run=True,
+        t1_run_entities=None):
+    if t1_run_entities is None:
+        t1_run_entities = ['1', None]
+
+    structure_dir = tempfile.mkdtemp(prefix="test_bids", dir=output_dir)
+    data_3d, data_dwi = np.empty((10, 10, 10)), np.empty((10, 10, 10, 10))
+
+    dwi_metadata = {
+        "RepetitionTime": 8.4,
+        "FlipAngle": 90,
+        "EchoTime": 0.09,
+        "EffectiveEchoSpacing": 0.0003927297862}
+
+    sub_tag = "sub-1"
+    ses_tag = "ses-1"
+    ses_dir = os.path.join(structure_dir, sub_tag, ses_tag)
+    dwi_dir = os.path.join(ses_dir, "dwi")
+    anat_dir = os.path.join(ses_dir, "anat")
+    os.makedirs(dwi_dir)
+    os.makedirs(anat_dir)
+
+    if dwi_has_run:
+        dwi_prefix = "{}_{}_run-1_dir-AP_dwi".format(sub_tag, ses_tag)
+    else:
+        dwi_prefix = "{}_{}_dir-AP_dwi".format(sub_tag, ses_tag)
+
+    generate_image_packet(
+        data_dwi, dwi_dir, dwi_prefix,
+        phase_dir="AP",
+        readout=0.069,
+        **dwi_metadata)
+
+    np.savetxt(os.path.join(dwi_dir, "{}.bval".format(dwi_prefix)),
+               np.ones((10,)) * 1000)
+    np.savetxt(os.path.join(dwi_dir, "{}.bvec".format(dwi_prefix)),
+               np.ones((3, 10)))
+
+    for index, run_entity in enumerate(t1_run_entities):
+        if run_entity is None:
+            t1_prefix = "{}_{}_acq-{}_T1w".format(sub_tag, ses_tag, index + 1)
+        else:
+            t1_prefix = "{}_{}_run-{}_T1w".format(sub_tag, ses_tag,
+                                                    run_entity)
+        generate_image_packet(data_3d, anat_dir, t1_prefix)
+
+    dataset_description_file = os.path.join(
+        structure_dir, "dataset_description.json")
+    with open(dataset_description_file, "w+") as f:
+        json.dump({"Name": "Test dataset", "BIDSVersion": "1.8.0"}, f)
+
+    return structure_dir
+
+
 def compare_jsons(json_output, test_dir):
     # Open test json file
     with open(os.path.join(test_dir, json_output), 'r') as f:
@@ -437,3 +493,70 @@ def test_bids_rev_dwi_sbref(
         assert compare_jsons(json_output, test_dir)
     else:
         assert False
+
+
+def test_bids_multiple_t1_default_no_run_match(tmpdir, script_runner):
+    test_dir = generate_fake_bids_structure_with_multiple_t1(
+        tmpdir,
+        dwi_has_run=True,
+        t1_run_entities=['1', None])
+
+    output_json = os.path.join(test_dir, 'test_multiple_t1_default.json')
+    ret = script_runner.run([
+        'scil_bids_validate',
+        test_dir,
+        output_json,
+        '-f', '-v'])
+
+    assert ret.success
+    with open(output_json, 'r') as f:
+        out_data = json.load(f)
+
+    assert len(out_data) == 1
+    assert out_data[0]['t1'] == 'todo'
+
+
+def test_bids_multiple_t1_match_t1_run_requires_t1_run_entity(
+        tmpdir, script_runner):
+    test_dir = generate_fake_bids_structure_with_multiple_t1(
+        tmpdir,
+        dwi_has_run=True,
+        t1_run_entities=[None, None])
+
+    output_json = os.path.join(test_dir, 'test_multiple_t1_match_run.json')
+    ret = script_runner.run([
+        'scil_bids_validate',
+        test_dir,
+        output_json,
+        '--match_t1_run',
+        '-f', '-v'])
+
+    assert ret.success
+    with open(output_json, 'r') as f:
+        out_data = json.load(f)
+
+    assert len(out_data) == 1
+    assert out_data[0]['t1'] == 'todo'
+
+
+def test_bids_multiple_t1_match_t1_run_selects_matching_run(
+        tmpdir, script_runner):
+    test_dir = generate_fake_bids_structure_with_multiple_t1(
+        tmpdir,
+        dwi_has_run=True,
+        t1_run_entities=['1', '2'])
+
+    output_json = os.path.join(test_dir, 'test_multiple_t1_match_run_selected.json')
+    ret = script_runner.run([
+        'scil_bids_validate',
+        test_dir,
+        output_json,
+        '--match_t1_run',
+        '-f', '-v'])
+
+    assert ret.success
+    with open(output_json, 'r') as f:
+        out_data = json.load(f)
+
+    assert len(out_data) == 1
+    assert out_data[0]['t1'].endswith('sub-1_ses-1_run-1_T1w.nii.gz')


### PR DESCRIPTION
# Quick description

I'm encountering issues when parsing the BIDS layout when there's the following scenario:
- I have a DWI for `ses-1` and `run-1`
- I have two T1s for `ses-1`: a T1 for `run-1` and another one for `run-2`.

I'd like to possibly match the DWI with its matching T1 (`ses-1` and `run-1`).

## Type of change

Check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [ ] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
