### PR TITLE
Adding keyword to be used with volume_stats_in_labels

### DIFF
--- a/src/scilpy/cli/scil_json_convert_entries_to_xlsx.py
+++ b/src/scilpy/cli/scil_json_convert_entries_to_xlsx.py
@@ -142,7 +142,7 @@ def _parse_scalar_meanstd(stats, subs, bundles, optional_keys):
             for m_stat in bundle_dict.values():
                 if isinstance(m_stat, dict):
                     found_keys.update(m_stat.keys())
-    keys_present = set(optional_keys) & found_keys
+    keys_present = set(optional_keys).intersection(found_keys)
     optional_arrays = {}
 
     for key in keys_present:
@@ -475,7 +475,7 @@ def _build_arg_parser():
                    help='If set, subjects won\'t be sorted alphabetically.')
     
     p.add_argument('--extra_key', nargs='+', default=[],
-                   help='Optional keys to export (only numeric values).')
+                   help='Optional keys to export (must be associated to numeric values only)')
 
     p.add_argument('--no_sort_bundles', action='store_false',
                    help='If set, bundles won\'t be sorted alphabetically.')


### PR DESCRIPTION
# Quick description

I added the subkeys from scil_volume_stats_in_labels. These keywords are optional and the script can still be used when you only have mean and std 
...

## Type of change

Check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [ ] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
