### PR TITLE
FIX: Bump pybids version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
 "openpyxl==3.1.*",
 "packaging==24.*",
 "pathspec==0.12.*",
-"pybids==0.18.*",
+"pybids==0.21.*",
 "PyMCubes==0.1.*",
 "pyparsing==3.2.*",
 "PySocks==1.7.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
 "openpyxl==3.1.*",
 "packaging==24.*",
 "pathspec==0.12.*",
-"pybids==0.21.*",
+"pybids==0.22.*",
 "PyMCubes==0.1.*",
 "pyparsing==3.2.*",
 "PySocks==1.7.*",


### PR DESCRIPTION
# Quick description

PyBids is used for `scil_bids_validate`. Current dcm2bids writes the "bids:" in the URI of the "IntendedFor" field of the JSON file associated with a fmap. The currently used pybids=0.18.1 doesn't seem to support this feature as an error `unknown protocol: bids` raises when using the `scil_bids_validate` script with data converted using the most recent `dcm2bids` version.

Bumping the pybids version solves this issue since the fix was merged in pybids==0.21.0.

## Type of change

Check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

<img width="1235" height="653" alt="image" src="https://github.com/user-attachments/assets/0f890ddd-80e6-4d34-9ae3-eaa588224aa9" />

# Checklist

- [x] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [x] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
