### PR TITLE
[NF] Script to split affine transform into components

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -263,6 +263,7 @@ scil_tractogram_segment_with_ROI_and_score  = "scilpy.cli.scil_tractogram_segmen
 scil_tractogram_shuffle  = "scilpy.cli.scil_tractogram_shuffle:main"
 scil_tractogram_smooth  = "scilpy.cli.scil_tractogram_smooth:main"
 scil_tractogram_split  = "scilpy.cli.scil_tractogram_split:main"
+scil_transform_split  = "scilpy.cli.scil_transform_split:main"
 scil_viz_bingham_fit  = "scilpy.cli.scil_viz_bingham_fit:main"
 scil_viz_bundle  = "scilpy.cli.scil_viz_bundle:main"
 scil_viz_bundle_screenshot_mni  = "scilpy.cli.scil_viz_bundle_screenshot_mni:main"

--- a/src/scilpy/cli/scil_bundle_label_map.py
+++ b/src/scilpy/cli/scil_bundle_label_map.py
@@ -78,7 +78,6 @@ from scilpy.io.utils import (add_overwrite_arg,
                              add_verbose_arg,
                              assert_inputs_exist,
                              assert_output_dirs_exist_and_empty,
-                             load_matrix_in_any_format,
                              load_transform_matrix_in_any_format,
                              ranged_type)
 from scilpy.tractanalysis.bundle_operations import uniformize_bundle_sft

--- a/src/scilpy/cli/scil_bundle_label_map.py
+++ b/src/scilpy/cli/scil_bundle_label_map.py
@@ -79,6 +79,7 @@ from scilpy.io.utils import (add_overwrite_arg,
                              assert_inputs_exist,
                              assert_output_dirs_exist_and_empty,
                              load_matrix_in_any_format,
+                             load_transform_matrix_in_any_format,
                              ranged_type)
 from scilpy.tractanalysis.bundle_operations import uniformize_bundle_sft
 from scilpy.tractanalysis.streamlines_metrics import compute_tract_counts_map
@@ -174,7 +175,7 @@ def main():
                                                   args.in_centroid)
     if args.transformation is not None:
         streamlines = sft_centroid.streamlines
-        transfo = load_matrix_in_any_format(args.transformation)
+        transfo = load_transform_matrix_in_any_format(args.transformation)
         if args.inverse:
             transfo = np.linalg.inv(transfo)
         streamlines = transform_streamlines(

--- a/src/scilpy/cli/scil_gradients_apply_transform.py
+++ b/src/scilpy/cli/scil_gradients_apply_transform.py
@@ -13,7 +13,7 @@ import numpy as np
 
 from scilpy.io.utils import (add_overwrite_arg, assert_inputs_exist,
                              assert_outputs_exist, add_verbose_arg,
-                             load_matrix_in_any_format)
+                             load_transform_matrix_in_any_format)
 from scilpy.version import version_string
 
 
@@ -47,7 +47,7 @@ def main():
     assert_inputs_exist(parser, [args.in_bvecs, args.in_transfo])
     assert_outputs_exist(parser, args, args.out_bvecs)
 
-    transfo = load_matrix_in_any_format(args.in_transfo)[:3, :3]
+    transfo = load_transform_matrix_in_any_format(args.in_transfo)[:3, :3]
 
     if args.inverse:
         transfo = np.linalg.inv(transfo)

--- a/src/scilpy/cli/scil_surface_apply_transform.py
+++ b/src/scilpy/cli/scil_surface_apply_transform.py
@@ -38,7 +38,7 @@ from scilpy.io.utils import (add_overwrite_arg,
                              assert_inputs_exist,
                              assert_outputs_exist,
                              convert_stateful_str_to_enum,
-                             load_matrix_in_any_format)
+                             load_transform_matrix_in_any_format)
 from scilpy.surfaces.surface_operations import apply_transform
 from scilpy.version import version_string
 
@@ -86,7 +86,7 @@ def main():
     sfs = load_surface_with_reference(parser, args, args.in_moving_surface)
 
     img = nib.load(args.in_target_reference)
-    transfo = load_matrix_in_any_format(args.in_transfo)
+    transfo = load_transform_matrix_in_any_format(args.in_transfo)
 
     deformation_data = None
     if args.in_deformation is not None:

--- a/src/scilpy/cli/scil_tractogram_apply_transform.py
+++ b/src/scilpy/cli/scil_tractogram_apply_transform.py
@@ -49,7 +49,7 @@ from scilpy.io.utils import (add_overwrite_arg,
                              add_verbose_arg,
                              assert_inputs_exist,
                              assert_outputs_exist,
-                             load_matrix_in_any_format)
+                             load_transform_matrix_in_any_format)
 from scilpy.tractograms.tractogram_operations import transform_warp_sft
 from scilpy.version import version_string
 
@@ -122,7 +122,7 @@ def main():
     moving_sft = load_tractogram_with_reference(parser, args,
                                                 args.in_moving_tractogram)
 
-    transfo = load_matrix_in_any_format(args.in_transfo)
+    transfo = load_transform_matrix_in_any_format(args.in_transfo)
     deformation_data = None
     if args.in_deformation is not None:
         deformation_data = np.squeeze(nib.load(

--- a/src/scilpy/cli/scil_tractogram_apply_transform_to_hdf5.py
+++ b/src/scilpy/cli/scil_tractogram_apply_transform_to_hdf5.py
@@ -28,7 +28,7 @@ from scilpy.io.utils import (add_overwrite_arg,
                              add_verbose_arg,
                              assert_inputs_exist,
                              assert_outputs_exist,
-                             load_matrix_in_any_format)
+                             load_transform_matrix_in_any_format)
 from scilpy.tractograms.tractogram_operations import transform_warp_sft
 from scilpy.version import version_string
 
@@ -93,7 +93,7 @@ def main():
         os.remove(args.out_hdf5)
 
     # Loading
-    transfo = load_matrix_in_any_format(args.in_transfo)
+    transfo = load_transform_matrix_in_any_format(args.in_transfo)
     deformation_data = None
     if args.in_deformation is not None:
         deformation_data = np.squeeze(nib.load(

--- a/src/scilpy/cli/scil_tractogram_segment_with_bundleseg.py
+++ b/src/scilpy/cli/scil_tractogram_segment_with_bundleseg.py
@@ -55,7 +55,7 @@ from scilpy.io.utils import (add_overwrite_arg, add_processes_arg,
                              add_reference_arg, add_verbose_arg,
                              assert_inputs_exist,
                              assert_output_dirs_exist_and_empty,
-                             load_matrix_in_any_format, ranged_type,
+                             load_transform_matrix_in_any_format, ranged_type,
                              assert_inputs_dirs_exist)
 from scilpy.segment.voting_scheme import VotingScheme
 from scilpy.version import version_string
@@ -153,7 +153,7 @@ def main():
     assert_output_dirs_exist_and_empty(parser, args, args.out_dir)
 
     # Loading
-    transfo = load_matrix_in_any_format(args.in_transfo)
+    transfo = load_transform_matrix_in_any_format(args.in_transfo)
 
     with open(args.in_config_file) as json_data:
         config = json.load(json_data)

--- a/src/scilpy/cli/scil_tractogram_segment_with_recobundles.py
+++ b/src/scilpy/cli/scil_tractogram_segment_with_recobundles.py
@@ -37,7 +37,8 @@ from scilpy.io.streamlines import (load_tractogram_with_reference,
                                    save_tractogram)
 from scilpy.io.utils import (add_overwrite_arg, add_reference_arg,
                              add_verbose_arg, assert_inputs_exist,
-                             assert_outputs_exist, load_matrix_in_any_format,
+                             assert_outputs_exist,
+                             load_transform_matrix_in_any_format,
                              ranged_type)
 from scilpy.utils.spatial import compute_distance_barycenters
 from scilpy.version import version_string
@@ -121,7 +122,7 @@ def main():
                                             arg_name='in_tractogram')
     model_sft = load_tractogram_with_reference(parser, args, args.in_model,
                                                arg_name='in_model')
-    transfo = load_matrix_in_any_format(args.in_transfo)
+    transfo = load_transform_matrix_in_any_format(args.in_transfo)
 
     # Processing
     if args.inverse:

--- a/src/scilpy/cli/scil_transform_split.py
+++ b/src/scilpy/cli/scil_transform_split.py
@@ -23,7 +23,7 @@ from scipy.spatial.transform import Rotation
 
 from scilpy.io.utils import (add_overwrite_arg, add_verbose_arg,
                              assert_inputs_exist, assert_outputs_exist,
-                             load_matrix_in_any_format)
+                             load_transform_matrix_in_any_format)
 from scilpy.utils.spatial import split_affine_transform
 from scilpy.version import version_string
 
@@ -87,7 +87,7 @@ def main():
     assert_outputs_exist(parser, args, [], [out for out in outputs
                                             if out is not None])
 
-    affine = load_matrix_in_any_format(args.in_transfo)
+    affine = load_transform_matrix_in_any_format(args.in_transfo)
     translation, rotation, shear, scale = split_affine_transform(affine)
 
     if args.translation:

--- a/src/scilpy/cli/scil_transform_split.py
+++ b/src/scilpy/cli/scil_transform_split.py
@@ -84,10 +84,11 @@ def main():
         parser.error('Options --angles and --rodrigues require --rotation.')
 
     assert_inputs_exist(parser, args.in_transfo)
-    assert_outputs_exist(parser, args, [], outputs)
+    assert_outputs_exist(parser, args, [], [out for out in outputs
+                                            if out is not None])
 
     affine = load_matrix_in_any_format(args.in_transfo)
-    translation, rotation, scale, shear = split_affine_transform(affine)
+    translation, rotation, shear, scale = split_affine_transform(affine)
 
     if args.translation:
         np.savetxt(args.translation, translation, fmt='%.18e')

--- a/src/scilpy/cli/scil_transform_split.py
+++ b/src/scilpy/cli/scil_transform_split.py
@@ -77,7 +77,7 @@ def main():
     logging.getLogger().setLevel(logging.getLevelName(args.verbose))
 
     outputs = [args.translation, args.rotation, args.scale, args.shear]
-    if np.all([out is None for out in outputs]):
+    if all(out is None for out in outputs):
         parser.error('No output selected. Choose at least one output option.')
 
     if (args.angles or args.rodrigues) and args.rotation is None:

--- a/src/scilpy/cli/scil_transform_split.py
+++ b/src/scilpy/cli/scil_transform_split.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Split a linear affine transform into translation, rotation, scale and shear.
+
+Accepted inputs include raw text 4x4 matrices, NumPy matrices, ANTs `.mat`
+affines and ITK affine text transforms.
+
+By default, each requested component is written as a homogeneous 4x4 matrix.
+The decomposition follows:
+
+    affine = translation @ rotation @ shear @ scale
+
+Rotation can instead be saved as intrinsic Euler angles in `XYZ` order or as
+Rodrigues angle-axis values. Angle-based outputs are written in radians.
+"""
+
+import argparse
+import logging
+
+import numpy as np
+from scipy.spatial.transform import Rotation
+
+from scilpy.io.utils import (add_overwrite_arg, add_verbose_arg,
+                             assert_inputs_exist, assert_outputs_exist,
+                             load_matrix_in_any_format)
+from scilpy.utils.spatial import split_affine_transform
+from scilpy.version import version_string
+
+
+def _build_arg_parser():
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=version_string)
+
+    p.add_argument('in_transfo',
+                   help='Path to the input affine transform.')
+    p.add_argument('--translation',
+                   help='Output text file for the translation component.')
+    p.add_argument('--rotation',
+                   help='Output text file for the rotation component.')
+    p.add_argument('--scale',
+                   help='Output text file for the scale component.')
+    p.add_argument('--shear',
+                   help='Output text file for the shear component.')
+
+    output_mode = p.add_mutually_exclusive_group()
+    output_mode.add_argument('--angles', action='store_true',
+                             help='Save rotation as 3 intrinsic Euler angles '
+                                  'in XYZ order (radians). Requires '
+                                  '--rotation.')
+    output_mode.add_argument('--rodrigues', action='store_true',
+                             help='Save rotation as 4 values: angle followed '
+                                  'by the 3 rotation-axis coordinates '
+                                  '(radians). Requires --rotation.')
+
+    add_verbose_arg(p)
+    add_overwrite_arg(p)
+
+    return p
+
+
+def _rotation_to_rodrigues(rotation_matrix, eps=1e-12):
+    rotvec = Rotation.from_matrix(rotation_matrix[:3, :3]).as_rotvec()
+    angle = np.linalg.norm(rotvec)
+    if angle < eps:
+        axis = np.array([1., 0., 0.])
+        angle = 0.
+    else:
+        axis = rotvec / angle
+    return np.concatenate(([angle], axis))
+
+
+def main():
+    parser = _build_arg_parser()
+    args = parser.parse_args()
+    logging.getLogger().setLevel(logging.getLevelName(args.verbose))
+
+    outputs = [args.translation, args.rotation, args.scale, args.shear]
+    if np.all([out is None for out in outputs]):
+        parser.error('No output selected. Choose at least one output option.')
+
+    if (args.angles or args.rodrigues) and args.rotation is None:
+        parser.error('Options --angles and --rodrigues require --rotation.')
+
+    assert_inputs_exist(parser, args.in_transfo)
+    assert_outputs_exist(parser, args, [], outputs)
+
+    affine = load_matrix_in_any_format(args.in_transfo)
+    translation, rotation, scale, shear = split_affine_transform(affine)
+
+    if args.translation:
+        np.savetxt(args.translation, translation, fmt='%.18e')
+    if args.rotation:
+        if args.angles:
+            rotation_values = Rotation.from_matrix(
+                rotation[:3, :3]).as_euler('XYZ', degrees=False)
+        elif args.rodrigues:
+            rotation_values = _rotation_to_rodrigues(rotation)
+        else:
+            rotation_values = rotation
+        np.savetxt(args.rotation, rotation_values, fmt='%.18e')
+    if args.scale:
+        np.savetxt(args.scale, scale, fmt='%.18e')
+    if args.shear:
+        np.savetxt(args.shear, shear, fmt='%.18e')
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scilpy/cli/scil_volume_apply_transform.py
+++ b/src/scilpy/cli/scil_volume_apply_transform.py
@@ -16,7 +16,7 @@ import numpy as np
 from scilpy.image.volume_operations import apply_transform
 from scilpy.io.utils import (add_overwrite_arg, assert_inputs_exist,
                              assert_outputs_exist, add_verbose_arg,
-                             load_matrix_in_any_format)
+                             load_transform_matrix_in_any_format)
 from scilpy.utils.filenames import split_name_with_nii
 from scilpy.version import version_string
 
@@ -69,7 +69,7 @@ def main():
         parser.error('{} is an unsupported format.'.format(args.in_file))
 
     # Loading
-    transfo = load_matrix_in_any_format(args.in_transfo)
+    transfo = load_transform_matrix_in_any_format(args.in_transfo)
     if args.inverse:
         transfo = np.linalg.inv(transfo)
     moving = nib.load(args.in_file)

--- a/src/scilpy/cli/tests/test_transform_split.py
+++ b/src/scilpy/cli/tests/test_transform_split.py
@@ -1,15 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import os
-import tempfile
-
 import numpy as np
+import pytest
 from scipy.io import savemat
 from scipy.spatial.transform import Rotation
-
-tmp_dir = tempfile.TemporaryDirectory()
-
 
 def _write_numeric_affine(path, translation, rotation, shear, scale):
     affine = np.eye(4)
@@ -36,21 +31,25 @@ def _write_itk_affine(path, rotation_ras, translation_ras):
         f.write('FixedParameters: 0 0 0\n')
 
 
+@pytest.fixture
+def workdir(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
 def test_help_option(script_runner):
     ret = script_runner.run(['scil_transform_split', '--help'])
     assert ret.success
 
 
-def test_fails_without_output(script_runner, monkeypatch):
-    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+def test_fails_without_output(script_runner, workdir):
     np.savetxt('affine.txt', np.eye(4))
 
     ret = script_runner.run(['scil_transform_split', 'affine.txt'])
     assert not ret.success
 
 
-def test_execution_itk_translation(script_runner, monkeypatch):
-    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_itk_translation(script_runner, workdir):
     translation = np.array([1.5, -2.5, 3.5])
     _write_itk_affine('affine_itk.txt', np.eye(3), translation)
 
@@ -64,8 +63,7 @@ def test_execution_itk_translation(script_runner, monkeypatch):
     np.testing.assert_allclose(out_translation, expected)
 
 
-def test_execution_ants_mat_translation(script_runner, monkeypatch):
-    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_ants_mat_translation(script_runner, workdir):
     translation = np.array([1.5, -2.5, 3.5])
     parameters = np.concatenate((np.eye(3).reshape(-1),
                                  [-translation[0], -translation[1],
@@ -85,8 +83,7 @@ def test_execution_ants_mat_translation(script_runner, monkeypatch):
     np.testing.assert_allclose(out_translation, expected)
 
 
-def test_execution_all_matrix_outputs(script_runner, monkeypatch):
-    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+def test_execution_all_matrix_outputs(script_runner, workdir):
     translation = np.array([1.2, -3.4, 5.6])
     rotation = Rotation.from_euler('XYZ', [0.3, -0.2, 0.4]).as_matrix()
     shear = np.array([[1., 0.2, -0.4],
@@ -120,8 +117,7 @@ def test_execution_all_matrix_outputs(script_runner, monkeypatch):
         affine)
 
 
-def test_angles_output(script_runner, monkeypatch):
-    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+def test_angles_output(script_runner, workdir):
     angles = np.array([0.3, -0.2, 0.4])
     rotation = Rotation.from_euler('XYZ', angles).as_matrix()
     _write_numeric_affine('affine.txt', np.zeros(3), rotation, np.eye(3),
@@ -136,8 +132,7 @@ def test_angles_output(script_runner, monkeypatch):
     np.testing.assert_allclose(out_angles, angles)
 
 
-def test_rodrigues_output(script_runner, monkeypatch):
-    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+def test_rodrigues_output(script_runner, workdir):
     rotation = Rotation.from_euler('XYZ', [0.3, -0.2, 0.4]).as_matrix()
     _write_numeric_affine('affine.txt', np.zeros(3), rotation, np.eye(3),
                           np.eye(3))
@@ -155,8 +150,7 @@ def test_rodrigues_output(script_runner, monkeypatch):
     np.testing.assert_allclose(out_rodrigues, expected)
 
 
-def test_rotation_encoding_requires_rotation(script_runner, monkeypatch):
-    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+def test_rotation_encoding_requires_rotation(script_runner, workdir):
     np.savetxt('affine.txt', np.eye(4))
 
     ret = script_runner.run(['scil_transform_split', 'affine.txt',
@@ -169,8 +163,7 @@ def test_rotation_encoding_requires_rotation(script_runner, monkeypatch):
 
 
 def test_rotation_output_modes_are_mutually_exclusive(script_runner,
-                                                      monkeypatch):
-    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+                                                      workdir):
     np.savetxt('affine.txt', np.eye(4))
 
     ret = script_runner.run(['scil_transform_split', 'affine.txt',
@@ -179,8 +172,7 @@ def test_rotation_output_modes_are_mutually_exclusive(script_runner,
     assert not ret.success
 
 
-def test_rejects_composite_itk_transform(script_runner, monkeypatch):
-    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+def test_rejects_composite_itk_transform(script_runner, workdir):
     with open('affine_itk.txt', 'w', encoding='utf-8') as f:
         f.write('#Insight Transform File V1.0\n')
         f.write('# Transform 0\n')
@@ -197,8 +189,7 @@ def test_rejects_composite_itk_transform(script_runner, monkeypatch):
     assert not ret.success
 
 
-def test_rejects_singular_affine(script_runner, monkeypatch):
-    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+def test_rejects_singular_affine(script_runner, workdir):
     np.savetxt('affine.txt', np.diag([1., 0., 2., 1.]))
 
     ret = script_runner.run(['scil_transform_split', 'affine.txt',
@@ -206,8 +197,7 @@ def test_rejects_singular_affine(script_runner, monkeypatch):
     assert not ret.success
 
 
-def test_rejects_malformed_itk_transform(script_runner, monkeypatch):
-    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+def test_rejects_malformed_itk_transform(script_runner, workdir):
     with open('affine_itk.txt', 'w', encoding='utf-8') as f:
         f.write('#Insight Transform File V1.0\n')
         f.write('Transform: AffineTransform_double_3_3\n')

--- a/src/scilpy/cli/tests/test_transform_split.py
+++ b/src/scilpy/cli/tests/test_transform_split.py
@@ -6,6 +6,7 @@ import pytest
 from scipy.io import savemat
 from scipy.spatial.transform import Rotation
 
+
 def _write_numeric_affine(path, translation, rotation, shear, scale):
     affine = np.eye(4)
     affine[:3, 3] = translation

--- a/src/scilpy/cli/tests/test_transform_split.py
+++ b/src/scilpy/cli/tests/test_transform_split.py
@@ -177,3 +177,41 @@ def test_rotation_output_modes_are_mutually_exclusive(script_runner,
                              '--rotation', 'rotation.txt',
                              '--angles', '--rodrigues'])
     assert not ret.success
+
+
+def test_rejects_composite_itk_transform(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+    with open('affine_itk.txt', 'w', encoding='utf-8') as f:
+        f.write('#Insight Transform File V1.0\n')
+        f.write('# Transform 0\n')
+        f.write('Transform: AffineTransform_double_3_3\n')
+        f.write('Parameters: 1 0 0 0 1 0 0 0 1 0 0 0\n')
+        f.write('FixedParameters: 0 0 0\n')
+        f.write('# Transform 1\n')
+        f.write('Transform: AffineTransform_double_3_3\n')
+        f.write('Parameters: 1 0 0 0 1 0 0 0 1 1 2 3\n')
+        f.write('FixedParameters: 0 0 0\n')
+
+    ret = script_runner.run(['scil_transform_split', 'affine_itk.txt',
+                             '--translation', 'translation.txt', '-f'])
+    assert not ret.success
+
+
+def test_rejects_singular_affine(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+    np.savetxt('affine.txt', np.diag([1., 0., 2., 1.]))
+
+    ret = script_runner.run(['scil_transform_split', 'affine.txt',
+                             '--translation', 'translation.txt', '-f'])
+    assert not ret.success
+
+
+def test_rejects_malformed_itk_transform(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+    with open('affine_itk.txt', 'w', encoding='utf-8') as f:
+        f.write('#Insight Transform File V1.0\n')
+        f.write('Transform: AffineTransform_double_3_3\n')
+
+    ret = script_runner.run(['scil_transform_split', 'affine_itk.txt',
+                             '--translation', 'translation.txt', '-f'])
+    assert not ret.success

--- a/src/scilpy/cli/tests/test_transform_split.py
+++ b/src/scilpy/cli/tests/test_transform_split.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import os
+import tempfile
+
+import numpy as np
+from scipy.io import savemat
+from scipy.spatial.transform import Rotation
+
+tmp_dir = tempfile.TemporaryDirectory()
+
+
+def _write_numeric_affine(path, translation, rotation, shear, scale):
+    affine = np.eye(4)
+    affine[:3, 3] = translation
+    affine[:3, :3] = rotation @ shear @ scale
+    np.savetxt(path, affine)
+    return affine
+
+
+def _write_itk_affine(path, rotation_ras, translation_ras):
+    lps2ras = np.diag([-1., -1., 1.])
+    rotation_lps = lps2ras @ rotation_ras @ lps2ras
+    translation_lps = np.array([-translation_ras[0],
+                                -translation_ras[1],
+                                translation_ras[2]])
+
+    parameters = np.concatenate((rotation_lps.reshape(-1), translation_lps))
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write('#Insight Transform File V1.0\n')
+        f.write('# Transform 0\n')
+        f.write('Transform: AffineTransform_double_3_3\n')
+        f.write('Parameters: {}\n'.format(
+            ' '.join('{:.18e}'.format(v) for v in parameters)))
+        f.write('FixedParameters: 0 0 0\n')
+
+
+def test_help_option(script_runner):
+    ret = script_runner.run(['scil_transform_split', '--help'])
+    assert ret.success
+
+
+def test_fails_without_output(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+    np.savetxt('affine.txt', np.eye(4))
+
+    ret = script_runner.run(['scil_transform_split', 'affine.txt'])
+    assert not ret.success
+
+
+def test_execution_itk_translation(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+    translation = np.array([1.5, -2.5, 3.5])
+    _write_itk_affine('affine_itk.txt', np.eye(3), translation)
+
+    ret = script_runner.run(['scil_transform_split', 'affine_itk.txt',
+                             '--translation', 'translation.txt', '-f'])
+    assert ret.success
+
+    out_translation = np.loadtxt('translation.txt')
+    expected = np.eye(4)
+    expected[:3, 3] = translation
+    np.testing.assert_allclose(out_translation, expected)
+
+
+def test_execution_ants_mat_translation(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+    translation = np.array([1.5, -2.5, 3.5])
+    parameters = np.concatenate((np.eye(3).reshape(-1),
+                                 [-translation[0], -translation[1],
+                                  translation[2]]))
+    savemat('affine.mat', {
+        'AffineTransform_double_3_3': parameters,
+        'fixed': np.zeros(3)
+    })
+
+    ret = script_runner.run(['scil_transform_split', 'affine.mat',
+                             '--translation', 'translation.txt', '-f'])
+    assert ret.success
+
+    out_translation = np.loadtxt('translation.txt')
+    expected = np.eye(4)
+    expected[:3, 3] = translation
+    np.testing.assert_allclose(out_translation, expected)
+
+
+def test_execution_all_matrix_outputs(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+    translation = np.array([1.2, -3.4, 5.6])
+    rotation = Rotation.from_euler('XYZ', [0.3, -0.2, 0.4]).as_matrix()
+    shear = np.array([[1., 0.2, -0.4],
+                      [0., 1., 0.3],
+                      [0., 0., 1.]])
+    scale = np.diag([2.0, 3.0, 4.0])
+    affine = _write_numeric_affine('affine.txt', translation, rotation,
+                                   shear, scale)
+
+    ret = script_runner.run([
+        'scil_transform_split', 'affine.txt',
+        '--translation', 'translation.txt',
+        '--rotation', 'rotation.txt',
+        '--scale', 'scale.txt',
+        '--shear', 'shear.txt',
+        '-f'
+    ])
+    assert ret.success
+
+    out_translation = np.loadtxt('translation.txt')
+    out_rotation = np.loadtxt('rotation.txt')
+    out_scale = np.loadtxt('scale.txt')
+    out_shear = np.loadtxt('shear.txt')
+
+    np.testing.assert_allclose(out_translation[:3, 3], translation)
+    np.testing.assert_allclose(out_rotation[:3, :3], rotation)
+    np.testing.assert_allclose(out_scale[:3, :3], scale)
+    np.testing.assert_allclose(out_shear[:3, :3], shear)
+    np.testing.assert_allclose(
+        out_translation @ out_rotation @ out_shear @ out_scale,
+        affine)
+
+
+def test_angles_output(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+    angles = np.array([0.3, -0.2, 0.4])
+    rotation = Rotation.from_euler('XYZ', angles).as_matrix()
+    _write_numeric_affine('affine.txt', np.zeros(3), rotation, np.eye(3),
+                          np.eye(3))
+
+    ret = script_runner.run(['scil_transform_split', 'affine.txt',
+                             '--rotation', 'rotation.txt',
+                             '--angles', '-f'])
+    assert ret.success
+
+    out_angles = np.loadtxt('rotation.txt')
+    np.testing.assert_allclose(out_angles, angles)
+
+
+def test_rodrigues_output(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+    rotation = Rotation.from_euler('XYZ', [0.3, -0.2, 0.4]).as_matrix()
+    _write_numeric_affine('affine.txt', np.zeros(3), rotation, np.eye(3),
+                          np.eye(3))
+
+    ret = script_runner.run(['scil_transform_split', 'affine.txt',
+                             '--rotation', 'rotation.txt',
+                             '--rodrigues', '-f'])
+    assert ret.success
+
+    out_rodrigues = np.loadtxt('rotation.txt')
+    expected_rotvec = Rotation.from_matrix(rotation).as_rotvec()
+    expected_angle = np.linalg.norm(expected_rotvec)
+    expected_axis = expected_rotvec / expected_angle
+    expected = np.concatenate(([expected_angle], expected_axis))
+    np.testing.assert_allclose(out_rodrigues, expected)
+
+
+def test_rotation_encoding_requires_rotation(script_runner, monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+    np.savetxt('affine.txt', np.eye(4))
+
+    ret = script_runner.run(['scil_transform_split', 'affine.txt',
+                             '--angles'])
+    assert not ret.success
+
+    ret = script_runner.run(['scil_transform_split', 'affine.txt',
+                             '--rodrigues'])
+    assert not ret.success
+
+
+def test_rotation_output_modes_are_mutually_exclusive(script_runner,
+                                                      monkeypatch):
+    monkeypatch.chdir(os.path.expanduser(tmp_dir.name))
+    np.savetxt('affine.txt', np.eye(4))
+
+    ret = script_runner.run(['scil_transform_split', 'affine.txt',
+                             '--rotation', 'rotation.txt',
+                             '--angles', '--rodrigues'])
+    assert not ret.success

--- a/src/scilpy/io/utils.py
+++ b/src/scilpy/io/utils.py
@@ -1053,30 +1053,106 @@ def read_info_from_mb_bdo(filename):
 def load_matrix_in_any_format(filepath):
     _, ext = os.path.splitext(filepath)
     if ext == '.txt':
-        data = np.loadtxt(filepath)
+        if _is_itk_transform_file(filepath):
+            data = _load_itk_affine_transform(filepath)
+        else:
+            data = np.loadtxt(filepath)
     elif ext == '.npy':
         data = np.load(filepath)
     elif ext == '.mat':
-        # .mat are actually dictionnary. This function support .mat from
-        # antsRegistration that encode a 4x4 transformation matrix.
-        transfo_dict = loadmat(filepath)
-        lps2ras = np.diag([-1, -1, 1])
-        transfo_key = 'AffineTransform_double_3_3'
-        if transfo_key not in transfo_dict:
-            transfo_key = 'AffineTransform_float_3_3'
-
-        rot = transfo_dict[transfo_key][0:9].reshape((3, 3))
-        trans = transfo_dict[transfo_key][9:12]
-        offset = transfo_dict['fixed']
-        r_trans = (np.dot(rot, offset) - offset - trans).T * [1, 1, -1]
-
-        data = np.eye(4)
-        data[0:3, 3] = r_trans
-        data[:3, :3] = np.dot(np.dot(lps2ras, rot), lps2ras)
+        data = _load_ants_affine_transform(filepath)
     else:
         raise ValueError('Extension {} is not supported'.format(ext))
 
     return data
+
+
+def _is_itk_transform_file(filepath):
+    with open(filepath, 'r', encoding='utf-8') as f:
+        for line in f:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            return stripped.startswith('#Insight Transform File') or \
+                stripped.startswith('Transform:')
+    return False
+
+
+def _convert_itk_ants_affine_to_ras(rot, trans, offset):
+    lps2ras = np.diag([-1, -1, 1])
+    r_trans = (np.dot(rot, offset) - offset - trans).T * [1, 1, -1]
+
+    data = np.eye(4)
+    data[0:3, 3] = r_trans
+    data[:3, :3] = np.dot(np.dot(lps2ras, rot), lps2ras)
+    return data
+
+
+def _load_ants_affine_transform(filepath):
+    # .mat are actually dictionnary. This function supports .mat from
+    # antsRegistration that encode a 4x4 transformation matrix.
+    transfo_dict = loadmat(filepath)
+    transfo_key = 'AffineTransform_double_3_3'
+    if transfo_key not in transfo_dict:
+        transfo_key = 'AffineTransform_float_3_3'
+    if transfo_key not in transfo_dict:
+        raise ValueError('Could not find an ANTs affine transform in {}'
+                         .format(filepath))
+
+    affine_params = np.asarray(transfo_dict[transfo_key]).ravel()
+    if affine_params.size != 12:
+        raise ValueError('Expected 12 ANTs affine parameters in {}, got {}'
+                         .format(filepath, affine_params.size))
+
+    offset = np.asarray(transfo_dict['fixed']).ravel()
+    if offset.size != 3:
+        raise ValueError('Expected 3 ANTs fixed parameters in {}, got {}'
+                         .format(filepath, offset.size))
+
+    rot = affine_params[:9].reshape((3, 3))
+    trans = affine_params[9:12]
+    return _convert_itk_ants_affine_to_ras(rot, trans, offset)
+
+
+def _load_itk_affine_transform(filepath):
+    transform_type = None
+    params = None
+    fixed_params = None
+
+    with open(filepath, 'r', encoding='utf-8') as f:
+        for line in f:
+            stripped = line.strip()
+            if not stripped or stripped.startswith('#'):
+                continue
+            if stripped.startswith('Transform:'):
+                transform_type = stripped.split(':', 1)[1].strip()
+            elif stripped.startswith('Parameters:'):
+                params = np.fromstring(stripped.split(':', 1)[1], sep=' ')
+            elif stripped.startswith('FixedParameters:'):
+                fixed_params = np.fromstring(
+                    stripped.split(':', 1)[1], sep=' ')
+
+    supported_types = (
+        'AffineTransform_double_3_3',
+        'AffineTransform_float_3_3',
+        'MatrixOffsetTransformBase_double_3_3',
+        'MatrixOffsetTransformBase_float_3_3',
+    )
+    if transform_type not in supported_types:
+        raise ValueError('Unsupported ITK transform type {} in {}'
+                         .format(transform_type, filepath))
+    if params is None or params.size != 12:
+        raise ValueError('Expected 12 ITK affine parameters in {}, got {}'
+                         .format(filepath, None if params is None else
+                                 params.size))
+    if fixed_params is None or fixed_params.size != 3:
+        raise ValueError('Expected 3 ITK fixed parameters in {}, got {}'
+                         .format(filepath, None if fixed_params is None else
+                                 fixed_params.size))
+
+    rot = params[:9].reshape((3, 3))
+    trans = params[9:12]
+    return _convert_itk_ants_affine_to_ras(rot, trans, fixed_params)
 
 
 def save_matrix_in_any_format(filepath, output_data):

--- a/src/scilpy/io/utils.py
+++ b/src/scilpy/io/utils.py
@@ -1160,6 +1160,9 @@ def _load_itk_affine_transform(filepath):
         'MatrixOffsetTransformBase_double_3_3',
         'MatrixOffsetTransformBase_float_3_3',
     )
+    if transform_type is None:
+        raise ValueError('No Transform entry found in {}'
+                         .format(filepath))
     if transform_type not in supported_types:
         raise ValueError('Unsupported ITK transform type {} in {}'
                          .format(transform_type, filepath))

--- a/src/scilpy/io/utils.py
+++ b/src/scilpy/io/utils.py
@@ -1068,13 +1068,17 @@ def load_matrix_in_any_format(filepath):
 
 
 def _is_itk_transform_file(filepath):
-    with open(filepath, 'r', encoding='utf-8') as f:
+    with open(filepath, 'r', encoding='utf-8', errors='replace') as f:
         for line in f:
             stripped = line.strip()
             if not stripped:
                 continue
-            return stripped.startswith('#Insight Transform File') or \
-                stripped.startswith('Transform:')
+            if stripped.startswith('#'):
+                if stripped.startswith('#Insight Transform File'):
+                    return True
+                continue
+            if stripped.startswith('Transform:'):
+                return True
     return False
 
 
@@ -1089,7 +1093,7 @@ def _convert_itk_ants_affine_to_ras(rot, trans, offset):
 
 
 def _load_ants_affine_transform(filepath):
-    # .mat are actually dictionnary. This function supports .mat from
+    # .mat are actually dictionary. This function supports .mat from
     # antsRegistration that encode a 4x4 transformation matrix.
     transfo_dict = loadmat(filepath)
     transfo_key = 'AffineTransform_double_3_3'

--- a/src/scilpy/io/utils.py
+++ b/src/scilpy/io/utils.py
@@ -1085,6 +1085,7 @@ def _is_itk_transform_file(filepath):
                     continue
                 if stripped.startswith('Transform:'):
                     return True
+                return False
     except UnicodeDecodeError:
         return False
     return False

--- a/src/scilpy/io/utils.py
+++ b/src/scilpy/io/utils.py
@@ -1053,10 +1053,7 @@ def read_info_from_mb_bdo(filename):
 def load_matrix_in_any_format(filepath):
     _, ext = os.path.splitext(filepath)
     if ext == '.txt':
-        if _is_itk_transform_file(filepath):
-            data = _load_itk_affine_transform(filepath)
-        else:
-            data = np.loadtxt(filepath)
+        data = np.loadtxt(filepath)
     elif ext == '.npy':
         data = np.load(filepath)
     elif ext == '.mat':
@@ -1067,18 +1064,29 @@ def load_matrix_in_any_format(filepath):
     return data
 
 
+def load_transform_matrix_in_any_format(filepath):
+    _, ext = os.path.splitext(filepath)
+    if ext == '.txt' and _is_itk_transform_file(filepath):
+        return _load_itk_affine_transform(filepath)
+
+    return load_matrix_in_any_format(filepath)
+
+
 def _is_itk_transform_file(filepath):
-    with open(filepath, 'r', encoding='utf-8', errors='replace') as f:
-        for line in f:
-            stripped = line.strip()
-            if not stripped:
-                continue
-            if stripped.startswith('#'):
-                if stripped.startswith('#Insight Transform File'):
+    try:
+        with open(filepath, 'r', encoding='utf-8') as f:
+            for line in f:
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                if stripped.startswith('#'):
+                    if stripped.startswith('#Insight Transform File'):
+                        return True
+                    continue
+                if stripped.startswith('Transform:'):
                     return True
-                continue
-            if stripped.startswith('Transform:'):
-                return True
+    except UnicodeDecodeError:
+        return False
     return False
 
 
@@ -1122,19 +1130,29 @@ def _load_itk_affine_transform(filepath):
     transform_type = None
     params = None
     fixed_params = None
+    transform_count = 0
 
-    with open(filepath, 'r', encoding='utf-8') as f:
-        for line in f:
-            stripped = line.strip()
-            if not stripped or stripped.startswith('#'):
-                continue
-            if stripped.startswith('Transform:'):
-                transform_type = stripped.split(':', 1)[1].strip()
-            elif stripped.startswith('Parameters:'):
-                params = np.fromstring(stripped.split(':', 1)[1], sep=' ')
-            elif stripped.startswith('FixedParameters:'):
-                fixed_params = np.fromstring(
-                    stripped.split(':', 1)[1], sep=' ')
+    try:
+        with open(filepath, 'r', encoding='utf-8') as f:
+            for line in f:
+                stripped = line.strip()
+                if not stripped or stripped.startswith('#'):
+                    continue
+                if stripped.startswith('Transform:'):
+                    transform_count += 1
+                    if transform_count > 1:
+                        raise ValueError(
+                            'Composite ITK transform files are not supported '
+                            'in {}.'.format(filepath))
+                    transform_type = stripped.split(':', 1)[1].strip()
+                elif stripped.startswith('Parameters:'):
+                    params = np.fromstring(stripped.split(':', 1)[1], sep=' ')
+                elif stripped.startswith('FixedParameters:'):
+                    fixed_params = np.fromstring(
+                        stripped.split(':', 1)[1], sep=' ')
+    except UnicodeDecodeError as exc:
+        raise ValueError('Could not decode ITK transform file {} as UTF-8.'
+                         .format(filepath)) from exc
 
     supported_types = (
         'AffineTransform_double_3_3',

--- a/src/scilpy/io/utils.py
+++ b/src/scilpy/io/utils.py
@@ -1166,14 +1166,18 @@ def _load_itk_affine_transform(filepath):
     if transform_type not in supported_types:
         raise ValueError('Unsupported ITK transform type {} in {}'
                          .format(transform_type, filepath))
-    if params is None or params.size != 12:
+    if params is None:
+        raise ValueError('Missing Parameters entry in {}'
+                         .format(filepath))
+    if params.size != 12:
         raise ValueError('Expected 12 ITK affine parameters in {}, got {}'
-                         .format(filepath, None if params is None else
-                                 params.size))
-    if fixed_params is None or fixed_params.size != 3:
+                         .format(filepath, params.size))
+    if fixed_params is None:
+        raise ValueError('Missing FixedParameters entry in {}'
+                         .format(filepath))
+    if fixed_params.size != 3:
         raise ValueError('Expected 3 ITK fixed parameters in {}, got {}'
-                         .format(filepath, None if fixed_params is None else
-                                 fixed_params.size))
+                         .format(filepath, fixed_params.size))
 
     rot = params[:9].reshape((3, 3))
     trans = params[9:12]

--- a/src/scilpy/utils/spatial.py
+++ b/src/scilpy/utils/spatial.py
@@ -237,7 +237,8 @@ def split_affine_transform(affine, eps=1e-8):
         raise ValueError('Expected a homogeneous affine matrix.')
 
     linear = affine[:3, :3]
-    if abs(np.linalg.det(linear)) < eps:
+    singular_values = np.linalg.svd(linear, compute_uv=False)
+    if singular_values[-1] < eps * singular_values[0]:
         raise ValueError('Affine transform is singular or near-singular.')
 
     rotation_3x3, upper = _decompose_linear_component(linear, eps=eps)

--- a/src/scilpy/utils/spatial.py
+++ b/src/scilpy/utils/spatial.py
@@ -223,10 +223,10 @@ def split_affine_transform(affine, eps=1e-8):
         4x4 pure translation matrix.
     rotation : np.ndarray
         4x4 pure rotation matrix.
-    scale : np.ndarray
-        4x4 diagonal scale matrix.
     shear : np.ndarray
         4x4 shear matrix.
+    scale : np.ndarray
+        4x4 diagonal scale matrix.
     """
     affine = np.asarray(affine, dtype=float)
     if affine.shape != (4, 4):
@@ -263,7 +263,7 @@ def split_affine_transform(affine, eps=1e-8):
     scale = np.eye(4)
     scale[:3, :3] = scale_3x3
 
-    return translation, rotation, scale, shear
+    return translation, rotation, shear, scale
 
 
 def _decompose_linear_component(linear, eps=1e-8):
@@ -277,6 +277,8 @@ def _decompose_linear_component(linear, eps=1e-8):
     upper = sign_correction @ r_mat
 
     if np.linalg.det(rotation) < 0:
+        # Flip the last axis to keep a proper rotation while preserving the
+        # upper-triangular structure of the remaining linear component.
         parity_correction = np.eye(3)
         parity_correction[-1, -1] = -1.0
         rotation = rotation @ parity_correction

--- a/src/scilpy/utils/spatial.py
+++ b/src/scilpy/utils/spatial.py
@@ -238,7 +238,7 @@ def split_affine_transform(affine, eps=1e-8):
 
     linear = affine[:3, :3]
     singular_values = np.linalg.svd(linear, compute_uv=False)
-    if singular_values[0] <= 0 or \
+    if singular_values[-1] <= 0 or \
             singular_values[-1] < eps * singular_values[0]:
         raise ValueError('Affine transform is singular or near-singular.')
 

--- a/src/scilpy/utils/spatial.py
+++ b/src/scilpy/utils/spatial.py
@@ -238,7 +238,8 @@ def split_affine_transform(affine, eps=1e-8):
 
     linear = affine[:3, :3]
     singular_values = np.linalg.svd(linear, compute_uv=False)
-    if singular_values[-1] < eps * singular_values[0]:
+    if singular_values[0] <= 0 or \
+            singular_values[-1] < eps * singular_values[0]:
         raise ValueError('Affine transform is singular or near-singular.')
 
     rotation_3x3, upper = _decompose_linear_component(linear, eps=eps)
@@ -267,6 +268,8 @@ def _decompose_linear_component(linear, eps=1e-8):
     q_mat, r_mat = np.linalg.qr(linear)
 
     diag_signs = np.sign(np.diag(r_mat))
+    if np.any(np.abs(diag_signs) < eps):
+        raise ValueError('Affine transform is singular or near-singular.')
     sign_correction = np.diag(diag_signs)
 
     rotation = q_mat @ sign_correction

--- a/src/scilpy/utils/spatial.py
+++ b/src/scilpy/utils/spatial.py
@@ -270,9 +270,11 @@ def split_affine_transform(affine, eps=1e-8):
 
 def _decompose_linear_component(linear, eps=1e-8):
     q_mat, r_mat = np.linalg.qr(linear)
+    abs_diag = np.abs(np.diag(r_mat))
+    if np.any(abs_diag < eps * np.max(abs_diag)):
+        raise ValueError('Affine transform is singular or near-singular.')
 
     diag_signs = np.sign(np.diag(r_mat))
-    diag_signs[np.abs(diag_signs) < eps] = 1.0
     sign_correction = np.diag(diag_signs)
 
     rotation = q_mat @ sign_correction

--- a/src/scilpy/utils/spatial.py
+++ b/src/scilpy/utils/spatial.py
@@ -199,6 +199,92 @@ def compute_distance_barycenters(ref_1, ref_2, ref_2_transfo):
     return distance_before, distance_after
 
 
+def split_affine_transform(affine, eps=1e-8):
+    """
+    Split a 4x4 affine transform into translation, rotation, shear and scale
+    components such that::
+
+        affine = translation @ rotation @ shear @ scale
+
+    The rotation is guaranteed to be a proper rotation matrix
+    (det(rotation[:3, :3]) == +1), the shear is upper triangular with a unit
+    diagonal and the scale is diagonal.
+
+    Parameters
+    ----------
+    affine : np.ndarray
+        Input 4x4 affine matrix.
+    eps : float
+        Tolerance used to detect degenerate scale values.
+
+    Returns
+    -------
+    translation : np.ndarray
+        4x4 pure translation matrix.
+    rotation : np.ndarray
+        4x4 pure rotation matrix.
+    scale : np.ndarray
+        4x4 diagonal scale matrix.
+    shear : np.ndarray
+        4x4 shear matrix.
+    """
+    affine = np.asarray(affine, dtype=float)
+    if affine.shape != (4, 4):
+        raise ValueError('Expected a 4x4 affine matrix, got shape {}'
+                         .format(affine.shape))
+
+    if not np.allclose(affine[3], [0., 0., 0., 1.]):
+        raise ValueError('Expected a homogeneous affine matrix.')
+
+    linear = affine[:3, :3]
+    if abs(np.linalg.det(linear)) < eps:
+        raise ValueError('Affine transform is singular or near-singular.')
+
+    rotation_3x3, upper = _decompose_linear_component(linear, eps=eps)
+
+    scales = np.diag(upper).copy()
+    if np.any(np.abs(scales) < eps):
+        raise ValueError('Affine transform contains a zero or near-zero scale '
+                         'component.')
+
+    inv_scale = np.diag(1.0 / scales)
+    shear_3x3 = upper @ inv_scale
+    scale_3x3 = np.diag(scales)
+
+    translation = np.eye(4)
+    translation[:3, 3] = affine[:3, 3]
+
+    rotation = np.eye(4)
+    rotation[:3, :3] = rotation_3x3
+
+    shear = np.eye(4)
+    shear[:3, :3] = shear_3x3
+
+    scale = np.eye(4)
+    scale[:3, :3] = scale_3x3
+
+    return translation, rotation, scale, shear
+
+
+def _decompose_linear_component(linear, eps=1e-8):
+    q_mat, r_mat = np.linalg.qr(linear)
+
+    diag_signs = np.sign(np.diag(r_mat))
+    diag_signs[np.abs(diag_signs) < eps] = 1.0
+    sign_correction = np.diag(diag_signs)
+
+    rotation = q_mat @ sign_correction
+    upper = sign_correction @ r_mat
+
+    if np.linalg.det(rotation) < 0:
+        parity_correction = np.eye(3)
+        parity_correction[-1, -1] = -1.0
+        rotation = rotation @ parity_correction
+        upper = parity_correction @ upper
+
+    return rotation, upper
+
+
 class WorldBoundingBox(object):
     """
     Class to store the bounding box of a volume in world space.

--- a/src/scilpy/utils/spatial.py
+++ b/src/scilpy/utils/spatial.py
@@ -265,9 +265,6 @@ def split_affine_transform(affine, eps=1e-8):
 
 def _decompose_linear_component(linear, eps=1e-8):
     q_mat, r_mat = np.linalg.qr(linear)
-    abs_diag = np.abs(np.diag(r_mat))
-    if np.any(abs_diag < eps * np.max(abs_diag)):
-        raise ValueError('Affine transform is singular or near-singular.')
 
     diag_signs = np.sign(np.diag(r_mat))
     sign_correction = np.diag(diag_signs)

--- a/src/scilpy/utils/spatial.py
+++ b/src/scilpy/utils/spatial.py
@@ -244,7 +244,8 @@ def split_affine_transform(affine, eps=1e-8):
     rotation_3x3, upper = _decompose_linear_component(linear, eps=eps)
 
     scales = np.diag(upper).copy()
-    if np.any(np.abs(scales) < eps):
+    max_scale = np.max(np.abs(scales))
+    if np.any(np.abs(scales) < eps * max_scale):
         raise ValueError('Affine transform contains a zero or near-zero scale '
                          'component.')
 

--- a/src/scilpy/utils/spatial.py
+++ b/src/scilpy/utils/spatial.py
@@ -244,11 +244,6 @@ def split_affine_transform(affine, eps=1e-8):
     rotation_3x3, upper = _decompose_linear_component(linear, eps=eps)
 
     scales = np.diag(upper).copy()
-    max_scale = np.max(np.abs(scales))
-    if np.any(np.abs(scales) < eps * max_scale):
-        raise ValueError('Affine transform contains a zero or near-zero scale '
-                         'component.')
-
     inv_scale = np.diag(1.0 / scales)
     shear_3x3 = upper @ inv_scale
     scale_3x3 = np.diag(scales)

--- a/src/scilpy/utils/tests/test_spatial.py
+++ b/src/scilpy/utils/tests/test_spatial.py
@@ -1,0 +1,53 @@
+import numpy as np
+import pytest
+from scipy.spatial.transform import Rotation
+
+from scilpy.utils.spatial import split_affine_transform
+
+
+def _compose_affine(translation, rotation, shear, scale):
+    affine = np.eye(4)
+    affine[:3, 3] = translation
+    affine[:3, :3] = rotation @ shear @ scale
+    return affine
+
+
+def test_split_affine_transform_recovers_components():
+    translation = np.array([1.2, -3.4, 5.6])
+    rotation = Rotation.from_euler('XYZ', [0.3, -0.2, 0.4]).as_matrix()
+    shear = np.array([[1., 0.2, -0.4],
+                      [0., 1., 0.3],
+                      [0., 0., 1.]])
+    scale = np.diag([2.0, 3.0, 4.0])
+
+    affine = _compose_affine(translation, rotation, shear, scale)
+    split_translation, split_rotation, split_scale, split_shear = \
+        split_affine_transform(affine)
+
+    np.testing.assert_allclose(split_translation[:3, 3], translation)
+    np.testing.assert_allclose(split_rotation[:3, :3], rotation)
+    np.testing.assert_allclose(split_scale[:3, :3], scale)
+    np.testing.assert_allclose(split_shear[:3, :3], shear)
+
+    recomposed = split_translation @ split_rotation @ split_shear @ split_scale
+    np.testing.assert_allclose(recomposed, affine)
+
+
+def test_split_affine_transform_keeps_rotation_proper():
+    affine = np.diag([-2.0, 3.0, 4.0, 1.0])
+
+    _, rotation, scale, shear = split_affine_transform(affine)
+
+    np.testing.assert_allclose(rotation[:3, :3].T @ rotation[:3, :3],
+                               np.eye(3))
+    assert np.isclose(np.linalg.det(rotation[:3, :3]), 1.0)
+    assert np.any(np.diag(scale[:3, :3]) < 0)
+    np.testing.assert_allclose(shear, np.eye(4))
+    np.testing.assert_allclose(rotation @ shear @ scale, affine)
+
+
+def test_split_affine_transform_rejects_degenerate_scale():
+    affine = np.diag([1.0, 0.0, 2.0, 1.0])
+
+    with pytest.raises(ValueError, match='singular or near-singular'):
+        split_affine_transform(affine)

--- a/src/scilpy/utils/tests/test_spatial.py
+++ b/src/scilpy/utils/tests/test_spatial.py
@@ -21,7 +21,7 @@ def test_split_affine_transform_recovers_components():
     scale = np.diag([2.0, 3.0, 4.0])
 
     affine = _compose_affine(translation, rotation, shear, scale)
-    split_translation, split_rotation, split_scale, split_shear = \
+    split_translation, split_rotation, split_shear, split_scale = \
         split_affine_transform(affine)
 
     np.testing.assert_allclose(split_translation[:3, 3], translation)
@@ -36,14 +36,14 @@ def test_split_affine_transform_recovers_components():
 def test_split_affine_transform_keeps_rotation_proper():
     affine = np.diag([-2.0, 3.0, 4.0, 1.0])
 
-    _, rotation, scale, shear = split_affine_transform(affine)
+    translation, rotation, shear, scale = split_affine_transform(affine)
 
     np.testing.assert_allclose(rotation[:3, :3].T @ rotation[:3, :3],
                                np.eye(3))
     assert np.isclose(np.linalg.det(rotation[:3, :3]), 1.0)
     assert np.any(np.diag(scale[:3, :3]) < 0)
     np.testing.assert_allclose(shear, np.eye(4))
-    np.testing.assert_allclose(rotation @ shear @ scale, affine)
+    np.testing.assert_allclose(translation @ rotation @ shear @ scale, affine)
 
 
 def test_split_affine_transform_rejects_degenerate_scale():

--- a/src/scilpy/utils/tests/test_spatial.py
+++ b/src/scilpy/utils/tests/test_spatial.py
@@ -51,3 +51,14 @@ def test_split_affine_transform_rejects_degenerate_scale():
 
     with pytest.raises(ValueError, match='singular or near-singular'):
         split_affine_transform(affine)
+
+
+def test_split_affine_transform_accepts_small_uniform_scale():
+    affine = np.diag([1e-3, 1e-3, 1e-3, 1.0])
+
+    translation, rotation, shear, scale = split_affine_transform(affine)
+
+    np.testing.assert_allclose(translation, np.eye(4))
+    np.testing.assert_allclose(rotation, np.eye(4))
+    np.testing.assert_allclose(shear, np.eye(4))
+    np.testing.assert_allclose(scale, affine)

--- a/src/scilpy/utils/tests/test_spatial.py
+++ b/src/scilpy/utils/tests/test_spatial.py
@@ -54,7 +54,7 @@ def test_split_affine_transform_rejects_degenerate_scale():
 
 
 def test_split_affine_transform_accepts_small_uniform_scale():
-    affine = np.diag([1e-3, 1e-3, 1e-3, 1.0])
+    affine = np.diag([1e-9, 1e-9, 1e-9, 1.0])
 
     translation, rotation, shear, scale = split_affine_transform(affine)
 


### PR DESCRIPTION
# Quick description

Split a affine transformation into components (translation, rotation, scale, shear). Only a subset of outputs is currently implemented, based on needs, that is :

- Rotation : the `4x4 matrix`, `XYZ` Euler angles, or `axis+angle` (aka Rodrigues)
- Translation : the `3x1 vector`
- Scale : `4x4 matrix`
- Shear : `4x4 matrix`

## Type of change

Check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [x] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [x] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
