### PR TITLE
gdown version

### DIFF
--- a/docs/source/documentation/getting_started.rst
+++ b/docs/source/documentation/getting_started.rst
@@ -20,6 +20,7 @@ Installation
     export SETUPTOOLS_USE_DISTUTILS=stdlib
 
     uv pip install scilpy # For the most recent release from PyPi
+    pip install "gdown>=6.0.0" # To download the data for the tutorials
 
 
 Download data
@@ -29,7 +30,7 @@ In order to follow the tutorials we highly encourage you to download this archiv
 
 .. code-block:: bash
 
-      gdown https://drive.google.com/file/d/1kbKvj0DdCExXcx9s3tTw3pKcY9IaAsvF/view?usp=sharing --fuzzy
+      gdown https://drive.google.com/file/d/1kbKvj0DdCExXcx9s3tTw3pKcY9IaAsvF/view?usp=sharing
       unzip data_for_test.zip
       rm data_for_test.zip
 


### PR DESCRIPTION
# Quick description

This PR fixes issue #1333 for the tutorial documentation to avoid confusion related to the removed fuzzy parameter in gdown v6.0.0.

## Type of change

Check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [ ] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
