### PR TITLE
[BF] Fix issue when running mean fixel afd from hdf5

### DIFF
--- a/src/scilpy/io/hdf5.py
+++ b/src/scilpy/io/hdf5.py
@@ -105,7 +105,7 @@ def reconstruct_sft_from_hdf5(hdf5_handle, group_keys, space=Space.VOX,
             for sub_key in hdf5_handle[group_key].keys():
                 if sub_key not in ['data', 'offsets', 'lengths']:
                     data = np.asarray(hdf5_handle[group_key][sub_key])
-                    if data.shape == hdf5_handle[group_key]['offsets'].shape or np.isreal(data):
+                    if data.shape == hdf5_handle[group_key]['offsets'].shape or np.isreal(data).all():
                         if data.shape == ():  # If data is a scalar (data_per_group coming from afd_fixel)
                             data = np.asarray(data).astype(float) * np.ones(hdf5_handle[group_key]['offsets'].shape)
                         # Discovered dps (the array is the same length as


### PR DESCRIPTION
# Quick description

```
$ scil_bundle_mean_fixel_afd_from_hdf5 results_conn/CF_F001/Run_COMMIT/CF_F001__decompose_commit.h5 ../rawdata/CF_F001/TF_F001__fodf.nii.gz CF_F001__decompose_afd_rd.h5 --sh_basis descoteaux07 --processes 4 -f
/home/local/USHERBROOKE/bora2502/.virtualenvs/scilpy/lib/python3.12/site-packages/dipy/utils/deprecator.py:435: UserWarning: Pass ['sh_order_max', 'basis_type'] as keyword args. From version 2.0.0 passing these as positional arguments will result in an error. 
  return function(*args, **kwargs)
/home/local/USHERBROOKE/bora2502/.virtualenvs/scilpy/lib/python3.12/site-packages/dipy/utils/deprecator.py:435: UserWarning: Pass ['sh_order_max', 'basis_type'] as keyword args. From version 2.0.0 passing these as positional arguments will result in an error. 
  return function(*args, **kwargs)
/home/local/USHERBROOKE/bora2502/.virtualenvs/scilpy/lib/python3.12/site-packages/dipy/utils/deprecator.py:435: UserWarning: Pass ['sh_order_max', 'basis_type'] as keyword args. From version 2.0.0 passing these as positional arguments will result in an error. 
  return function(*args, **kwargs)
/home/local/USHERBROOKE/bora2502/.virtualenvs/scilpy/lib/python3.12/site-packages/dipy/utils/deprecator.py:435: UserWarning: Pass ['sh_order_max', 'basis_type'] as keyword args. From version 2.0.0 passing these as positional arguments will result in an error. 
  return function(*args, **kwargs)
multiprocessing.pool.RemoteTraceback: 
"""
Traceback (most recent call last):
  File "/usr/local/fsl/lib/python3.12/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
                    ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/fsl/lib/python3.12/multiprocessing/pool.py", line 48, in mapstar
    return list(map(*args))
           ^^^^^^^^^^^^^^^^
  File "/home/local/USHERBROOKE/bora2502/p/scil/s/scilpy/src/scilpy/cli/scil_bundle_mean_fixel_afd_from_hdf5.py", line 52, in _afd_rd_wrapper
    sft, _ = reconstruct_sft_from_hdf5(in_hdf5_file, key, allow_empty=True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/local/USHERBROOKE/bora2502/p/scil/s/scilpy/src/scilpy/io/hdf5.py", line 108, in reconstruct_sft_from_hdf5
    if data.shape == hdf5_handle[group_key]['offsets'].shape or np.isreal(data):
                                                                ^^^^^^^^^^^^^^^
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/local/USHERBROOKE/bora2502/.virtualenvs/scilpy/bin/scil_bundle_mean_fixel_afd_from_hdf5", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/local/USHERBROOKE/bora2502/p/scil/s/scilpy/src/scilpy/cli/scil_bundle_mean_fixel_afd_from_hdf5.py", line 121, in main
    results_list = pool.map(_afd_rd_wrapper,
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/fsl/lib/python3.12/multiprocessing/pool.py", line 367, in map
    return self._map_async(func, iterable, mapstar, chunksize).get()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/fsl/lib/python3.12/multiprocessing/pool.py", line 774, in get
    raise self._value
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```


...

## Type of change

Check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [ ] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
