### PR TITLE
Fix command reference in error message

### DIFF
--- a/src/scilpy/io/image.py
+++ b/src/scilpy/io/image.py
@@ -120,7 +120,7 @@ def get_data_as_mask(mask_img, dtype=np.uint8):
                       'with a mask.\n'
                       'To convert your data, you may use tools like mrconvert '
                       'or \n'
-                      '>> scil_volume_math.py convert IMG IMG '
+                      '>> scil_volume_math convert IMG IMG '
                       '--data_type uint8 -f'.format(basename, curr_type))
 
     return data


### PR DESCRIPTION
# Quick description

removing ".py"  from 
To convert your data, you may use tools like mrconvert or >> **scil_volume_math.py** convert IMG IMG --data_type uint8 -f 

## Type of change

Check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [x] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
