### PR TITLE
ENH: Prefer excluding upper bound in streamline length filtering

### DIFF
--- a/src/scilpy/tractograms/streamline_operations.py
+++ b/src/scilpy/tractograms/streamline_operations.py
@@ -443,6 +443,9 @@ def filter_streamlines_by_length(sft, min_length=0., max_length=np.inf,
     """
     Filter streamlines using minimum and max length.
 
+    Keeps all streamlines with lengths in the
+    ``[min_length, max_length)`` half-open interval.
+
     Parameters
     ----------
     sft: StatefulTractogram
@@ -476,7 +479,7 @@ def filter_streamlines_by_length(sft, min_length=0., max_length=np.inf,
 
         # Filter lengths
         valid_length_ids = np.logical_and(lengths >= min_length,
-                                          lengths <= max_length)
+                                          lengths < max_length)
         filtered_sft = sft[valid_length_ids]
     else:
         valid_length_ids = np.array([], dtype=bool)


### PR DESCRIPTION
# Quick description

Change streamline length filtering to use a half-open interval, including streamlines at the minimum length threshold while excluding those exactly matching the maximum length threshold.

Using a half-open interval simplifies length binning by allowing natural bin definitions (e.g., [80, 90), [90, 100), etc.), avoiding arbitrary floating-point thresholds (e.g. [80-89.99], [90-99.99] or [80.01-90], [90.01-100], etc.) and preventing duplicate assignments at bin boundaries.

Also, this allows the philosophy to be consistent with major Python packages like NumPy, etc. when dealing with intervals.

## Type of change

Check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

N/A

# Checklist

- [X] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
