### PR TITLE
fix: Add replace_bad_voxels option in freewater/noddi

### DIFF
--- a/src/scilpy/cli/scil_NODDI_maps.py
+++ b/src/scilpy/cli/scil_NODDI_maps.py
@@ -58,7 +58,8 @@ def _build_arg_parser():
                    help='Output directory for the NODDI results. '
                         '[%(default)s]')
     p.add_argument('--replace_bad_voxels', type=float, default=None,
-                   help='Replace bad voxels (NaNs or infs) in the input DWI with the specified value.')
+                   help='Replace bad voxels (NaNs or infs) in the input DWI '
+                        'with the specified value.')
     add_tolerance_arg(p)
     add_skip_b0_check_arg(p, will_overwrite_with_min=False,
                           b0_tol_name='--tolerance')

--- a/src/scilpy/cli/scil_NODDI_maps.py
+++ b/src/scilpy/cli/scil_NODDI_maps.py
@@ -57,6 +57,8 @@ def _build_arg_parser():
     p.add_argument('--out_dir', default="results",
                    help='Output directory for the NODDI results. '
                         '[%(default)s]')
+    p.add_argument('--replace_bad_voxels', type=float, default=None,
+                   help='Replace bad voxels (NaNs or infs) in the input DWI with the specified value.')
     add_tolerance_arg(p)
     add_skip_b0_check_arg(p, will_overwrite_with_min=False,
                           b0_tol_name='--tolerance')
@@ -144,7 +146,8 @@ def main():
         # Load the data
         amico.core.setup()
         ae = amico.Evaluation('.', '.')
-        ae.load_data(args.in_dwi, tmp_scheme_filename, mask_filename=args.mask)
+        ae.load_data(args.in_dwi, tmp_scheme_filename, mask_filename=args.mask,
+                     replace_bad_voxels=args.replace_bad_voxels)
 
         # Compute the response functions
         ae.set_model("NODDI")

--- a/src/scilpy/cli/scil_freewater_maps.py
+++ b/src/scilpy/cli/scil_freewater_maps.py
@@ -61,7 +61,8 @@ def _build_arg_parser():
                         'existing shell. Above this limit, the b-value is '
                         'placed on a new shell. This includes b0s values.')
     p.add_argument('--replace_bad_voxels', type=float, default=None,
-                   help='Replace bad voxels (NaNs or infs) in the input DWI with the specified value.')
+                   help='Replace bad voxels (NaNs or infs) in the input DWI '
+                        'with the specified value.')
 
     g1 = p.add_argument_group(title='Model options')
     g1.add_argument('--para_diff', type=float, default=1.5e-3,

--- a/src/scilpy/cli/scil_freewater_maps.py
+++ b/src/scilpy/cli/scil_freewater_maps.py
@@ -60,6 +60,8 @@ def _build_arg_parser():
                    help='Limit value to consider that a b-value is on an '
                         'existing shell. Above this limit, the b-value is '
                         'placed on a new shell. This includes b0s values.')
+    p.add_argument('--replace_bad_voxels', type=float, default=None,
+                   help='Replace bad voxels (NaNs or infs) in the input DWI with the specified value.')
 
     g1 = p.add_argument_group(title='Model options')
     g1.add_argument('--para_diff', type=float, default=1.5e-3,
@@ -139,7 +141,8 @@ def main():
         # Load the data
         ae.load_data(args.in_dwi,
                      scheme_filename=tmp_scheme_filename,
-                     mask_filename=args.mask)
+                     mask_filename=args.mask,
+                     replace_bad_voxels=args.replace_bad_voxels)
 
         # Compute the response functions
         ae.set_model("FreeWater")

--- a/src/scilpy/cli/scil_tractogram_commit.py
+++ b/src/scilpy/cli/scil_tractogram_commit.py
@@ -149,6 +149,9 @@ def _build_arg_parser():
                    help='Binary mask where tratography was allowed.\n'
                         'If not set, uses a binary mask computed from '
                         'the streamlines.')
+    p.add_argument('--replace_bad_voxels', type=float, default=None,
+                   help='Replace bad voxels (NaNs or infs) in the input DWI '
+                        'with the specified value.')
 
     g0 = p.add_argument_group(title='COMMIT2 options')
     g0.add_argument('--commit2', action='store_true',
@@ -451,7 +454,8 @@ def main():
                  os.path.join(tmp_dir.name, 'dwi_zero_fix.nii.gz'))
 
         mit.load_data(os.path.join(tmp_dir.name, 'dwi_zero_fix.nii.gz'),
-                      tmp_scheme_filename)
+                      tmp_scheme_filename,
+                      replace_bad_voxels=args.replace_bad_voxels)
         mit.set_model('StickZeppelinBall')
         mit.model.set(args.para_diff, perp_diff, isotropc_diff)
 

--- a/src/scilpy/cli/tests/test_NODDI_maps.py
+++ b/src/scilpy/cli/tests/test_NODDI_maps.py
@@ -33,6 +33,7 @@ def test_execution_commit_amico(script_runner, monkeypatch):
                              '--out_dir', 'noddi', '--tol', '30',
                              '--para_diff', '0.0017', '--iso_diff', '0.003',
                              '--lambda1', '0.5', '--lambda2', '0.001',
+                             '--replace_bad_voxels', '0',
                              '--processes', '1', '-f'])
     assert ret.success
 

--- a/src/scilpy/cli/tests/test_freewater_maps.py
+++ b/src/scilpy/cli/tests/test_freewater_maps.py
@@ -34,5 +34,6 @@ def test_execution_commit_amico(script_runner, monkeypatch):
                              '--perp_diff_min', '0.0001',
                              '--perp_diff_max', '0.0007',
                              '--lambda1', '0.0', '--lambda2', '0.001',
+                             '--replace_bad_voxels', '0',
                              '--processes', '1'])
     assert ret.success

--- a/src/scilpy/cli/tests/test_tractogram_commit.py
+++ b/src/scilpy/cli/tests/test_tractogram_commit.py
@@ -35,6 +35,7 @@ def test_execution_commit_amico(script_runner, monkeypatch):
         '--in_tracking_mask', in_mask,
         '--perp_diff', '1.19E-3', '0.85E-3', '0.51E-3', '0.17E-3',
         '--iso_diff', '1.7E-3', '3.0E-3',
+        '--replace_bad_voxels', '0',
         '--processes', '1', '--keep_whole_tractogram'])
     assert ret.success
 


### PR DESCRIPTION
# Quick description

When running sf-pediatric, I stumbled upon a few subjects failing during NODDI/Freewater computation with this error:
```python
[ ERROR ] Nan or Inf values in the raw signal. Try using the "replace_bad_voxels" or "b0_min_signal" parameters when calling "load_data()"
```
After inspection of the data itself, I noticed there were some NaNs (since the acquisition had a lot of slice dropping, I assume it might come from `eddy`)
```
In [13]: np.count_nonzero(np.isnan(data))
Out[13]: 7

In [14]: data.shape
Out[14]: (166, 171, 132, 80)
```
I added the option to both  CLI scripts to replace bad voxels with a user-specified value. The script runs fine, and the maps also look pretty normal to me.

## Type of change

Check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

I can share some if needed.

# Checklist

- [ ] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
