### PR TITLE
Fix bug for flat patch double counting

### DIFF
--- a/src/scilpy/cli/scil_bundle_shape_measures.py
+++ b/src/scilpy/cli/scil_bundle_shape_measures.py
@@ -115,6 +115,10 @@ def compute_measures(args):
     length_min = float(np.min(length_list))
     length_max = float(np.max(length_list))
 
+    curvature_list = [mean_curvature(s) for s in streamline_cords
+                      if len(s) >= 2]
+    mean_curv = float(np.mean(curvature_list)) if len(curvature_list) else 0.0
+
     sft.to_vox()
     sft.to_corner()
     streamlines = sft.streamlines
@@ -138,29 +142,35 @@ def compute_measures(args):
         np.where(endpoints_map_head != 0, 1, endpoints_map_head)
     endpoints_map_tail_roi = \
         np.where(endpoints_map_tail != 0, 1, endpoints_map_tail)
-    end_sur_area_head = \
-        approximate_surface_node(endpoints_map_head_roi) * (voxel_size[0] ** 2)
-    end_sur_area_tail = \
-        approximate_surface_node(endpoints_map_tail_roi) * (voxel_size[0] ** 2)
+    end_sur_area_head = float(
+        np.count_nonzero(endpoints_map_head_roi) * (voxel_size[0] * voxel_size[1]))
+    end_sur_area_tail = float(
+        np.count_nonzero(endpoints_map_tail_roi) * (voxel_size[0] * voxel_size[1]))
 
-    endpoints_coords_head = np.array(np.where(endpoints_map_head_roi)).T
-    endpoints_coords_tail = np.array(np.where(endpoints_map_tail_roi)).T
-    radius_head = 1.5 * np.average(
-        np.sqrt(((endpoints_coords_head - np.average(
-            endpoints_coords_head, axis=0))
-            ** 2).sum(axis=1)))
-    radius_tail = 1.5 * np.average(
-        np.sqrt(((endpoints_coords_tail - np.average(
-            endpoints_coords_tail, axis=0))
-            ** 2).sum(axis=1)))
-    end_irreg_head = (np.pi * radius_head ** 2) / end_sur_area_head
-    end_irreg_tail = (np.pi * radius_tail ** 2) / end_sur_area_tail
+    endpoints_coords_head = np.argwhere(endpoints_map_head_roi) * voxel_size
+    endpoints_coords_tail = np.argwhere(endpoints_map_tail_roi) * voxel_size
+    if len(endpoints_coords_head):
+        radius_head = float(1.5 * np.average(
+            np.sqrt(((endpoints_coords_head - np.average(
+                endpoints_coords_head, axis=0))
+                ** 2).sum(axis=1))))
+    else:
+        radius_head = 0.0
+
+    if len(endpoints_coords_tail):
+        radius_tail = float(1.5 * np.average(
+            np.sqrt(((endpoints_coords_tail - np.average(
+                endpoints_coords_tail, axis=0))
+                ** 2).sum(axis=1))))
+    else:
+        radius_tail = 0.0
+
+    end_irreg_head = float((np.pi * radius_head ** 2) / end_sur_area_head) \
+        if end_sur_area_head > 0 else 0.0
+    end_irreg_tail = float((np.pi * radius_tail ** 2) / end_sur_area_tail) \
+        if end_sur_area_tail > 0 else 0.0
 
     fractal_dimension = compute_fractal_dimension(density)
-
-    curvature_list = np.zeros((nbr_streamlines,))
-    for i in range(nbr_streamlines):
-        curvature_list[i] = mean_curvature(sft.streamlines[i])
 
     return dict(zip(['volume', 'volume_endpoints', 'streamlines_count',
                      'avg_length', 'std_length', 'min_length', 'max_length',
@@ -176,7 +186,7 @@ def compute_measures(args):
                      span, curl, diameter, elon, surf_area, end_sur_area_head,
                      end_sur_area_tail, radius_head, radius_tail, irregularity,
                      end_irreg_head, end_irreg_tail,
-                     float(np.mean(curvature_list)), fractal_dimension]))
+                     mean_curv, fractal_dimension]))
 
 
 def compute_span(streamline_coords):

--- a/src/scilpy/cli/tests/test_bundle_shape_measures.py
+++ b/src/scilpy/cli/tests/test_bundle_shape_measures.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+import json
 import os
 import tempfile
 
@@ -27,3 +28,9 @@ def test_execution_bundles(script_runner, monkeypatch):
                             in_1, in_2, '--out_json', 'AF_L_measures.json',
                             '--reference', in_ref, '--processes', '1'])
     assert ret.success
+    with open('AF_L_measures.json') as f:
+        data = json.load(f)
+    assert 'end_surface_area_head' in data
+    assert all(val > 0 for val in data['end_surface_area_head'])
+    assert all(val > 0 for val in data['radius_head'])
+    assert all(val > 0 for val in data['irregularity_of_end_surface_head'])

--- a/src/scilpy/tractanalysis/tests/test_reproducibility_measures.py
+++ b/src/scilpy/tractanalysis/tests/test_reproducibility_measures.py
@@ -5,14 +5,28 @@ import os
 from dipy.io.stateful_tractogram import StatefulTractogram
 from dipy.io.streamline import load_tractogram
 import numpy as np
+import pytest
 
 from scilpy import SCILPY_HOME
 from scilpy.io.fetcher import fetch_data, get_testing_files_dict
 from scilpy.tractanalysis.streamlines_metrics import compute_tract_counts_map
 from scilpy.tractanalysis.reproducibility_measures import \
-    tractogram_pairwise_comparison
+    approximate_surface_node, tractogram_pairwise_comparison
 
 fetch_data(get_testing_files_dict(), keys=['bst.zip'])
+
+
+@pytest.mark.parametrize("cube_size", [3, 5, 7])
+def test_approximate_surface_node_solid_cube(cube_size):
+    # Square-cube law (https://en.wikipedia.org/wiki/Square%E2%80%93cube_law):
+    # surface is exactly 6*n**2, shrinking as 6/n relative to volume.
+    grid = np.zeros((cube_size + 4,) * 3, dtype=int)
+    grid[2:2 + cube_size, 2:2 + cube_size, 2:2 + cube_size] = 1
+
+    surface = approximate_surface_node(grid)
+
+    assert surface == 6 * cube_size ** 2
+    assert surface / np.count_nonzero(grid) == pytest.approx(6 / cube_size)
 
 
 def test_tractogram_pairwise_comparison():

--- a/src/scilpy/tractograms/streamline_and_mask_operations.py
+++ b/src/scilpy/tractograms/streamline_and_mask_operations.py
@@ -23,7 +23,6 @@ class CuttingStyle(Enum):
     TRIM_ENDPOINTS = 2
 
 
-
 def get_endpoints_density_map(sft, point_to_select=1, to_millimeters=False,
                               binary=False):
     """
@@ -61,7 +60,7 @@ def get_endpoints_density_map(sft, point_to_select=1, to_millimeters=False,
         for streamline in sft.streamlines:
             endpoints_mask[tuple(streamline[0].astype(np.int16))] += 1
             endpoints_mask[tuple(streamline[-1].astype(np.int16))] += 1
-        mask=endpoints_mask
+        mask = endpoints_mask
     else:
 
         # For more complex options, using head + tail
@@ -114,6 +113,23 @@ def get_head_tail_density_maps(sft, point_to_select=1, to_millimeters=False,
     streamlines._data = streamlines._data.astype(np.float32)
 
     dimensions = sft.dimensions
+    if point_to_select == 1 and not to_millimeters:
+        endpoints_map_head = np.zeros(dimensions, dtype=int)
+        endpoints_map_tail = np.zeros(dimensions, dtype=int)
+        for streamline in streamlines:
+            endpoints_map_head[tuple(streamline[0].astype(np.int16))] += 1
+            endpoints_map_tail[tuple(streamline[-1].astype(np.int16))] += 1
+
+        if binary:
+            endpoints_map_head = (endpoints_map_head > 0).astype(np.int16)
+            endpoints_map_tail = (endpoints_map_tail > 0).astype(np.int16)
+
+        if swap:
+            endpoints_map_head, endpoints_map_tail = \
+                endpoints_map_tail, endpoints_map_head
+
+        return endpoints_map_head, endpoints_map_tail
+
     # Uncompress the streamlines to get the indices of the voxels intersected
     streamlines._data = streamlines._data.astype(np.float32)
     list_indices, points_to_indices = streamlines_to_voxel_coordinates(


### PR DESCRIPTION
Fixes several correctness bugs in scil_bundle_shape_measures.py's shape metrics from Yeh (2020): mean curvature was being computed in voxel space instead of world space, endpoint radius was mixed with mm-based surface area causing unit mismatches on anisotropic voxels, and the end-surface-area calculation incorrectly reused the 3D "exposed-face" surface algorithm instead of the paper's flat voxel-count method for terminal regions. Also adds a fast, exact-endpoint path to get_head_tail_density_maps to match get_endpoints_density_map's existing behavior, and  extends tests to cover the new head/tail JSON output fields.
