### PR TITLE
-1 flag for peaks indices

### DIFF
--- a/src/scilpy/cli/scil_aodf_metrics.py
+++ b/src/scilpy/cli/scil_aodf_metrics.py
@@ -189,7 +189,7 @@ def main():
                      args.peak_values)
 
         if args.peak_indices:
-            nib.save(nib.Nifti1Image(indices.astype(np.uint8), sh_img.affine),
+            nib.save(nib.Nifti1Image(indices.astype(np.int16), sh_img.affine),
                      args.peak_indices)
 
         if args.nufid:

--- a/src/scilpy/reconst/sh.py
+++ b/src/scilpy/reconst/sh.py
@@ -354,7 +354,8 @@ def peaks_from_sh(shm_coeff, sphere, mask=None, relative_peak_threshold=0.5,
     # Bring back to the original shape
     peak_dirs_array = np.zeros(data_shape[0:3] + (npeaks, 3))
     peak_values_array = np.zeros(data_shape[0:3] + (npeaks,))
-    peak_indices_array = np.zeros(data_shape[0:3] + (npeaks,))
+    peak_indices_array = np.full(
+        data_shape[0:3] + (npeaks,), -1, dtype=np.int16)
     peak_dirs_array[mask] = tmp_peak_dirs_array
     peak_values_array[mask] = tmp_peak_values_array
     peak_indices_array[mask] = tmp_peak_indices_array


### PR DESCRIPTION
# Quick description

Fixes the flag value used for "no peak" in peaks_from_sh()'s peak_indices output.

Previously, unfilled peak slots (background voxels, or voxels with fewer than npeaks detected peaks) were left at 0 — but 0 is also a valid sphere-vertex index, so there was no way to distinguish "no peak here" from "peak pointing at vertex 0." This is now filled with -1 and stored as int16, matching the convention already used internally.

Also fixes scil_aodf_metrics.py's --peak_indices output, which cast to uint8 before saving — that wrapped -1 to 255, and separately already truncated any real index above 255 for its own default symmetric724 sphere (724 vertices). Now cast to int16, which represents both the flag and the full index range.
...

## Type of change

Check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Provide data, screenshots, command line to test (if relevant)

...

# Checklist

- [ ] My code follows the style guidelines of this project (run [autopep8](https://pypi.org/project/autopep8/))
- [ ] I added relevant citations to scripts, modules and functions docstrings and descriptions
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I moved all functions from the script file (except the argparser and main) to scilpy modules
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
