### PR TITLE
Fix: Add b_thr argument to ae.load_data() in NODDI and freewater

### DIFF
--- a/src/scilpy/cli/scil_NODDI_maps.py
+++ b/src/scilpy/cli/scil_NODDI_maps.py
@@ -148,7 +148,7 @@ def main():
         amico.core.setup()
         ae = amico.Evaluation('.', '.')
         ae.load_data(args.in_dwi, tmp_scheme_filename, mask_filename=args.mask,
-                     replace_bad_voxels=args.replace_bad_voxels)
+                     replace_bad_voxels=args.replace_bad_voxels, b0_thr=args.tolerance)
 
         # Compute the response functions
         ae.set_model("NODDI")

--- a/src/scilpy/cli/scil_NODDI_maps.py
+++ b/src/scilpy/cli/scil_NODDI_maps.py
@@ -60,6 +60,10 @@ def _build_arg_parser():
     p.add_argument('--replace_bad_voxels', type=float, default=None,
                    help='Replace bad voxels (NaNs or infs) in the input DWI '
                         'with the specified value.')
+    p.add_argument('--compute_rmse', action='store_true',
+                     help='Compute the RMSE map of the model fit.')
+    p.add_argument('--compute_nrmse', action='store_true',
+                     help='Compute the NRMSE map of the model fit.')
     add_tolerance_arg(p)
     add_skip_b0_check_arg(p, will_overwrite_with_min=False,
                           b0_tol_name='--tolerance')
@@ -178,6 +182,8 @@ def main():
         ae.set_config('OUTPUT_path', args.out_dir)
         ae.set_config('nthreads', args.nbr_processes)
         ae.set_config('BLAS_nthreads', 1)
+        ae.set_config('doComputeRMSE', args.compute_rmse)
+        ae.set_config('doComputeNRMSE', args.compute_nrmse)
         ae.generate_kernels(regenerate=regenerate_kernels)
         if args.compute_only:
             return

--- a/src/scilpy/cli/scil_NODDI_maps.py
+++ b/src/scilpy/cli/scil_NODDI_maps.py
@@ -61,9 +61,11 @@ def _build_arg_parser():
                    help='Replace bad voxels (NaNs or infs) in the input DWI '
                         'with the specified value.')
     p.add_argument('--compute_rmse', action='store_true',
-                     help='Compute the RMSE map of the model fit.')
+                     help='Compute the RMSE map of the model fit. Will be saved '
+                          'as fit_RMSE.nii.gz in the output directory.')
     p.add_argument('--compute_nrmse', action='store_true',
-                     help='Compute the NRMSE map of the model fit.')
+                     help='Compute the NRMSE map of the model fit. Will be saved '
+                          'as fit_NRMSE.nii.gz in the output directory.')
     add_tolerance_arg(p)
     add_skip_b0_check_arg(p, will_overwrite_with_min=False,
                           b0_tol_name='--tolerance')

--- a/src/scilpy/cli/scil_freewater_maps.py
+++ b/src/scilpy/cli/scil_freewater_maps.py
@@ -63,6 +63,10 @@ def _build_arg_parser():
     p.add_argument('--replace_bad_voxels', type=float, default=None,
                    help='Replace bad voxels (NaNs or infs) in the input DWI '
                         'with the specified value.')
+    p.add_argument('--compute_rmse', action='store_true',
+                     help='Compute the RMSE map of the model fit.')
+    p.add_argument('--compute_nrmse', action='store_true',
+                     help='Compute the NRMSE map of the model fit.')
 
     g1 = p.add_argument_group(title='Model options')
     g1.add_argument('--para_diff', type=float, default=1.5e-3,
@@ -174,6 +178,8 @@ def main():
         ae.set_config('ATOMS_path', kernels_dir)
         ae.set_config('OUTPUT_path', args.out_dir)
         ae.set_config('nthreads', args.nbr_processes)
+        ae.set_config('doComputeRMSE', args.compute_rmse)
+        ae.set_config('doComputeNRMSE', args.compute_nrmse)
         ae.generate_kernels(regenerate=regenerate_kernels)
         if args.compute_only:
             return

--- a/src/scilpy/cli/scil_freewater_maps.py
+++ b/src/scilpy/cli/scil_freewater_maps.py
@@ -143,7 +143,8 @@ def main():
         ae.load_data(args.in_dwi,
                      scheme_filename=tmp_scheme_filename,
                      mask_filename=args.mask,
-                     replace_bad_voxels=args.replace_bad_voxels)
+                     replace_bad_voxels=args.replace_bad_voxels,
+                     b0_thr=args.b_thr)
 
         # Compute the response functions
         ae.set_model("FreeWater")

--- a/src/scilpy/cli/scil_freewater_maps.py
+++ b/src/scilpy/cli/scil_freewater_maps.py
@@ -64,9 +64,11 @@ def _build_arg_parser():
                    help='Replace bad voxels (NaNs or infs) in the input DWI '
                         'with the specified value.')
     p.add_argument('--compute_rmse', action='store_true',
-                     help='Compute the RMSE map of the model fit.')
+                     help='Compute the RMSE map of the model fit. Will be saved '
+                          'as fit_RMSE.nii.gz in the output directory.')
     p.add_argument('--compute_nrmse', action='store_true',
-                     help='Compute the NRMSE map of the model fit.')
+                     help='Compute the NRMSE map of the model fit. Will be saved '
+                          'as fit_NRMSE.nii.gz in the output directory.')
 
     g1 = p.add_argument_group(title='Model options')
     g1.add_argument('--para_diff', type=float, default=1.5e-3,

--- a/src/scilpy/cli/tests/test_NODDI_maps.py
+++ b/src/scilpy/cli/tests/test_NODDI_maps.py
@@ -34,6 +34,7 @@ def test_execution_commit_amico(script_runner, monkeypatch):
                              '--para_diff', '0.0017', '--iso_diff', '0.003',
                              '--lambda1', '0.5', '--lambda2', '0.001',
                              '--replace_bad_voxels', '0',
+                             '--compute_rmse', '--compute_nrmse',
                              '--processes', '1', '-f'])
     assert ret.success
 

--- a/src/scilpy/cli/tests/test_freewater_maps.py
+++ b/src/scilpy/cli/tests/test_freewater_maps.py
@@ -35,5 +35,6 @@ def test_execution_commit_amico(script_runner, monkeypatch):
                              '--perp_diff_max', '0.0007',
                              '--lambda1', '0.0', '--lambda2', '0.001',
                              '--replace_bad_voxels', '0',
+                             '--compute_rmse', '--compute_nrmse',
                              '--processes', '1'])
     assert ret.success


### PR DESCRIPTION
# Quick description

Both scripts had a tolerance parameter for b0 detection, but was not passed to the `.load_data()` function of AMICO creating issues when a subject has only non-zero shells. This PR simply links the CLI params to the function argument.

## Type of change

Check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [ ] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
